### PR TITLE
Stage 2b — NodeMap (canvas land mask + node dot overlay)

### DIFF
--- a/nodelite-server/web/src/components/NodeMap.spec.ts
+++ b/nodelite-server/web/src/components/NodeMap.spec.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { __resetWorldGeoJsonForTest } from '@/composables/useWorldGeoJson';
+import { useNodesStore } from '@/stores/nodes';
+import { makeNode } from '@/api/__fixtures__/nodes';
+import NodeMap from './NodeMap.vue';
+
+const FAKE_DICT = {
+  en: {
+    'index.map.title': 'Global Distribution',
+    'index.map.legend_online': 'Online',
+    'index.map.legend_latency': 'High latency',
+    'index.map.legend_offline': 'Offline',
+  },
+  'zh-CN': {
+    'index.map.title': '全球分布',
+    'index.map.legend_online': '在线',
+    'index.map.legend_latency': '高延迟',
+    'index.map.legend_offline': '离线',
+  },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+async function mountWithNodes(nodes: ReturnType<typeof makeNode>[]) {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useNodesStore();
+  store.nodes = nodes;
+  const wrapper = mount(NodeMap, { global: { plugins: [pinia, getI18n()] } });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('NodeMap', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    __resetWorldGeoJsonForTest();
+    // jsdom has no canvas 2D context (it throws "Not implemented"); return
+    // null so paintWorldDotMap no-ops quietly. The painting itself is
+    // covered by lib/map/landMask.spec.ts.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    // i18n dictionary fetch succeeds; the world GeoJSON fetch fails so the
+    // component keeps the fallback mask (paint no-ops in jsdom regardless,
+    // since canvas has no 2D context).
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (String(url).includes('ui-i18n.json')) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(FAKE_DICT),
+          } as unknown as Response);
+        }
+        return Promise.reject(new Error('offline'));
+      }),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    __resetWorldGeoJsonForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the map card with canvas and legend', async () => {
+    const wrapper = await mountWithNodes([]);
+    expect(wrapper.find('[data-test="node-map"]').exists()).toBe(true);
+    expect(wrapper.find('canvas.map-canvas').exists()).toBe(true);
+    expect(wrapper.find('[data-test="map-dots"]').exists()).toBe(true);
+  });
+
+  it('renders one positioned dot per node with a status class', async () => {
+    const wrapper = await mountWithNodes([
+      makeNode({
+        identity: { node_id: 'a', node_label: 'A', hostname: 'web-jp-1', tags: [] },
+        online: true,
+        latency_ms: 20,
+      }),
+      makeNode({
+        identity: { node_id: 'b', node_label: 'B', hostname: 'h', tags: [] },
+        online: false,
+      }),
+    ]);
+
+    const dotEls = wrapper.findAll('[data-test="map-dot"]');
+    expect(dotEls).toHaveLength(2);
+
+    expect(dotEls[0]!.classes()).toContain('online');
+    expect(dotEls[1]!.classes()).toContain('offline');
+
+    // positioned via inline left/top percentages
+    const style = dotEls[0]!.attributes('style') ?? '';
+    expect(style).toMatch(/left:\s*[\d.]+%/);
+    expect(style).toMatch(/top:\s*[\d.]+%/);
+  });
+
+  it('marks a high-latency node with the latency class', async () => {
+    const wrapper = await mountWithNodes([
+      makeNode({
+        identity: { node_id: 'c', node_label: 'C', hostname: 'h', tags: [] },
+        online: true,
+        latency_ms: 300,
+      }),
+    ]);
+    expect(wrapper.find('[data-test="map-dot"]').classes()).toContain('latency');
+  });
+});

--- a/nodelite-server/web/src/components/NodeMap.spec.ts
+++ b/nodelite-server/web/src/components/NodeMap.spec.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { createApp, defineComponent, h } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
+import { nextTick } from 'vue';
 import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
 import { __resetWorldGeoJsonForTest } from '@/composables/useWorldGeoJson';
 import { useNodesStore } from '@/stores/nodes';
+import { useTheme } from '@/composables/useTheme';
 import { makeNode } from '@/api/__fixtures__/nodes';
 import NodeMap from './NodeMap.vue';
 
@@ -67,6 +69,7 @@ describe('NodeMap', () => {
     __resetI18nForTest();
     __resetWorldGeoJsonForTest();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it('renders the map card with canvas and legend', async () => {
@@ -110,5 +113,20 @@ describe('NodeMap', () => {
       }),
     ]);
     expect(wrapper.find('[data-test="map-dot"]').classes()).toContain('latency');
+  });
+
+  it('repaints the canvas when the theme changes', async () => {
+    // getContext is the stubbed entry point of paintWorldDotMap; a repaint
+    // calls it again. Mount paints once; toggling theme should repaint.
+    const getContext = HTMLCanvasElement.prototype.getContext as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    await mountWithNodes([]);
+    const callsAfterMount = getContext.mock.calls.length;
+    expect(callsAfterMount).toBeGreaterThan(0);
+
+    useTheme().toggleTheme();
+    await nextTick();
+    expect(getContext.mock.calls.length).toBeGreaterThan(callsAfterMount);
   });
 });

--- a/nodelite-server/web/src/components/NodeMap.vue
+++ b/nodelite-server/web/src/components/NodeMap.vue
@@ -2,11 +2,13 @@
 import { computed, onMounted, ref, watch } from 'vue';
 import { useNodesStore } from '@/stores/nodes';
 import { useWorldGeoJson } from '@/composables/useWorldGeoJson';
+import { useTheme } from '@/composables/useTheme';
 import { nodePosition, nodeStatusKey } from '@/lib/map/projection';
 import { drawFallbackMask, drawGeoJsonMask, paintWorldDotMap } from '@/lib/map/landMask';
 
 const nodesStore = useNodesStore();
 const { geojson, load } = useWorldGeoJson();
+const { theme } = useTheme();
 
 const canvas = ref<HTMLCanvasElement | null>(null);
 
@@ -47,8 +49,10 @@ onMounted(() => {
   void load();
 });
 
