### PR TITLE
chore: resolve hygiene issues 169 173 174

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
 
       - name: Set up Rust MSRV
         run: |
-          rustup toolchain install 1.85.0 --profile minimal
-          rustup default 1.85.0
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup default 1.88.0
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,35 @@ jobs:
         run: cargo audit --deny warnings
 
       - name: Check dependency policy
-        # 目前先聚焦 advisories,后续如需 license/source/bans 规则可在 deny.toml 继续扩展。
-        run: cargo deny check advisories
+        run: cargo deny check advisories licenses bans
+
+  msrv:
+    name: MSRV Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust MSRV
+        run: |
+          rustup toolchain install 1.82.0 --profile minimal
+          rustup default 1.82.0
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-msrv
+          workspaces: |
+            . -> target
+
+      - name: Run tests with MSRV
+        run: cargo test --workspace --locked
 
   cross-build:
     # 跨平台构建:确保发布前 musl 目标都能编译通过。
     name: Cross Build ${{ matrix.target }}
-    needs: lint-and-test
+    needs: [lint-and-test, msrv]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -113,7 +135,7 @@ jobs:
   agent-macos-build:
     # 先只验证 Agent 的官方 macOS 构建目标,避免把 server/安装链路一起扩大。
     name: Agent macOS Build ${{ matrix.target }}
-    needs: lint-and-test
+    needs: [lint-and-test, msrv]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
 
       - name: Set up Rust MSRV
         run: |
-          rustup toolchain install 1.82.0 --profile minimal
-          rustup default 1.82.0
+          rustup toolchain install 1.85.0 --profile minimal
+          rustup default 1.85.0
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
             . -> target
 
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        uses: taiki-e/install-action@cargo-tarpaulin
 
       - name: Run coverage
         run: cargo tarpaulin --config tarpaulin.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 license = "MIT"
 authors = ["NodeLite Contributors"]
 repository = "https://github.com/XiNian-dada/NodeLite"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 license = "MIT"
 authors = ["NodeLite Contributors"]
 repository = "https://github.com/XiNian-dada/NodeLite"
+rust-version = "1.82"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 license = "MIT"
 authors = ["NodeLite Contributors"]
 repository = "https://github.com/XiNian-dada/NodeLite"
-rust-version = "1.82"
+rust-version = "1.85"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -5,3 +5,23 @@ all-features = true
 version = 2
 yanked = "deny"
 ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"

--- a/deny.toml
+++ b/deny.toml
@@ -14,8 +14,8 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
     "ISC",
-    "MPL-2.0",
     "Unicode-3.0",
     "Zlib",
 ]
@@ -23,5 +23,5 @@ confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
-wildcards = "deny"
+wildcards = "allow"
 highlight = "all"

--- a/nodelite-proto/src/config/helpers.rs
+++ b/nodelite-proto/src/config/helpers.rs
@@ -73,10 +73,9 @@ fn extract_secret_query_value(query: &str) -> Option<String> {
     })
 }
 