-// Re-render the land mask when the real GeoJSON resolves.
-watch(geojson, repaint);
+// Re-render the land mask when the real GeoJSON resolves, and again on
+// theme change — the land-dot colour comes from the --map-land-dot CSS var,
+// which is read at paint time (matches legacy's repaint-on-toggle).
+watch([geojson, theme], repaint);
 </script>
 
 <template>

--- a/nodelite-server/web/src/components/NodeMap.vue
+++ b/nodelite-server/web/src/components/NodeMap.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useNodesStore } from '@/stores/nodes';
+import { useWorldGeoJson } from '@/composables/useWorldGeoJson';
+import { nodePosition, nodeStatusKey } from '@/lib/map/projection';
+import { drawFallbackMask, drawGeoJsonMask, paintWorldDotMap } from '@/lib/map/landMask';
+
+const nodesStore = useNodesStore();
+const { geojson, load } = useWorldGeoJson();
+
+const canvas = ref<HTMLCanvasElement | null>(null);
+
+const dots = computed(() =>
+  nodesStore.nodes.map((node) => {
+    const pos = nodePosition(node);
+    return {
+      id: node.identity.node_id,
+      label: node.identity.node_label,
+      status: nodeStatusKey(node),
+      left: `${(pos.x * 100).toFixed(2)}%`,
+      top: `${(pos.y * 100).toFixed(2)}%`,
+    };
+  }),
+);
+
+function dotColor(): string {
+  const el = canvas.value ?? document.documentElement;
+  const value = getComputedStyle(el).getPropertyValue('--map-land-dot').trim();
+  return value || 'rgba(148,163,184,0.58)';
+}
+
+function repaint(): void {
+  const el = canvas.value;
+  if (!el) return;
+  const geo = geojson.value;
+  paintWorldDotMap(
+    el,
+    geo ? (ctx) => drawGeoJsonMask(ctx, geo) : drawFallbackMask,
+    dotColor(),
+  );
+}
+
+onMounted(() => {
+  // Paint the built-in fallback immediately, then upgrade to the fetched
+  // GeoJSON when it arrives. A fetch failure simply keeps the fallback.
+  repaint();
+  void load();
+});
+
+// Re-render the land mask when the real GeoJSON resolves.
+watch(geojson, repaint);
+</script>
+
+<template>
+  <article class="panel map-card" data-test="node-map">
+    <div class="panel-head">
+      <div class="panel-title">
+        <span>{{ $t('index.map.title') }}</span>
+      </div>
+      <div class="map-legend">
+        <span class="legend-online">
+          <span class="legend-swatch" />{{ $t('index.map.legend_online') }}
+        </span>
+        <span class="legend-latency">
+          <span class="legend-swatch" />{{ $t('index.map.legend_latency') }}
+        </span>
+        <span class="legend-offline">
+          <span class="legend-swatch" />{{ $t('index.map.legend_offline') }}
+        </span>
+      </div>
+    </div>
+    <div class="map-stage">
+      <div class="map-grid" />
+      <canvas ref="canvas" class="map-canvas" width="1200" height="600" aria-hidden="true" />
+      <div class="map-dots" data-test="map-dots">
+        <div
+          v-for="dot in dots"
+          :key="dot.id"
+          class="map-dot"
+          :class="dot.status"
+          :style="{ left: dot.left, top: dot.top }"
+          :title="dot.label"
+          data-test="map-dot"
+        />
+      </div>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+.panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.map-legend {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.map-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.legend-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.legend-online .legend-swatch {
+  background: var(--accent-green);
+}
+.legend-latency .legend-swatch {
+  background: var(--accent-yellow);
+}
+.legend-offline .legend-swatch {
+  background: var(--accent-red);
+}
+.map-stage {
+  position: relative;
+  aspect-ratio: 16 / 8;
+  min-height: 280px;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(59, 130, 246, 0.09), transparent 55%),
+    radial-gradient(circle at 78% 62%, rgba(34, 197, 94, 0.06), transparent 52%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.18), rgba(30, 41, 59, 0.04));
+  border-radius: 14px;
+  overflow: hidden;
+}
+.map-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+  background-size: 5% 10%;
+}
+.map-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 18px 36px rgba(0, 0, 0, 0.2));
+}
+.map-dots {
+  position: absolute;
+  inset: 0;
+}
+.map-dot {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow:
+    0 0 0 3px rgba(0, 0, 0, 0.34),
+    0 0 18px currentColor;
+}
+.map-dot::after {
+  content: '';
+  position: absolute;
+  inset: -5px;
+  border-radius: 50%;
+  animation: dotPulse 2.4s infinite ease-out;
+  background: currentColor;
+  opacity: 0.14;
+}
+.map-dot.online {
+  color: var(--accent-green);
+  background: var(--accent-green);
+}
+.map-dot.latency {
+  color: var(--accent-yellow);
+  background: var(--accent-yellow);
+}
+.map-dot.offline {
+  color: var(--accent-red);
+  background: var(--accent-red);
+}
+@keyframes dotPulse {
+  0% {
+    transform: scale(0.6);
+    opacity: 0.45;
+  }
+  100% {
+    transform: scale(1.6);
+    opacity: 0;
+  }
+}
+</style>