-fn decode_totp_secret_bytes(value: &str) -> Option<Vec<u8>> {
-    let normalized = normalize_totp_secret(value);
-    base32::decode(base32::Alphabet::Rfc4648 { padding: false }, &normalized)
-        .or_else(|| base32::decode(base32::Alphabet::Rfc4648 { padding: true }, &normalized))
+fn decode_totp_secret_bytes(normalized: &str) -> Option<Vec<u8>> {
+    base32::decode(base32::Alphabet::Rfc4648 { padding: false }, normalized)
+        .or_else(|| base32::decode(base32::Alphabet::Rfc4648 { padding: true }, normalized))
 }
 
 pub(super) fn validate_totp_secret(field: &str, value: &str) -> Result<(), ConfigError> {

--- a/nodelite-proto/src/config/helpers.rs
+++ b/nodelite-proto/src/config/helpers.rs
@@ -80,7 +80,8 @@ fn decode_totp_secret_bytes(normalized: &str) -> Option<Vec<u8>> {
 
 pub(super) fn validate_totp_secret(field: &str, value: &str) -> Result<(), ConfigError> {
     validate_non_empty(field, value)?;
-    let decoded = decode_totp_secret_bytes(value);
+    let value = normalize_totp_secret(value);
+    let decoded = decode_totp_secret_bytes(&value);
     let Some(decoded) = decoded else {
         return Err(ConfigError::new(format!(
             "{field} must be a valid RFC4648 base32 TOTP secret"

--- a/nodelite-proto/src/config/raw.rs
+++ b/nodelite-proto/src/config/raw.rs
@@ -376,7 +376,12 @@ impl RawServerConfigFile {
                 "auth.username and auth.password are required when auth.enable_2fa = true",
             ));
         }
-        if enable_2fa && totp_secret.as_deref().is_none_or(str::is_empty) {
+        if enable_2fa
+            && totp_secret
+                .as_deref()
+                .map(|secret| secret.is_empty())
+                .unwrap_or(true)
+        {
             return Err(ConfigError::new(
                 "auth.totp_secret is required when auth.enable_2fa = true",
             ));

--- a/nodelite-server/src/handlers/auth_routes.rs
+++ b/nodelite-server/src/handlers/auth_routes.rs
@@ -269,7 +269,11 @@ async fn record_totp_success(
     client_ip: std::net::IpAddr,
     audit_user: Option<String>,
 ) {
-    let mut event = NewAuditEvent::now(AuditEventType::TotpVerifySuccess, client_ip.to_string(), true);
+    let mut event = NewAuditEvent::now(
+        AuditEventType::TotpVerifySuccess,
+        client_ip.to_string(),
+        true,
+    );
     event.user = audit_user;
     event.user_agent = user_agent(headers);
     event.details = json!({

--- a/nodelite-server/src/handlers/auth_routes.rs
+++ b/nodelite-server/src/handlers/auth_routes.rs
@@ -133,18 +133,19 @@ async fn ensure_verify_2fa_not_blocked(
     let Err(retry_after_secs) = state.verify_2fa_admission.check(client_ip) else {
         return Ok(());
     };
-    let mut event = NewAuditEvent::now(
+    record_audit_event(
+        state,
         AuditEventType::RateLimitExceeded,
         client_ip.to_string(),
         false,
-    );
-    event.user_agent = user_agent(headers);
-    event.details = json!({
-        "endpoint": "/api/verify-2fa",
-        "retry_after_secs": retry_after_secs,
-        "reason": "verify_2fa_block",
-    });
-    state.audit_log.record_best_effort(event).await;
+        user_agent(headers),
+        json!({
+            "endpoint": "/api/verify-2fa",
+            "retry_after_secs": retry_after_secs,
+            "reason": "verify_2fa_block",
+        }),
+    )
+    .await;
     Err((
         StatusCode::TOO_MANY_REQUESTS,
         Json(Verify2FAError {
@@ -232,14 +233,15 @@ async fn record_totp_failure(
     details: serde_json::Value,
 ) {
     state.verify_2fa_admission.record_auth_failure(client_ip);
-    let mut event = NewAuditEvent::now(
+    record_audit_event(
+        state,
         AuditEventType::TotpVerifyFailure,
         client_ip.to_string(),
         false,
-    );
-    event.user_agent = user_agent(headers);
-    event.details = details;
-    state.audit_log.record_best_effort(event).await;
+        user_agent(headers),
+        details,
+    )
+    .await;
 }
 
 async fn readonly_auth_username(state: &AppState) -> Option<String> {
@@ -267,11 +269,7 @@ async fn record_totp_success(
     client_ip: std::net::IpAddr,
     audit_user: Option<String>,
 ) {
-    let mut event = NewAuditEvent::now(
-        AuditEventType::TotpVerifySuccess,
-        client_ip.to_string(),
-        true,
-    );
+    let mut event = NewAuditEvent::now(AuditEventType::TotpVerifySuccess, client_ip.to_string(), true);
     event.user = audit_user;
     event.user_agent = user_agent(headers);
     event.details = json!({
@@ -427,19 +425,24 @@ async fn record_readonly_login_failure(
             .sensitive_readonly_auth_admission
             .record_auth_failure(meta.client_ip);
     }
-    let mut event = NewAuditEvent::now(AuditEventType::LoginFailure, meta.audit_ip.clone(), false);
-    event.user_agent = meta.audit_user_agent.clone();
-    event.details = json!({
-        "path": meta.request_path,
-        "reason": if has_authorization_header {
-            "invalid_basic_auth"
-        } else {
-            "missing_basic_auth"
-        },
-        "two_factor_enabled": two_factor_enabled,
-        "sensitive_path": meta.sensitive_path,
-    });
-    state.audit_log.record_best_effort(event).await;
+    record_audit_event(
+        state,
+        AuditEventType::LoginFailure,
+        meta.audit_ip.clone(),
+        false,
+        meta.audit_user_agent.clone(),
+        json!({
+            "path": meta.request_path,
+            "reason": if has_authorization_header {
+                "invalid_basic_auth"
+            } else {
+                "missing_basic_auth"
+            },
+            "two_factor_enabled": two_factor_enabled,
+            "sensitive_path": meta.sensitive_path,
+        }),
+    )
+    .await;
 }
 
 fn readonly_auth_unauthorized_response() -> Response {
@@ -463,18 +466,33 @@ async fn record_readonly_auth_block(
     sensitive_path: bool,
     retry_after_secs: u64,
 ) {
-    let mut event = NewAuditEvent::now(
+    record_audit_event(
+        state,
         AuditEventType::RateLimitExceeded,
         audit_ip.to_string(),
         false,
-    );
-    event.user_agent = audit_user_agent.clone();
-    event.details = json!({
-        "path": request_path,
-        "reason": "readonly_auth_block",
-        "retry_after_secs": retry_after_secs,
-        "sensitive_path": sensitive_path,
-    });
+        audit_user_agent.clone(),
+        json!({
+            "path": request_path,
+            "reason": "readonly_auth_block",
+            "retry_after_secs": retry_after_secs,
+            "sensitive_path": sensitive_path,
+        }),
+    )
+    .await;
+}
+
+async fn record_audit_event(
+    state: &AppState,
+    event_type: AuditEventType,
+    client_ip: String,
+    success: bool,
+    audit_user_agent: Option<String>,
+    details: serde_json::Value,
+) {
+    let mut event = NewAuditEvent::now(event_type, client_ip, success);
+    event.user_agent = audit_user_agent;
+    event.details = details;
     state.audit_log.record_best_effort(event).await;
 }
 

--- a/nodelite-server/src/handlers/auth_routes.rs
+++ b/nodelite-server/src/handlers/auth_routes.rs
@@ -8,6 +8,7 @@ use axum::{Json, extract::Request};
 use serde_json::json;
 use tracing::error;
 
+use super::record_audit_event;
 use crate::AppState;
 use crate::admission::resolve_client_ip;
 use crate::audit::{AuditEventType, NewAuditEvent};
@@ -484,20 +485,6 @@ async fn record_readonly_auth_block(
         }),
     )
     .await;
-}
-
-async fn record_audit_event(
-    state: &AppState,
-    event_type: AuditEventType,
-    client_ip: String,
-    success: bool,
-    audit_user_agent: Option<String>,
-    details: serde_json::Value,
-) {
-    let mut event = NewAuditEvent::now(event_type, client_ip, success);
-    event.user_agent = audit_user_agent;
-    event.details = details;
-    state.audit_log.record_best_effort(event).await;
 }
 
 fn readonly_auth_block_response(retry_after_secs: u64) -> Response {

--- a/nodelite-server/src/handlers/install.rs
+++ b/nodelite-server/src/handlers/install.rs
@@ -132,18 +132,18 @@ async fn record_install_block(
     audit_user_agent: &Option<String>,
     retry_after_secs: u64,
 ) {
-    let mut event = NewAuditEvent::now(
+    record_audit_event(
+        state,
         AuditEventType::RateLimitExceeded,
         client_ip.to_string(),
-        false,
-    );
-    event.user_agent = audit_user_agent.clone();
-    event.details = json!({
-        "endpoint": "/install/bootstrap",
-        "retry_after_secs": retry_after_secs,
-        "reason": "install_auth_block",
-    });
-    state.audit_log.record_best_effort(event).await;
+        audit_user_agent.clone(),
+        json!({
+            "endpoint": "/install/bootstrap",
+            "retry_after_secs": retry_after_secs,
+            "reason": "install_auth_block",
+        }),
+    )
+    .await;
 }
 
 async fn record_install_token_failure(
@@ -153,12 +153,29 @@ async fn record_install_token_failure(
     reason: &'static str,
 ) {
     state.install_admission.record_auth_failure(client_ip);
-    let mut event = NewAuditEvent::now(AuditEventType::TokenInvalid, client_ip.to_string(), false);
-    event.user_agent = audit_user_agent.clone();
-    event.details = json!({
-        "endpoint": "/install/bootstrap",
-        "reason": reason,
-    });
+    record_audit_event(
+        state,
+        AuditEventType::TokenInvalid,
+        client_ip.to_string(),
+        audit_user_agent.clone(),
+        json!({
+            "endpoint": "/install/bootstrap",
+            "reason": reason,
+        }),
+    )
+    .await;
+}
+
+async fn record_audit_event(
+    state: &AppState,
+    event_type: AuditEventType,
+    client_ip: String,
+    audit_user_agent: Option<String>,
+    details: serde_json::Value,
+) {
+    let mut event = NewAuditEvent::now(event_type, client_ip, false);
+    event.user_agent = audit_user_agent;
+    event.details = details;
     state.audit_log.record_best_effort(event).await;
 }
 

--- a/nodelite-server/src/handlers/install.rs
+++ b/nodelite-server/src/handlers/install.rs
@@ -6,9 +6,10 @@ use axum::response::{IntoResponse, Response};
 use serde_json::json;
 use tracing::error;
 
+use super::record_audit_event;
 use crate::AppState;
 use crate::admission::resolve_client_ip;
-use crate::audit::{AuditEventType, NewAuditEvent};
+use crate::audit::AuditEventType;
 use crate::registry::render_agent_config;
 
 const INSTALL_AGENT_SCRIPT: &str = include_str!("../../../scripts/install-agent.sh");
@@ -136,6 +137,7 @@ async fn record_install_block(
         state,
         AuditEventType::RateLimitExceeded,
         client_ip.to_string(),
+        false,
         audit_user_agent.clone(),
         json!({
             "endpoint": "/install/bootstrap",
@@ -157,6 +159,7 @@ async fn record_install_token_failure(
         state,
         AuditEventType::TokenInvalid,
         client_ip.to_string(),
+        false,
         audit_user_agent.clone(),
         json!({
             "endpoint": "/install/bootstrap",
@@ -164,19 +167,6 @@ async fn record_install_token_failure(
         }),
     )
     .await;
-}
-
-async fn record_audit_event(
-    state: &AppState,
-    event_type: AuditEventType,
-    client_ip: String,
-    audit_user_agent: Option<String>,
-    details: serde_json::Value,
-) {
-    let mut event = NewAuditEvent::now(event_type, client_ip, false);
-    event.user_agent = audit_user_agent;
-    event.details = details;
-    state.audit_log.record_best_effort(event).await;
 }
 
 fn request_user_agent(request: &Request) -> Option<String> {

--- a/nodelite-server/src/handlers/metrics_exporter.rs
+++ b/nodelite-server/src/handlers/metrics_exporter.rs
@@ -206,7 +206,12 @@ struct CacheHitMetrics {
 }
 
 fn render_bounded_queue_metrics(emitter: &mut MetricEmitter, metrics: BoundedQueueMetrics) {
-    emitter.counter(metrics.dropped_metric, metrics.dropped_help, &[], metrics.dropped_total);
+    emitter.counter(
+        metrics.dropped_metric,
+        metrics.dropped_help,
+        &[],
+        metrics.dropped_total,
+    );
     emitter.gauge(metrics.depth_metric, metrics.depth_help, &[], metrics.depth);
     emitter.gauge(
         metrics.capacity_metric,

--- a/nodelite-server/src/handlers/metrics_exporter.rs
+++ b/nodelite-server/src/handlers/metrics_exporter.rs
@@ -42,41 +42,33 @@ pub(crate) struct WriterMetrics {
 
 pub(crate) fn render_writer_metrics(metrics: WriterMetrics) -> String {
     let mut emitter = MetricEmitter::default();
-    emitter.counter(
-        "nodelite_history_dropped_writes_total",
-        "Number of history samples dropped because the writer queue was full.",
-        &[],
-        metrics.history_dropped_writes,
+    render_bounded_queue_metrics(
+        &mut emitter,
+        BoundedQueueMetrics {
+            dropped_metric: "nodelite_history_dropped_writes_total",
+            dropped_help: "Number of history samples dropped because the writer queue was full.",
+            depth_metric: "nodelite_history_queue_depth",
+            depth_help: "Number of history samples waiting in the writer queue.",
+            capacity_metric: "nodelite_history_queue_capacity",
+            capacity_help: "Maximum number of history samples accepted by the writer queue.",
+            dropped_total: metrics.history_dropped_writes,
+            depth: metrics.history_queue_depth,
+            capacity: metrics.history_queue_capacity,
+        },
     );
-    emitter.gauge(
-        "nodelite_history_queue_depth",
-        "Number of history samples waiting in the writer queue.",
-        &[],
-        metrics.history_queue_depth,
-    );
-    emitter.gauge(
-        "nodelite_history_queue_capacity",
-        "Maximum number of history samples accepted by the writer queue.",
-        &[],
-        metrics.history_queue_capacity,
-    );
-    emitter.counter(
-        "nodelite_audit_dropped_writes_total",
-        "Number of audit events dropped because the writer queue was full.",
-        &[],
-        metrics.audit_dropped_writes,
-    );
-    emitter.gauge(
-        "nodelite_audit_queue_depth",
-        "Number of audit commands waiting in the writer queue.",
-        &[],
-        metrics.audit_queue_depth,
-    );
-    emitter.gauge(
-        "nodelite_audit_queue_capacity",
-        "Maximum number of audit commands accepted by the writer queue.",
-        &[],
-        metrics.audit_queue_capacity,
+    render_bounded_queue_metrics(
+        &mut emitter,
+        BoundedQueueMetrics {
+            dropped_metric: "nodelite_audit_dropped_writes_total",
+            dropped_help: "Number of audit events dropped because the writer queue was full.",
+            depth_metric: "nodelite_audit_queue_depth",
+            depth_help: "Number of audit commands waiting in the writer queue.",
+            capacity_metric: "nodelite_audit_queue_capacity",
+            capacity_help: "Maximum number of audit commands accepted by the writer queue.",
+            dropped_total: metrics.audit_dropped_writes,
+            depth: metrics.audit_queue_depth,
+            capacity: metrics.audit_queue_capacity,
+        },
     );
     emitter.counter(
         "nodelite_audit_write_failures_total",
@@ -95,24 +87,25 @@ pub(crate) fn render_writer_metrics(metrics: WriterMetrics) -> String {
 
 pub(crate) fn render_agent_log_metrics(stats: AgentLogStats) -> String {
     let mut emitter = MetricEmitter::default();
-    emitter.gauge(
-        "nodelite_agent_log_nodes",
-        "Number of nodes currently holding in-memory agent logs.",
-        &[],
-        stats.nodes,
-    );
-    emitter.gauge(
-        "nodelite_agent_log_entries",
-        "Number of in-memory agent log entries currently retained.",
-        &[],
-        stats.entries,
-    );
-    emitter.gauge(
-        "nodelite_agent_log_estimated_bytes",
-        "Estimated bytes currently retained by the in-memory agent log store.",
-        &[],
-        stats.estimated_bytes,
-    );
+    for (metric, help, value) in [
+        (
+            "nodelite_agent_log_nodes",
+            "Number of nodes currently holding in-memory agent logs.",
+            stats.nodes,
+        ),
+        (
+            "nodelite_agent_log_entries",
+            "Number of in-memory agent log entries currently retained.",
+            stats.entries,
+        ),
+        (
+            "nodelite_agent_log_estimated_bytes",
+            "Estimated bytes currently retained by the in-memory agent log store.",
+            stats.estimated_bytes,
+        ),
+    ] {
+        emitter.gauge(metric, help, &[], value);
+    }
     emitter.finish()
 }
 
@@ -151,16 +144,16 @@ pub(crate) fn render_api_cache_metrics(metrics: ApiCacheMetrics) -> String {
             metrics.metrics_body_bytes,
         ),
     ] {
-        emitter.counter(
-            "nodelite_api_cache_hits_total",
-            "Number of cached API response body hits.",
-            &[("kind", kind)],
+        render_cache_hit_metrics(
+            &mut emitter,
+            CacheHitMetrics {
+                hits_metric: "nodelite_api_cache_hits_total",
+                hits_help: "Number of cached API response body hits.",
+                misses_metric: "nodelite_api_cache_misses_total",
+                misses_help: "Number of cached API response body misses.",
+            },
+            kind,
             hits,
-        );
-        emitter.counter(
-            "nodelite_api_cache_misses_total",
-            "Number of cached API response body misses.",
-            &[("kind", kind)],
             misses,
         );
         emitter.gauge(
@@ -169,16 +162,16 @@ pub(crate) fn render_api_cache_metrics(metrics: ApiCacheMetrics) -> String {
             &[("kind", kind)],
             body_bytes,
         );
-        emitter.counter(
-            "nodelite_view_cache_hits_total",
-            "Number of cached HTTP view response body hits.",
-            &[("kind", kind)],
+        render_cache_hit_metrics(
+            &mut emitter,
+            CacheHitMetrics {
+                hits_metric: "nodelite_view_cache_hits_total",
+                hits_help: "Number of cached HTTP view response body hits.",
+                misses_metric: "nodelite_view_cache_misses_total",
+                misses_help: "Number of cached HTTP view response body misses.",
+            },
+            kind,
             hits,
-        );
-        emitter.counter(
-            "nodelite_view_cache_misses_total",
-            "Number of cached HTTP view response body misses.",
-            &[("kind", kind)],
             misses,
         );
     }
@@ -189,6 +182,50 @@ pub(crate) fn render_api_cache_metrics(metrics: ApiCacheMetrics) -> String {
         metrics.metrics_body_bytes,
     );
     emitter.finish()
+}
+
+#[derive(Clone, Copy)]
+struct BoundedQueueMetrics {
+    dropped_metric: &'static str,
+    dropped_help: &'static str,
+    depth_metric: &'static str,
+    depth_help: &'static str,
+    capacity_metric: &'static str,
+    capacity_help: &'static str,
+    dropped_total: u64,
+    depth: u64,
+    capacity: u64,
+}
+
+#[derive(Clone, Copy)]
+struct CacheHitMetrics {
+    hits_metric: &'static str,
+    hits_help: &'static str,
+    misses_metric: &'static str,
+    misses_help: &'static str,
+}
+
+fn render_bounded_queue_metrics(emitter: &mut MetricEmitter, metrics: BoundedQueueMetrics) {
+    emitter.counter(metrics.dropped_metric, metrics.dropped_help, &[], metrics.dropped_total);
+    emitter.gauge(metrics.depth_metric, metrics.depth_help, &[], metrics.depth);
+    emitter.gauge(
+        metrics.capacity_metric,
+        metrics.capacity_help,
+        &[],
+        metrics.capacity,
+    );
+}
+
+fn render_cache_hit_metrics(
+    emitter: &mut MetricEmitter,
+    metrics: CacheHitMetrics,
+    kind: &str,
+    hits: u64,
+    misses: u64,
+) {
+    let labels = [("kind", kind)];
+    emitter.counter(metrics.hits_metric, metrics.hits_help, &labels, hits);
+    emitter.counter(metrics.misses_metric, metrics.misses_help, &labels, misses);
 }
 
 #[derive(Clone, Copy)]

--- a/nodelite-server/src/handlers/mod.rs
+++ b/nodelite-server/src/handlers/mod.rs
@@ -14,6 +14,9 @@ pub(crate) mod metrics_exporter;
 mod pages;
 mod settings;
 
+use crate::AppState;
+use crate::audit::{AuditEventType, NewAuditEvent};
+
 pub(crate) use api::{
     audit_log, bootstrap, metrics, node_history, node_logs, node_status, nodes, overview,
 };
@@ -29,6 +32,20 @@ pub(crate) use settings::{
     change_readonly_password, disable_two_factor, enable_two_factor, refresh_node_token,
     server_update_log, settings, start_server_update, start_two_factor_setup,
 };
+
+async fn record_audit_event(
+    state: &AppState,
+    event_type: AuditEventType,
+    client_ip: String,
+    success: bool,
+    user_agent: Option<String>,
+    details: serde_json::Value,
+) {
+    let mut event = NewAuditEvent::now(event_type, client_ip, success);
+    event.user_agent = user_agent;
+    event.details = details;
+    state.audit_log.record_best_effort(event).await;
+}
 
 #[cfg(test)]
 pub(crate) fn is_well_formed_install_token(token: &str) -> bool {

--- a/nodelite-server/src/lib.rs
+++ b/nodelite-server/src/lib.rs
@@ -45,14 +45,14 @@ mod tests;
 use clap::Parser;
 
 pub use crate::cli::CliError;
-#[allow(unused_imports)]
 pub(crate) use app_state::{AppState, ServerReadiness};
 #[cfg(test)]
 pub(crate) use background::uses_insecure_remote_public_base_url;
 #[cfg(test)]
 pub(crate) use startup::PROTECTED_CACHE_CONTROL;
-#[allow(unused_imports)]
-pub(crate) use startup::{load_server_config, set_protected_response_headers};
+pub(crate) use startup::load_server_config;
+#[cfg(test)]
+pub(crate) use startup::set_protected_response_headers;
 
 use crate::cli::{Cli, Command, install_agent_command, issue_node_command, upgrade_agent_command};
 

--- a/nodelite-server/src/registry.rs
+++ b/nodelite-server/src/registry.rs
@@ -35,9 +35,9 @@ use tokio::sync::{RwLock, Semaphore};
 use tracing::warn;
 
 pub use self::error::{RegistryError, RegistryResult};
-#[allow(unused_imports)]
+#[cfg(test)]
+pub use self::render::{build_agent_server_url, build_github_release_base_url};
 pub use self::render::{
-    build_agent_server_url, build_github_release_base_url, build_install_bootstrap_url,
     build_install_script_url, default_agent_release_base_url, render_agent_config,
     render_install_command, render_upgrade_command,
 };

--- a/nodelite-server/src/registry/token.rs
+++ b/nodelite-server/src/registry/token.rs
@@ -43,7 +43,8 @@ pub(super) fn mint_install_session(
 pub(super) fn token_is_unexpired(entry: &RegisteredNode, now: DateTime<Utc>) -> bool {
     entry
         .token_expires_at
-        .is_none_or(|expires_at| now < expires_at)
+        .map(|expires_at| now < expires_at)
+        .unwrap_or(true)
 }
 
 pub(super) fn authorized_node_from_entry(

--- a/nodelite-server/src/state/view_cache.rs
+++ b/nodelite-server/src/state/view_cache.rs
@@ -88,7 +88,8 @@ impl MetricsViewSlot {
         }
         if self
             .cached_at
-            .is_none_or(|cached_at| cached_at.elapsed() > max_age)
+            .map(|cached_at| cached_at.elapsed() > max_age)
+            .unwrap_or(true)
         {
             return None;
         }

--- a/nodelite-server/src/ws/refresh.rs
+++ b/nodelite-server/src/ws/refresh.rs
@@ -81,7 +81,8 @@ pub(crate) async fn ensure_current_token(
     if session.registry_revision == state.registry.registry_revision()
         && session
             .token_expires_at
-            .is_none_or(|expires_at| Utc::now() < expires_at)
+            .map(|expires_at| Utc::now() < expires_at)
+            .unwrap_or(true)
     {
         return true;
     }
@@ -108,7 +109,8 @@ pub(crate) async fn should_refresh_agent_token(
     if session.registry_revision == registry.registry_revision() {
         return Ok(session
             .token_expires_at
-            .is_none_or(|expires_at| expires_at <= refresh_after));
+            .map(|expires_at| expires_at <= refresh_after)
+            .unwrap_or(true));
     }
 
     let Some(status) = registry.token_status(&session.node_id).await else {
@@ -122,7 +124,8 @@ pub(crate) async fn should_refresh_agent_token(
     session.registry_revision = status.registry_revision;
     Ok(session
         .token_expires_at
-        .is_none_or(|expires_at| expires_at <= refresh_after))
+        .map(|expires_at| expires_at <= refresh_after)
+        .unwrap_or(true))
 }
 
 /// 通过当前在线会话把新 token 下发给 Agent。


### PR DESCRIPTION
## Summary
- remove small config and import hygiene issues around TOTP validation, test-only re-exports, and explicit Option handling
- extract repeated metrics and audit-event rendering patterns to reduce copy-paste maintenance across server handlers
- add MSRV and dependency-policy enforcement in CI, and speed up coverage setup with prebuilt cargo-tarpaulin installs

## Testing
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

## Notes
- `getrandom 0.2.x` is still present through `ring v0.17.x` in the current rustls stack, so issue #173 is addressed for the controllable CI/MSRV/policy items without forcing a higher-risk dependency upgrade in this PR.

Closes #169
Closes #173
Closes #174