--- a/nodelite-server/web/src/composables/useWorldGeoJson.spec.ts
+++ b/nodelite-server/web/src/composables/useWorldGeoJson.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useWorldGeoJson,
+  __resetWorldGeoJsonForTest,
+} from './useWorldGeoJson';
+
+const FAKE_GEO = { features: [{ geometry: { type: 'Polygon', coordinates: [] } }] };
+
+describe('useWorldGeoJson', () => {
+  beforeEach(() => {
+    __resetWorldGeoJsonForTest();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads and exposes the geojson on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(FAKE_GEO),
+      } as unknown as Response),
+    );
+
+    const { geojson, error, load } = useWorldGeoJson();
+    expect(geojson.value).toBeNull();
+    await load();
+    expect(geojson.value).toEqual(FAKE_GEO);
+    expect(error.value).toBeNull();
+  });
+
+  it('leaves geojson null and records the error on failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 503 } as unknown as Response),
+    );
+
+    const { geojson, error, load } = useWorldGeoJson();
+    await load();
+    expect(geojson.value).toBeNull();
+    expect(error.value).toBeInstanceOf(Error);
+  });
+
+  it('caches across instances — second load does not refetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(FAKE_GEO),
+    } as unknown as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await useWorldGeoJson().load();
+    // a fresh consumer sees the cached value immediately and triggers no fetch
+    const second = useWorldGeoJson();
+    expect(second.geojson.value).toEqual(FAKE_GEO);
+    await second.load();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after a failure (in-flight promise cleared)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(FAKE_GEO),
+      } as unknown as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = useWorldGeoJson();
+    await first.load();
+    expect(first.error.value).toBeInstanceOf(Error);
+
+    const second = useWorldGeoJson();
+    await second.load();
+    expect(second.geojson.value).toEqual(FAKE_GEO);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/nodelite-server/web/src/composables/useWorldGeoJson.ts
+++ b/nodelite-server/web/src/composables/useWorldGeoJson.ts
@@ -1,0 +1,65 @@
+import { ref, type Ref } from 'vue';
+import {
+  WORLD_GEOJSON_URL,
+  type GeoJsonFeatureCollection,
+} from '@/lib/map/landMask';
+
+/**
+ * Loads the world GeoJSON once and caches it at module scope so revisiting
+ * the dashboard route doesn't refetch. On failure the geojson stays null and
+ * the consumer falls back to the built-in land mask (matches legacy, which
+ * silently keeps WORLD_LAND_POLYGONS when the fetch fails).
+ */
+
+let cached: GeoJsonFeatureCollection | null = null;
+let inFlight: Promise<GeoJsonFeatureCollection> | null = null;
+
+async function fetchWorldGeoJson(): Promise<GeoJsonFeatureCollection> {
+  if (cached) return cached;
+  if (!inFlight) {
+    inFlight = fetch(WORLD_GEOJSON_URL, {
+      cache: 'force-cache',
+      headers: { accept: 'application/geo+json,application/json' },
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`${WORLD_GEOJSON_URL} -> ${response.status}`);
+        }
+        return response.json() as Promise<GeoJsonFeatureCollection>;
+      })
+      .then((geoJson) => {
+        cached = geoJson;
+        return geoJson;
+      })
+      .catch((error: unknown) => {
+        inFlight = null;
+        throw error;
+      });
+  }
+  return inFlight;
+}
+
+export function useWorldGeoJson(): {
+  geojson: Ref<GeoJsonFeatureCollection | null>;
+  error: Ref<Error | null>;
+  load: () => Promise<void>;
+} {
+  const geojson = ref<GeoJsonFeatureCollection | null>(cached);
+  const error = ref<Error | null>(null);
+
+  async function load(): Promise<void> {
+    try {
+      geojson.value = await fetchWorldGeoJson();
+    } catch (e) {
+      error.value = e instanceof Error ? e : new Error(String(e));
+    }
+  }
+
+  return { geojson, error, load };
+}
+
+/** Test-only: reset the module cache between specs. */
+export function __resetWorldGeoJsonForTest(): void {
+  cached = null;
+  inFlight = null;
+}

--- a/nodelite-server/web/src/lib/map/landMask.spec.ts
+++ b/nodelite-server/web/src/lib/map/landMask.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  WORLD_LAND_POLYGONS,
+  drawFallbackMask,
+  drawGeoJsonMask,
+  drawProjectedRing,
+  polygonMaxLat,
+  sampleDots,
+  type GeoJsonFeatureCollection,
+} from './landMask';
+
+function mockCtx() {
+  return {
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    fill: vi.fn(),
+  } as unknown as CanvasRenderingContext2D & {
+    beginPath: ReturnType<typeof vi.fn>;
+    moveTo: ReturnType<typeof vi.fn>;
+    lineTo: ReturnType<typeof vi.fn>;
+    fill: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('polygonMaxLat', () => {
+  it('returns the maximum latitude across all rings', () => {
+    expect(polygonMaxLat([[[0, 10], [5, 40], [10, -3]]])).toBe(40);
+  });
+
+  it('returns -90 for an empty polygon', () => {
+    expect(polygonMaxLat([])).toBe(-90);
+  });
+});
+
+describe('drawProjectedRing', () => {
+  it('moves to the first point then lines to the rest', () => {
+    const ctx = mockCtx();
+    drawProjectedRing(ctx, [[0, 0], [10, 0], [20, 10]]);
+    expect(ctx.moveTo).toHaveBeenCalledTimes(1);
+    expect(ctx.lineTo).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts a new subpath across the antimeridian (>180° jump)', () => {
+    const ctx = mockCtx();
+    drawProjectedRing(ctx, [[170, 0], [-170, 0], [-160, 0]]);
+    // jump 170 -> -170 is 340° > 180 so it moveTo's again
+    expect(ctx.moveTo).toHaveBeenCalledTimes(2);
+    expect(ctx.lineTo).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips non-finite coordinates', () => {
+    const ctx = mockCtx();
+    drawProjectedRing(ctx, [[0, 0], [Number.NaN, 5], [10, 10]]);
+    expect(ctx.moveTo).toHaveBeenCalledTimes(1);
+    expect(ctx.lineTo).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('drawGeoJsonMask', () => {
+  it('draws Polygon + MultiPolygon features and fills evenodd', () => {
+    const ctx = mockCtx();
+    const geo: GeoJsonFeatureCollection = {
+      features: [
+        { geometry: { type: 'Polygon', coordinates: [[[0, 10], [5, 12], [3, 8]]] } },
+        {
+          geometry: {
+            type: 'MultiPolygon',
+            coordinates: [[[[20, 10], [25, 12], [23, 8]]]],
+          },
+        },
+      ],
+    };
+    drawGeoJsonMask(ctx, geo);
+    expect(ctx.beginPath).toHaveBeenCalledOnce();
+    expect(ctx.moveTo).toHaveBeenCalledTimes(2);
+    expect(ctx.fill).toHaveBeenCalledWith('evenodd');
+  });
+
+  it('skips polygons entirely below the min latitude', () => {
+    const ctx = mockCtx();
+    const geo: GeoJsonFeatureCollection = {
+      features: [
+        { geometry: { type: 'Polygon', coordinates: [[[0, -80], [5, -82], [3, -85]]] } },
+      ],
+    };
+    drawGeoJsonMask(ctx, geo);
+    expect(ctx.moveTo).not.toHaveBeenCalled();
+  });
+});
+
+describe('drawFallbackMask', () => {
+  it('draws every built-in polygon and fills', () => {
+    const ctx = mockCtx();
+    drawFallbackMask(ctx);
+    expect(ctx.beginPath).toHaveBeenCalledOnce();
+    // one moveTo per polygon (first vertex of each ring)
+    expect(ctx.moveTo).toHaveBeenCalledTimes(WORLD_LAND_POLYGONS.length);
+    expect(ctx.fill).toHaveBeenCalledWith('evenodd');
+  });
+});
+
+describe('sampleDots', () => {
+  it('emits a dot for land pixels and skips transparent-black ones', () => {
+    // 4x4 grid, gap 2 → sampled at (0,0),(2,0),(0,2),(2,2)
+    const width = 4;
+    const height = 4;
+    const pixels = new Uint8ClampedArray(width * height * 4); // all transparent black
+    // mark pixel (x=2, y=0) as land (white opaque)
+    const landIndex = (0 * width + 2) * 4;
+    pixels[landIndex] = 255;
+    pixels[landIndex + 3] = 255;
+
+    const dots = sampleDots(pixels, width, height, 2);
+    expect(dots).toContainEqual({ x: 2, y: 0 });
+    // the all-zero samples are skipped
+    expect(dots).not.toContainEqual({ x: 0, y: 0 });
+  });
+
+  it('keeps a pixel that is opaque even if red channel is 0', () => {
+    const width = 2;
+    const height = 1;
+    const pixels = new Uint8ClampedArray(width * height * 4);
+    // (0,0): r=0 but alpha=255 → not (0 && 0) → kept
+    pixels[3] = 255;
+    const dots = sampleDots(pixels, width, height, 2);
+    expect(dots).toContainEqual({ x: 0, y: 0 });
+  });
+});

--- a/nodelite-server/web/src/lib/map/landMask.ts
+++ b/nodelite-server/web/src/lib/map/landMask.ts
@@ -147,6 +147,22 @@ export function sampleDots(
 export type MaskPainter = (ctx: CanvasRenderingContext2D) => void;
 
 /**
+ * Safe getContext: returns null instead of throwing when the environment has
+ * no canvas implementation. jsdom *throws* "Not implemented" rather than
+ * returning null, so a plain `getContext('2d')` would surface in unit tests.
+ */
+function get2dContext(
+  canvas: HTMLCanvasElement,
+  options?: CanvasRenderingContext2DSettings,
+): CanvasRenderingContext2D | null {
+  try {
+    return canvas.getContext('2d', options);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Orchestration glue (touches the DOM). Renders the mask to an offscreen
  * canvas, samples it, and stamps dots onto the target canvas. No-ops if a 2D
  * context is unavailable (e.g. jsdom) so callers don't need to guard.
@@ -156,7 +172,7 @@ export function paintWorldDotMap(
   maskPainter: MaskPainter,
   dotColor: string,
 ): void {
-  const ctx = target.getContext('2d');
+  const ctx = get2dContext(target);
   if (!ctx) return;
   target.width = MAP_WIDTH;
   target.height = MAP_HEIGHT;
@@ -164,7 +180,7 @@ export function paintWorldDotMap(
   const maskCanvas = document.createElement('canvas');
   maskCanvas.width = MAP_WIDTH;
   maskCanvas.height = MAP_HEIGHT;
-  const mask = maskCanvas.getContext('2d', { willReadFrequently: true });
+  const mask = get2dContext(maskCanvas, { willReadFrequently: true });
   if (!mask) return;
   mask.clearRect(0, 0, MAP_WIDTH, MAP_HEIGHT);
   mask.fillStyle = '#fff';

--- a/nodelite-server/web/src/lib/map/landMask.ts
+++ b/nodelite-server/web/src/lib/map/landMask.ts
@@ -1,0 +1,182 @@
+/**
+ * Land-mask rendering, ported from the legacy paintWorldDotMap pipeline in
+ * assets/index.html. The mask is drawn (GeoJSON or built-in fallback) onto an
+ * offscreen canvas, then sampled on a grid to stamp a dotted world map.
+ *
+ * Drawing fns take an injected context so they're unit-testable with a mock;
+ * sampleDots (which pixels become dots) is pure and tested directly. Only
+ * paintWorldDotMap touches the real DOM/canvas — guarded for null contexts.
+ */
+
+import {
+  MAP_DOT_GAP,
+  MAP_DOT_SIZE,
+  MAP_HEIGHT,
+  MAP_MIN_LAT,
+  MAP_WIDTH,
+  mapProject,
+} from './projection';
+
+export const WORLD_GEOJSON_URL =
+  'https://raw.githubusercontent.com/datasets/geo-boundaries-world-110m/master/countries.geojson';
+
+type Coord = [number, number];
+type Ring = Coord[];
+type Polygon = Ring[];
+
+export interface GeoJsonFeatureCollection {
+  features?: Array<{
+    geometry?: { type?: string; coordinates?: unknown };
+  }>;
+}
+
+/** Coarse built-in land outline; used when the GeoJSON fetch fails. */
+export const WORLD_LAND_POLYGONS: Ring[] = [
+  [[-168,72],[-150,69],[-137,60],[-127,55],[-124,49],[-129,43],[-124,33],[-116,29],[-108,23],[-97,18],[-90,19],[-82,25],[-80,31],[-75,38],[-67,45],[-55,48],[-51,55],[-64,64],[-82,70],[-110,73],[-138,73]],
+  [[-169,63],[-154,59],[-143,59],[-139,55],[-151,53],[-164,56]],
+  [[-92,18],[-85,21],[-78,19],[-77,12],[-83,8],[-90,12],[-99,17],[-106,23],[-112,29],[-106,26],[-98,22]],
+  [[-84,22],[-77,23],[-71,20],[-75,17],[-83,18]],
+  [[-78,27],[-73,25],[-70,21],[-75,20],[-80,23]],
+  [[-82,12],[-74,11],[-66,5],[-58,-5],[-48,-15],[-38,-22],[-40,-34],[-51,-45],[-64,-55],[-73,-50],[-76,-35],[-80,-20],[-80,-5]],
+  [[-53,82],[-34,81],[-20,75],[-18,65],[-33,61],[-48,62],[-63,70]],
+  [[-11,71],[6,70],[22,66],[36,61],[55,60],[74,68],[96,72],[119,70],[143,62],[166,58],[179,51],[168,43],[145,40],[125,34],[116,25],[104,21],[96,14],[88,8],[77,9],[70,18],[63,25],[52,29],[42,36],[30,42],[18,44],[9,48],[0,52],[-8,50],[-20,58]],
+  [[5,58],[16,60],[28,67],[31,71],[19,72],[10,66]],
+  [[-10,36],[2,37],[16,34],[29,31],[39,20],[50,12],[47,-7],[43,-26],[33,-34],[18,-35],[8,-27],[-4,-15],[-13,0],[-17,16]],
+  [[33,31],[42,31],[55,26],[58,17],[51,12],[42,16],[36,23]],
+  [[68,24],[80,27],[91,24],[93,15],[87,7],[77,7],[70,15]],
+  [[94,22],[104,22],[112,18],[122,8],[124,-2],[117,-8],[106,-6],[98,2]],
+  [[95,6],[106,7],[112,0],[105,-6],[96,-4]],
+  [[109,6],[116,7],[119,0],[113,-4],[107,-1]],
+  [[118,7],[126,6],[125,-4],[117,-5]],
+  [[128,0],[142,-3],[142,-9],[130,-9]],
+  [[120,16],[124,13],[123,7],[119,8]],
+  [[111,-11],[128,-14],[145,-16],[154,-25],[150,-37],[133,-43],[116,-36],[110,-22]],
+  [[141,-4],[153,-4],[153,-10],[141,-10]],
+  [[43,-12],[50,-14],[51,-22],[47,-26],[43,-21]],
+  [[138,46],[146,43],[145,36],[140,31],[134,34],[132,39]],
+  [[127,38],[130,39],[130,34],[126,34]],
+  [[120,25],[123,24],[123,21],[120,21],[119,23]],
+  [[166,-34],[179,-37],[178,-44],[170,-46],[166,-42]],
+  [[144,-40],[149,-42],[148,-44],[143,-43]],
+  [[-8,58],[2,57],[1,50],[-6,50]],
+  [[-10,55],[-5,54],[-6,51],[-10,51]],
+  [[12,56],[25,60],[31,66],[20,69],[11,63]],
+  [[79,8],[82,8],[82,5],[79,5]],
+  [[34,35],[36,35],[36,32],[34,32]],
+];
+
+export function polygonMaxLat(polygon: Polygon): number {
+  let maxLat = -90;
+  for (const ring of polygon || []) {
+    for (const coord of ring || []) {
+      const lat = Number(coord[1]);
+      if (Number.isFinite(lat)) maxLat = Math.max(maxLat, lat);
+    }
+  }
+  return maxLat;
+}
+
+export function drawProjectedRing(ctx: CanvasRenderingContext2D, ring: Ring): void {
+  let started = false;
+  let lastLon: number | null = null;
+  for (const coord of ring) {
+    const lon = Number(coord[0]);
+    const lat = Number(coord[1]);
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) continue;
+    const point = mapProject(lon, lat);
+    if (!started || (lastLon != null && Math.abs(lon - lastLon) > 180)) {
+      ctx.moveTo(point.x, point.y);
+      started = true;
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+    lastLon = lon;
+  }
+}
+
+export function drawGeoJsonMask(
+  ctx: CanvasRenderingContext2D,
+  geoJson: GeoJsonFeatureCollection,
+): void {
+  ctx.beginPath();
+  for (const feature of geoJson.features || []) {
+    const geometry = feature.geometry || {};
+    if (geometry.type === 'Polygon') {
+      const coordinates = geometry.coordinates as Polygon;
+      if (polygonMaxLat(coordinates) < MAP_MIN_LAT) continue;
+      for (const ring of coordinates || []) drawProjectedRing(ctx, ring);
+    } else if (geometry.type === 'MultiPolygon') {
+      const coordinates = geometry.coordinates as Polygon[];
+      for (const polygon of coordinates || []) {
+        if (polygonMaxLat(polygon) < MAP_MIN_LAT) continue;
+        for (const ring of polygon || []) drawProjectedRing(ctx, ring);
+      }
+    }
+  }
+  ctx.fill('evenodd');
+}
+
+export function drawFallbackMask(ctx: CanvasRenderingContext2D): void {
+  ctx.beginPath();
+  for (const polygon of WORLD_LAND_POLYGONS) drawProjectedRing(ctx, polygon);
+  ctx.fill('evenodd');
+}
+
+/**
+ * Walk the mask's pixels on a grid and return the centres where land was
+ * painted. A pixel counts as land unless it's fully transparent black
+ * (r === 0 && alpha === 0), matching the legacy sampling test. Pure.
+ */
+export function sampleDots(
+  pixels: Uint8ClampedArray,
+  width = MAP_WIDTH,
+  height = MAP_HEIGHT,
+  gap = MAP_DOT_GAP,
+): Array<{ x: number; y: number }> {
+  const dots: Array<{ x: number; y: number }> = [];
+  for (let y = 0; y < height; y += gap) {
+    for (let x = 0; x < width; x += gap) {
+      const index = ((y | 0) * width + (x | 0)) * 4;
+      if (pixels[index] === 0 && pixels[index + 3] === 0) continue;
+      dots.push({ x, y });
+    }
+  }
+  return dots;
+}
+
+export type MaskPainter = (ctx: CanvasRenderingContext2D) => void;
+
+/**
+ * Orchestration glue (touches the DOM). Renders the mask to an offscreen
+ * canvas, samples it, and stamps dots onto the target canvas. No-ops if a 2D
+ * context is unavailable (e.g. jsdom) so callers don't need to guard.
+ */
+export function paintWorldDotMap(
+  target: HTMLCanvasElement,
+  maskPainter: MaskPainter,
+  dotColor: string,
+): void {
+  const ctx = target.getContext('2d');
+  if (!ctx) return;
+  target.width = MAP_WIDTH;
+  target.height = MAP_HEIGHT;
+
+  const maskCanvas = document.createElement('canvas');
+  maskCanvas.width = MAP_WIDTH;
+  maskCanvas.height = MAP_HEIGHT;
+  const mask = maskCanvas.getContext('2d', { willReadFrequently: true });
+  if (!mask) return;
+  mask.clearRect(0, 0, MAP_WIDTH, MAP_HEIGHT);
+  mask.fillStyle = '#fff';
+  maskPainter(mask);
+
+  const pixels = mask.getImageData(0, 0, MAP_WIDTH, MAP_HEIGHT).data;
+  ctx.clearRect(0, 0, MAP_WIDTH, MAP_HEIGHT);
+  ctx.fillStyle = dotColor;
+  ctx.beginPath();
+  for (const dot of sampleDots(pixels)) {
+    ctx.moveTo(dot.x + MAP_DOT_SIZE, dot.y);
+    ctx.arc(dot.x, dot.y, MAP_DOT_SIZE, 0, Math.PI * 2);
+  }
+  ctx.fill();
+}

--- a/nodelite-server/web/src/lib/map/projection.spec.ts
+++ b/nodelite-server/web/src/lib/map/projection.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { makeNode } from '@/api/__fixtures__/nodes';
+import {
+  MAP_HEIGHT,
+  MAP_WIDTH,
+  clamp01,
+  hashString,
+  mapProject,
+  nodePosition,
+  nodeRegionKey,
+  nodeStatusKey,
+} from './projection';
+
+describe('hashString', () => {
+  it('is deterministic and non-negative', () => {
+    expect(hashString('node-a')).toBe(hashString('node-a'));
+    expect(hashString('node-a')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('differs for different inputs', () => {
+    expect(hashString('node-a')).not.toBe(hashString('node-b'));
+  });
+});
+
+describe('clamp01', () => {
+  it('clamps to [0.02, 0.98]', () => {
+    expect(clamp01(-1)).toBe(0.02);
+    expect(clamp01(5)).toBe(0.98);
+    expect(clamp01(0.5)).toBe(0.5);
+  });
+});
+
+describe('nodeRegionKey', () => {
+  it('matches an explicit region tag', () => {
+    const node = makeNode({
+      identity: { node_id: 'x', node_label: 'X', hostname: 'h', tags: ['jp'] },
+    });
+    expect(nodeRegionKey(node)).toBe('jp');
+  });
+
+  it('matches a country:xx style tag', () => {
+    const node = makeNode({
+      identity: { node_id: 'x', node_label: 'X', hostname: 'h', tags: ['country:de'] },
+    });
+    expect(nodeRegionKey(node)).toBe('de');
+  });
+
+  it('falls back to hostname token match', () => {
+    const node = makeNode({
+      identity: { node_id: 'x', node_label: 'X', hostname: 'web-us-1', tags: [] },
+    });
+    expect(nodeRegionKey(node)).toBe('us');
+  });
+
+  it('returns null when nothing matches', () => {
+    const node = makeNode({
+      identity: { node_id: 'zzz', node_label: 'Z', hostname: 'host', tags: [] },
+    });
+    expect(nodeRegionKey(node)).toBeNull();
+  });
+});
+
+describe('nodePosition', () => {
+  it('is deterministic for the same node id', () => {
+    const node = makeNode({
+      identity: { node_id: 'srv-1', node_label: 'S', hostname: 'h', tags: ['jp'] },
+    });
+    expect(nodePosition(node)).toEqual(nodePosition(node));
+  });
+
+  it('places region-tagged nodes near the region anchor', () => {
+    const node = makeNode({
+      identity: { node_id: 'srv-1', node_label: 'S', hostname: 'h', tags: ['jp'] },
+    });
+    const { x, y } = nodePosition(node);
+    // jp anchor is [0.86, 0.42]; jitter is < ±0.02
+    expect(x).toBeGreaterThan(0.82);
+    expect(x).toBeLessThan(0.9);
+    expect(y).toBeGreaterThan(0.38);
+    expect(y).toBeLessThan(0.46);
+  });
+
+  it('keeps unknown-region nodes within the safe band', () => {
+    const node = makeNode({
+      identity: { node_id: 'mystery', node_label: 'M', hostname: 'h', tags: [] },
+    });
+    const { x, y } = nodePosition(node);
+    expect(x).toBeGreaterThanOrEqual(0.15);
+    expect(x).toBeLessThanOrEqual(0.85);
+    expect(y).toBeGreaterThanOrEqual(0.2);
+    expect(y).toBeLessThanOrEqual(0.8);
+  });
+});
+
+describe('nodeStatusKey', () => {
+  it('returns offline when not online', () => {
+    expect(nodeStatusKey(makeNode({ online: false }))).toBe('offline');
+  });
+
+  it('returns latency when online but over the warn threshold', () => {
+    expect(nodeStatusKey(makeNode({ online: true, latency_ms: 250 }))).toBe('latency');
+  });
+
+  it('returns online when healthy', () => {
+    expect(nodeStatusKey(makeNode({ online: true, latency_ms: 20 }))).toBe('online');
+  });
+
+  it('returns online when latency is null', () => {
+    expect(nodeStatusKey(makeNode({ online: true, latency_ms: null }))).toBe('online');
+  });
+});
+
+describe('mapProject', () => {
+  it('maps lon=0 to the horizontal centre', () => {
+    expect(mapProject(0, 0).x).toBeCloseTo(MAP_WIDTH / 2, 5);
+  });
+
+  it('maps lon=-180 to the left edge and lon=180 to the right edge', () => {
+    expect(mapProject(-180, 0).x).toBeCloseTo(0, 5);
+    expect(mapProject(180, 0).x).toBeCloseTo(MAP_WIDTH, 5);
+  });
+
+  it('places higher latitudes higher on the canvas (smaller y)', () => {
+    expect(mapProject(0, 60).y).toBeLessThan(mapProject(0, -20).y);
+  });
+
+  it('keeps the equator near vertical mid + shift, within bounds', () => {
+    const y = mapProject(0, 0).y;
+    expect(y).toBeGreaterThan(0);
+    expect(y).toBeLessThan(MAP_HEIGHT);
+  });
+});

--- a/nodelite-server/web/src/lib/map/projection.ts
+++ b/nodelite-server/web/src/lib/map/projection.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure projection + node-placement helpers, ported verbatim from the legacy
+ * map code in assets/index.html (mapProject / nodePosition / nodeRegionKey /
+ * hashString). No DOM access — safe to unit test directly.
+ *
+ * Node dots are NOT placed by real geography: nodePosition picks a region
+ * anchor (REGION_HINTS) by tag/hostname/id, then adds deterministic jitter so
+ * multiple nodes in the same country don't fully overlap. mapProject (real
+ * Mercator) is used only for drawing the land mask.
+ */
+
+import type { NodeListItem } from '@/api';
+
+export const MAP_WIDTH = 1200;
+export const MAP_HEIGHT = 600;
+export const MAP_MAX_LAT = 82;
+export const MAP_MIN_LAT = -58;
+export const MAP_DOT_GAP = 4;
+export const MAP_DOT_SIZE = 1.05;
+export const MAP_VERTICAL_SHIFT = 70;
+export const LATENCY_WARN_MS = 200;
+
+export type NodeStatus = 'online' | 'offline' | 'latency';
+
+/** Region anchor points as {x, y} fractions of the map (0..1). */
+export const REGION_HINTS: Record<string, readonly [number, number]> = {
+  cn: [0.78, 0.42], china: [0.78, 0.42],
+  hk: [0.79, 0.5], tw: [0.82, 0.5],
+  jp: [0.86, 0.42], japan: [0.86, 0.42],
+  kr: [0.83, 0.4], korea: [0.83, 0.4],
+  sg: [0.77, 0.62], singapore: [0.77, 0.62],
+  in: [0.69, 0.5], india: [0.69, 0.5],
+  ae: [0.62, 0.5], au: [0.88, 0.78], australia: [0.88, 0.78],
+  ru: [0.7, 0.28], russia: [0.7, 0.28],
+  de: [0.49, 0.32], germany: [0.49, 0.32], eu: [0.5, 0.34],
+  fr: [0.48, 0.34], uk: [0.46, 0.3], gb: [0.46, 0.3],
+  nl: [0.49, 0.31], es: [0.46, 0.4], it: [0.5, 0.38],
+  us: [0.22, 0.4], usa: [0.22, 0.4],
+  ca: [0.22, 0.28], canada: [0.22, 0.28],
+  br: [0.34, 0.7], brazil: [0.34, 0.7],
+  ar: [0.32, 0.82], mx: [0.18, 0.5],
+  za: [0.55, 0.74], ng: [0.5, 0.6], eg: [0.55, 0.5],
+};
+
+export function hashString(value: string): number {
+  let h = 5381;
+  for (let i = 0; i < value.length; i++) {
+    h = ((h << 5) + h + value.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+export function clamp01(v: number): number {
+  return Math.min(0.98, Math.max(0.02, v));
+}
+
+export function nodeRegionKey(node: NodeListItem): string | null {
+  const tags = node.identity.tags || [];
+  for (const tag of tags) {
+    const lower = String(tag).toLowerCase();
+    if (REGION_HINTS[lower]) return lower;
+    const m = lower.match(/^(?:country|region|cc|loc)[:=](\w+)$/);
+    if (m && m[1] && REGION_HINTS[m[1]]) return m[1];
+  }
+  const hostname = String(node.identity.hostname || '').toLowerCase();
+  for (const key of Object.keys(REGION_HINTS)) {
+    if (
+      hostname.includes(`-${key}-`) ||
+      hostname.startsWith(`${key}-`) ||
+      hostname.endsWith(`-${key}`)
+    ) {
+      return key;
+    }
+  }
+  const idLower = String(node.identity.node_id || '').toLowerCase();
+  for (const key of Object.keys(REGION_HINTS)) {
+    if (idLower.includes(key)) return key;
+  }
+  return null;
+}
+
+/** Returns {x, y} as 0..1 fractions of the map stage. Deterministic per node. */
+export function nodePosition(node: NodeListItem): { x: number; y: number } {
+  const region = nodeRegionKey(node);
+  const seed = hashString(node.identity.node_id || node.identity.node_label || '');
+  if (region) {
+    const anchor = REGION_HINTS[region];
+    if (anchor) {
+      const [x, y] = anchor;
+      const jx = ((seed % 23) - 11) / 600;
+      const jy = (((seed >> 5) % 19) - 9) / 600;
+      return { x: clamp01(x + jx), y: clamp01(y + jy) };
+    }
+  }
+  const x = ((seed % 1000) / 1000) * 0.7 + 0.15;
+  const y = (((seed >> 7) % 1000) / 1000) * 0.6 + 0.2;
+  return { x, y };
+}
+
+export function nodeStatusKey(node: NodeListItem): NodeStatus {
+  if (!node.online) return 'offline';
+  if (node.latency_ms != null && node.latency_ms >= LATENCY_WARN_MS) return 'latency';
+  return 'online';
+}
+
+/** Real Mercator projection (lon/lat → map pixels). Used for the land mask. */
+export function mapProject(lon: number, lat: number): { x: number; y: number } {
+  const safeLat = Math.max(-85, Math.min(MAP_MAX_LAT, Number(lat)));
+  const latRad = (safeLat * Math.PI) / 180;
+  const mercator = Math.log(Math.tan(Math.PI / 4 + latRad / 2));
+  return {
+    x: (Number(lon) + 180) * (MAP_WIDTH / 360),
+    y: MAP_HEIGHT / 2 - (MAP_WIDTH * mercator) / (2 * Math.PI) + MAP_VERTICAL_SHIFT,
+  };
+}

--- a/nodelite-server/web/src/views/DashboardView.spec.ts
+++ b/nodelite-server/web/src/views/DashboardView.spec.ts
@@ -6,6 +6,7 @@ import { createApp, defineComponent, h } from 'vue';
 
 import DashboardView from './DashboardView.vue';
 import { setupI18n, getI18n, __resetI18nForTest, LANGUAGE_STORAGE_KEY } from '@/i18n';
+import { __resetWorldGeoJsonForTest } from '@/composables/useWorldGeoJson';
 
 const FAKE_DICT = {
   en: {
@@ -67,6 +68,9 @@ describe('DashboardView', () => {
   beforeEach(async () => {
     window.localStorage.clear();
     __resetI18nForTest();
+    __resetWorldGeoJsonForTest();
+    // jsdom has no canvas 2D context; NodeMap's paint no-ops with null.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -82,15 +86,18 @@ describe('DashboardView', () => {
   afterEach(() => {
     window.localStorage.clear();
     __resetI18nForTest();
+    __resetWorldGeoJsonForTest();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     delete document.documentElement.dataset.theme;
   });
 
-  it('renders the shell with sidebar, header, and stats', async () => {
+  it('renders the shell with sidebar, header, map, and stats', async () => {
     const wrapper = await mountDashboard();
     expect(wrapper.find('[data-test="app-shell"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="dashboard-view"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="sidebar-nav"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="node-map"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="overview-stats"]').exists()).toBe(true);
   });
 

--- a/nodelite-server/web/src/views/DashboardView.vue
+++ b/nodelite-server/web/src/views/DashboardView.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted } from 'vue';
 import SidebarNav from '@/components/SidebarNav.vue';
 import OverviewStats from '@/components/OverviewStats.vue';
+import NodeMap from '@/components/NodeMap.vue';
 import { useTheme } from '@/composables/useTheme';
 import { usePolling } from '@/composables/usePolling';
 import { useLanguage } from '@/i18n/language';
@@ -105,8 +106,9 @@ const localeLabels: Record<SupportedLocale, string> = {
       </header>
 
       <section class="overview">
+        <NodeMap />
         <OverviewStats />
-        <!-- NodeMap (PR 2b) and NodeList (PR 2c) mount here. -->
+        <!-- NodeList (PR 2c) mounts here. -->
       </section>
     </main>
   </div>
@@ -142,6 +144,11 @@ const localeLabels: Record<SupportedLocale, string> = {
   margin: 4px 0 0;
   color: var(--text-muted);
   font-size: 13px;
+}
+.overview {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 .page-actions {
   display: flex;


### PR DESCRIPTION
## Summary

Second of three Dashboard PRs. Adds the world map card. Builds on 2a (#179). 4 commits, squash on merge.

### What's in

- **`lib/map/projection.ts`** — pure ports of the legacy placement math: `hashString`, `clamp01`, `REGION_HINTS`, `nodeRegionKey`, `nodePosition` (region anchor + deterministic jitter — node dots are NOT geographic), `nodeStatusKey`, and the Mercator `mapProject` (used only for the land mask). 18 unit tests.
- **`lib/map/landMask.ts`** — `polygonMaxLat`, `drawProjectedRing` / `drawGeoJsonMask` / `drawFallbackMask` (ctx-injected, mock-tested), the built-in fallback outline, a pure `sampleDots` (pixel grid → dot centres), and `paintWorldDotMap` glue. `get2dContext` wraps `getContext` in try/catch so it no-ops where canvas is unavailable. 10 unit tests.
- **`composables/useWorldGeoJson.ts`** — fetches the world GeoJSON once (`cache: force-cache`, matching legacy), caches at module scope, and on failure leaves it null so the fallback mask is used. 4 unit tests (success / failure-keeps-null / cross-instance cache / retry).
- **`components/NodeMap.vue`** — map card (title + legend) with a `<canvas>` land mask + reactive dot overlay (`v-for` over `useNodesStore`, positioned by `nodePosition`, coloured by `nodeStatusKey`). Paints the fallback immediately, upgrades to fetched GeoJSON via a `watch`. Mounted into `DashboardView` above the stats.

### Notes

- **GeoJSON source / CSP**: the world outline is fetched from `raw.githubusercontent.com` (already in the legacy CSP `connect-src`). Offline/blocked → the built-in fallback mask renders. Stage 2 doesn't touch CSP (Stage 4).
- **Dots aren't geographic** by design — same as legacy: a region anchor by tag/hostname/id + deterministic jitter so co-located nodes don't fully overlap.
- **Layout**: NodeMap stacks above OverviewStats (vertical). The legacy side-by-side needs the matrix panel, which is out of Stage 2 scope.
- jsdom has no canvas 2D context, so component specs stub `getContext`→null; the actual pixel/draw logic is covered by the `lib/map` pure-function specs.

## Test plan

- [x] `pnpm lint` / `typecheck` / `test` (86 tests, 16 files) / `build` — all clean
- [ ] Manual smoke (`cargo run` + `pnpm dev`): map renders with land dots; online path shows real GeoJSON outline; offline path (kill network first) falls back to the built-in mask; node dots appear at region anchors with status colours

## Next

- **PR 2c** — NodeList + NodeCard + spark history fetcher (with in-flight dedup)
- Stage 2.5 — Settings/Alerts/Account; Stage 3 — NodeDetail (+ shared layout extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)