### PR TITLE
Stage 2c — NodeList + NodeCard + spark history

### DIFF
--- a/nodelite-server/web/src/api/__fixtures__/nodes.ts
+++ b/nodelite-server/web/src/api/__fixtures__/nodes.ts
@@ -16,6 +16,13 @@ export function makeBootstrap(
 }
 
 export function makeNode(overrides: Partial<NodeListItem> = {}): NodeListItem {
+  // Honor explicitly-passed values by key presence so tests can set
+  // latency_ms / snapshot to null (a plain ?? would coalesce null away).
+  const defaultSnapshot = {
+    cpu_usage_percent: 12.5,
+    load: { one: 0.3 },
+    memory: { total_bytes: 8_000_000_000, used_bytes: 2_000_000_000 },
+  };
   return {
     identity: {
       node_id: 'node-a',
@@ -24,13 +31,9 @@ export function makeNode(overrides: Partial<NodeListItem> = {}): NodeListItem {
       tags: [],
       ...overrides.identity,
     },
-    snapshot: overrides.snapshot ?? {
-      cpu_usage_percent: 12.5,
-      load: { one: 0.3 },
-      memory: { total_bytes: 8_000_000_000, used_bytes: 2_000_000_000 },
-    },
-    latency_ms: overrides.latency_ms ?? 5,
-    online: overrides.online ?? true,
+    snapshot: 'snapshot' in overrides ? (overrides.snapshot ?? null) : defaultSnapshot,
+    latency_ms: 'latency_ms' in overrides ? (overrides.latency_ms ?? null) : 5,
+    online: 'online' in overrides ? (overrides.online ?? false) : true,
   };
 }
 

--- a/nodelite-server/web/src/api/index.spec.ts
+++ b/nodelite-server/web/src/api/index.spec.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiClient } from './index';
+
+function jsonResponse(body: unknown): Response {
+  const headers = new Headers({ 'content-type': 'application/json' });
+  return {
+    status: 200,
+    ok: true,
+    redirected: false,
+    url: 'http://localhost/x',
+    headers,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('apiClient.nodeHistory', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('builds the history URL with window_hours + max_points', async () => {
+    await apiClient.nodeHistory('node-a', { windowHours: 3, maxPoints: 180 });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toBe('/api/nodes/node-a/history?window_hours=3&max_points=180');
+  });
+
+  it('encodes the node id and omits unset query params', async () => {
+    await apiClient.nodeHistory('a b/c');
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toBe('/api/nodes/a%20b%2Fc/history');
+  });
+
+  it('sends only the params that are provided', async () => {
+    await apiClient.nodeHistory('n', { maxPoints: 60 });
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toBe('/api/nodes/n/history?max_points=60');
+  });
+});

--- a/nodelite-server/web/src/components/NodeCard.spec.ts
+++ b/nodelite-server/web/src/components/NodeCard.spec.ts
@@ -4,6 +4,7 @@ import { createApp, defineComponent, h } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
 import { apiClient } from '@/api';
+import { useNodeHistoryStore } from '@/stores/nodeHistory';
 import { makeNode } from '@/api/__fixtures__/nodes';
 import NodeCard from './NodeCard.vue';
 
@@ -123,5 +124,36 @@ describe('NodeCard', () => {
     });
     await mountCard(node);
     expect(mockHistory).toHaveBeenCalledWith('abc', { windowHours: 3, maxPoints: 180 });
+  });
+
+  it('re-requests history when the snapshot changes (polling refresh)', async () => {
+    // Spy on the store action so the assertion is independent of the TTL
+    // clock — the point is the watch fires loadIfStale again, not whether
+    // the store decides to refetch.
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const store = useNodeHistoryStore();
+    const loadSpy = vi.spyOn(store, 'loadIfStale');
+
+    const node = makeNode({
+      identity: { node_id: 'n1', node_label: 'N', hostname: 'h', tags: [] },
+      snapshot: { cpu_usage_percent: 10, load: { one: 0.1 }, memory: { total_bytes: 1, used_bytes: 0 } },
+    });
+    const wrapper = mount(NodeCard, {
+      props: { node },
+      global: { plugins: [pinia, getI18n()], stubs: { RouterLink: RouterLinkStub } },
+    });
+    await flushPromises();
+    expect(loadSpy).toHaveBeenCalledTimes(1); // immediate
+
+    // A poll replaces the node object with a fresh snapshot reference.
+    await wrapper.setProps({
+      node: makeNode({
+        identity: { node_id: 'n1', node_label: 'N', hostname: 'h', tags: [] },
+        snapshot: { cpu_usage_percent: 55, load: { one: 0.9 }, memory: { total_bytes: 1, used_bytes: 0 } },
+      }),
+    });
+    await flushPromises();
+    expect(loadSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/nodelite-server/web/src/components/NodeCard.spec.ts
+++ b/nodelite-server/web/src/components/NodeCard.spec.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises, RouterLinkStub } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { apiClient } from '@/api';
+import { makeNode } from '@/api/__fixtures__/nodes';
+import NodeCard from './NodeCard.vue';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, nodeHistory: vi.fn() },
+  };
+});
+
+const mockHistory = vi.mocked(apiClient.nodeHistory);
+
+const FAKE_DICT = {
+  en: {
+    'index.node.latency': 'Latency',
+    'index.node.load': 'Load',
+    'index.node.cpu': 'CPU',
+    'common.online': 'Online',
+    'common.offline': 'Offline',
+    'common.latency_warn': 'High latency',
+  },
+  'zh-CN': {
+    'index.node.latency': '延迟',
+    'index.node.load': '负载',
+    'index.node.cpu': 'CPU',
+    'common.online': '在线',
+    'common.offline': '离线',
+    'common.latency_warn': '高延迟',
+  },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+async function mountCard(node: ReturnType<typeof makeNode>) {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const wrapper = mount(NodeCard, {
+    props: { node },
+    global: {
+      plugins: [pinia, getI18n()],
+      stubs: { RouterLink: RouterLinkStub },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('NodeCard', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    mockHistory.mockResolvedValue([]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('links to the node detail route', async () => {
+    const node = makeNode({
+      identity: { node_id: 'srv 1', node_label: 'Server', hostname: 'h', tags: [] },
+    });
+    const wrapper = await mountCard(node);
+    const link = wrapper.findComponent(RouterLinkStub);
+    expect(link.props('to')).toBe('/nodes/srv%201');
+  });
+
+  it('renders metrics with rounded latency, load, and cpu%', async () => {
+    const node = makeNode({
+      online: true,
+      latency_ms: 42,
+      snapshot: {
+        cpu_usage_percent: 63.7,
+        load: { one: 1.234 },
+        memory: { total_bytes: 100, used_bytes: 50 },
+      },
+    });
+    const wrapper = await mountCard(node);
+    expect(wrapper.find('[data-test="metric-latency"]').text()).toBe('42 ms');
+    expect(wrapper.find('[data-test="metric-load"]').text()).toBe('1.23');
+    expect(wrapper.find('[data-test="metric-cpu"]').text()).toBe('64%');
+    // 63.7% → yellow band [50,80)
+    expect(wrapper.find('[data-test="metric-cpu"]').classes()).toContain('accent-yellow');
+  });
+
+  it('shows em dashes when metrics are unavailable', async () => {
+    const node = makeNode({ online: true, latency_ms: null, snapshot: null });
+    const wrapper = await mountCard(node);
+    expect(wrapper.find('[data-test="metric-latency"]').text()).toBe('—');
+    expect(wrapper.find('[data-test="metric-load"]').text()).toBe('—');
+    expect(wrapper.find('[data-test="metric-cpu"]').text()).toBe('—');
+  });
+
+  it('shows the offline badge label for an offline node', async () => {
+    const node = makeNode({ online: false });
+    const wrapper = await mountCard(node);
+    const badge = wrapper.find('[data-test="node-badge"]');
+    expect(badge.classes()).toContain('offline');
+    expect(badge.text()).toBe('Offline');
+  });
+
+  it('requests history for its node on mount', async () => {
+    const node = makeNode({
+      identity: { node_id: 'abc', node_label: 'A', hostname: 'h', tags: [] },
+    });
+    await mountCard(node);
+    expect(mockHistory).toHaveBeenCalledWith('abc', { windowHours: 3, maxPoints: 180 });
+  });
+});

--- a/nodelite-server/web/src/components/NodeCard.vue
+++ b/nodelite-server/web/src/components/NodeCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue';
+import { computed, watch } from 'vue';
 import type { NodeListItem } from '@/api';
 import { nodeFlag, nodeStatusKey } from '@/lib/map/projection';
 import { buildSparkline, nodeSparkPoints, sparklineColor } from '@/lib/chart/sparkline';
@@ -53,8 +53,12 @@ const sparkPoints = computed(() =>
 );
 const spark = computed(() => buildSparkline(sparkPoints.value));
 
-onMounted(() => {
-  void historyStore.loadIfStale(nodeId.value);
+// Re-request on every snapshot change (the 5s poll replaces node objects),
+// throttled to once a minute by the store's TTL. NodeCard is keyed by
+// node_id so the instance is reused across polls — onMounted alone would
+// fire only once and freeze the sparkline.
+watch(() => props.node.snapshot, () => void historyStore.loadIfStale(nodeId.value), {
+  immediate: true,
 });
 </script>
 

--- a/nodelite-server/web/src/components/NodeCard.vue
+++ b/nodelite-server/web/src/components/NodeCard.vue
@@ -1,0 +1,228 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue';
+import type { NodeListItem } from '@/api';
+import { nodeFlag, nodeStatusKey } from '@/lib/map/projection';
+import { buildSparkline, nodeSparkPoints, sparklineColor } from '@/lib/chart/sparkline';
+import { useNodeHistoryStore } from '@/stores/nodeHistory';
+
+const props = defineProps<{ node: NodeListItem }>();
+
+const historyStore = useNodeHistoryStore();
+
+const nodeId = computed(() => props.node.identity.node_id);
+const status = computed(() => nodeStatusKey(props.node));
+
+const title = computed(() => {
+  const { node_label: label, node_id: id } = props.node.identity;
+  return label && label !== id ? `${label}: ${id}` : id;
+});
+
+const statusLabelKey = computed(() => {
+  switch (status.value) {
+    case 'offline':
+      return 'common.offline';
+    case 'latency':
+      return 'common.latency_warn';
+    default:
+      return 'common.online';
+  }
+});
+
+const latencyText = computed(() =>
+  props.node.latency_ms == null ? '—' : `${Math.round(props.node.latency_ms)} ms`,
+);
+
+const loadText = computed(() => {
+  const one = props.node.snapshot?.load.one;
+  return one == null ? '—' : one.toFixed(2);
+});
+
+const cpu = computed(() => props.node.snapshot?.cpu_usage_percent ?? null);
+const cpuText = computed(() => (cpu.value == null ? '—' : `${cpu.value.toFixed(0)}%`));
+const cpuClass = computed(() => {
+  const v = cpu.value;
+  if (v == null) return '';
+  if (v >= 80) return 'accent-red';
+  if (v >= 50) return 'accent-yellow';
+  return 'accent-green';
+});
+
+const sparkColor = computed(() => sparklineColor(status.value));
+const sparkPoints = computed(() =>
+  nodeSparkPoints(historyStore.points(nodeId.value), cpu.value),
+);
+const spark = computed(() => buildSparkline(sparkPoints.value));
+
+onMounted(() => {
+  void historyStore.loadIfStale(nodeId.value);
+});
+</script>
+
+<template>
+  <RouterLink
+    class="node-card"
+    :to="`/nodes/${encodeURIComponent(nodeId)}`"
+    data-test="node-card"
+    :data-node-id="nodeId"
+  >
+    <div class="node-card-head">
+      <div class="node-card-title">
+        <span class="flag">{{ nodeFlag(node) }}</span>
+        <span :title="title">{{ title }}</span>
+      </div>
+      <span class="badge" :class="status" data-test="node-badge">
+        {{ $t(statusLabelKey) }}
+      </span>
+    </div>
+
+    <div class="node-metrics">
+      <div class="node-metric">
+        <div class="label">{{ $t('index.node.latency') }}</div>
+        <div class="value" data-test="metric-latency">{{ latencyText }}</div>
+      </div>
+      <div class="node-metric">
+        <div class="label">{{ $t('index.node.load') }}</div>
+        <div class="value" data-test="metric-load">{{ loadText }}</div>
+      </div>
+      <div class="node-metric">
+        <div class="label">{{ $t('index.node.cpu') }}</div>
+        <div class="value" :class="cpuClass" data-test="metric-cpu">{{ cpuText }}</div>
+      </div>
+    </div>
+
+    <div class="node-spark" :style="{ color: sparkColor }">
+      <svg
+        v-if="spark"
+        :viewBox="`0 0 ${spark.width} ${spark.height}`"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <path :d="spark.area" :fill="sparkColor" fill-opacity="0.16" />
+        <path
+          :d="spark.line"
+          fill="none"
+          :stroke="sparkColor"
+          stroke-width="1.1"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          vector-effect="non-scaling-stroke"
+        />
+      </svg>
+      <svg v-else viewBox="0 0 200 60" preserveAspectRatio="none" aria-hidden="true">
+        <line x1="0" y1="48" x2="200" y2="48" :stroke="sparkColor" stroke-width="1" stroke-opacity="0.28" />
+      </svg>
+    </div>
+  </RouterLink>
+</template>
+
+<style scoped>
+.node-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  padding: 14px 16px 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 168px;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease;
+  overflow: hidden;
+}
+.node-card:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+.node-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.node-card-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-primary);
+  min-width: 0;
+}
+.node-card-title .flag {
+  font-size: 18px;
+  line-height: 1;
+}
+.node-card-title span:last-child {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--bg-card-soft);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.badge::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.badge.online {
+  color: var(--accent-green);
+  background: var(--accent-green-soft);
+}
+.badge.latency {
+  color: var(--accent-yellow);
+  background: var(--accent-yellow-soft);
+}
+.badge.offline {
+  color: var(--accent-red);
+  background: var(--accent-red-soft);
+}
+.node-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 12px 0 4px;
+}
+.node-metric .label {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+.node-metric .value {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.node-metric .value.accent-green {
+  color: var(--accent-green);
+}
+.node-metric .value.accent-yellow {
+  color: var(--accent-yellow);
+}
+.node-metric .value.accent-red {
+  color: var(--accent-red);
+}
+.node-spark {
+  height: 52px;
+  margin: 8px -16px -2px;
+  position: relative;
+}
+.node-spark svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+</style>

--- a/nodelite-server/web/src/components/NodeList.spec.ts
+++ b/nodelite-server/web/src/components/NodeList.spec.ts
@@ -3,7 +3,6 @@ import { mount, flushPromises, RouterLinkStub } from '@vue/test-utils';
 import { createApp, defineComponent, h } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
-import { apiClient } from '@/api';
 import { useNodesStore } from '@/stores/nodes';
 import { makeNode } from '@/api/__fixtures__/nodes';
 import NodeList from './NodeList.vue';

--- a/nodelite-server/web/src/components/NodeList.spec.ts
+++ b/nodelite-server/web/src/components/NodeList.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises, RouterLinkStub } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { apiClient } from '@/api';
+import { useNodesStore } from '@/stores/nodes';
+import { makeNode } from '@/api/__fixtures__/nodes';
+import NodeList from './NodeList.vue';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, nodeHistory: vi.fn().mockResolvedValue([]) },
+  };
+});
+
+const FAKE_DICT = {
+  en: {
+    'common.waiting_for_data': 'Waiting for data…',
+    'index.node.latency': 'Latency',
+    'index.node.load': 'Load',
+    'index.node.cpu': 'CPU',
+    'common.online': 'Online',
+    'common.offline': 'Offline',
+    'common.latency_warn': 'High latency',
+  },
+  'zh-CN': { 'common.waiting_for_data': '等待数据…' },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+async function mountList(nodes: ReturnType<typeof makeNode>[]) {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useNodesStore();
+  store.nodes = nodes;
+  const wrapper = mount(NodeList, {
+    global: {
+      plugins: [pinia, getI18n()],
+      stubs: { RouterLink: RouterLinkStub },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('NodeList', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('renders one card per node, keyed by node id', async () => {
+    const wrapper = await mountList([
+      makeNode({ identity: { node_id: 'a', node_label: 'A', hostname: 'ha', tags: [] } }),
+      makeNode({ identity: { node_id: 'b', node_label: 'B', hostname: 'hb', tags: [] } }),
+      makeNode({ identity: { node_id: 'c', node_label: 'C', hostname: 'hc', tags: [] } }),
+    ]);
+    expect(wrapper.findAll('[data-test="node-card"]')).toHaveLength(3);
+    expect(wrapper.find('[data-test="node-list-empty"]').exists()).toBe(false);
+  });
+
+  it('shows the empty state when there are no nodes', async () => {
+    const wrapper = await mountList([]);
+    expect(wrapper.findAll('[data-test="node-card"]')).toHaveLength(0);
+    expect(wrapper.find('[data-test="node-list-empty"]').text()).toBe('Waiting for data…');
+  });
+});

--- a/nodelite-server/web/src/components/NodeList.vue
+++ b/nodelite-server/web/src/components/NodeList.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { useNodesStore } from '@/stores/nodes';
+import NodeCard from './NodeCard.vue';
+
+const nodesStore = useNodesStore();
+</script>
+
+<template>
+  <section class="nodes-section" data-test="node-list">
+    <div v-if="nodesStore.nodes.length > 0" class="node-grid">
+      <NodeCard
+        v-for="node in nodesStore.nodes"
+        :key="node.identity.node_id"
+        :node="node"
+      />
+    </div>
+    <p v-else class="nodes-empty" data-test="node-list-empty">
+      {{ $t('common.waiting_for_data') }}
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.nodes-section {
+  margin-top: 12px;
+}
+.node-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+.nodes-empty {
+  color: var(--text-muted);
+  font-size: 13px;
+  margin: 0;
+  padding: 24px 0;
+}
+</style>

--- a/nodelite-server/web/src/lib/chart/sparkline.spec.ts
+++ b/nodelite-server/web/src/lib/chart/sparkline.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { HistoryPoint } from '@/api';
+import {
+  aggregateSeries,
+  buildSparkline,
+  nodeSparkPoints,
+  smoothPath,
+  sparklineColor,
+} from './sparkline';
+
+function point(recorded_at: string, cpu: number | null): HistoryPoint {
+  return {
+    node_id: 'n',
+    recorded_at,
+    cpu_usage_percent: cpu,
+    memory_used_percent: 0,
+    rx_bytes_per_sec: null,
+    tx_bytes_per_sec: null,
+    latency_ms: null,
+    disk_used_percent: null,
+  };
+}
+
+describe('aggregateSeries', () => {
+  it('returns [] for empty/undefined history', () => {
+    expect(aggregateSeries(undefined, 'cpu_usage_percent')).toEqual([]);
+    expect(aggregateSeries([], 'cpu_usage_percent')).toEqual([]);
+  });
+
+  it('averages values within the same minute bucket, ascending by time', () => {
+    const series = aggregateSeries(
+      [
+        point('2026-05-29T00:00:10Z', 10),
+        point('2026-05-29T00:00:50Z', 30), // same minute → avg 20
+        point('2026-05-29T00:01:05Z', 50), // next minute
+      ],
+      'cpu_usage_percent',
+    );
+    expect(series).toEqual([20, 50]);
+  });
+
+  it('skips null and non-finite values', () => {
+    const series = aggregateSeries(
+      [point('2026-05-29T00:00:10Z', null), point('2026-05-29T00:01:00Z', 42)],
+      'cpu_usage_percent',
+    );
+    expect(series).toEqual([42]);
+  });
+});
+
+describe('sparklineColor', () => {
+  it('maps status to colour', () => {
+    expect(sparklineColor('offline')).toBe('#ef4444');
+    expect(sparklineColor('latency')).toBe('#eab308');
+    expect(sparklineColor('online')).toBe('#22c55e');
+  });
+});
+
+describe('smoothPath', () => {
+  it('returns empty string for no coords', () => {
+    expect(smoothPath([])).toBe('');
+  });
+
+  it('returns a lone moveTo for a single point', () => {
+    expect(smoothPath([[3, 4]])).toBe('M3.0,4.0');
+  });
+
+  it('emits a cubic segment for multiple points', () => {
+    const d = smoothPath([
+      [0, 0],
+      [10, 10],
+    ]);
+    expect(d.startsWith('M0.0,0.0')).toBe(true);
+    expect(d).toContain(' C');
+  });
+});
+
+describe('buildSparkline', () => {
+  it('returns null for fewer than 2 points', () => {
+    expect(buildSparkline([])).toBeNull();
+    expect(buildSparkline([5])).toBeNull();
+  });
+
+  it('builds line + closed area paths for >=2 points', () => {
+    const spark = buildSparkline([0, 50, 100]);
+    expect(spark).not.toBeNull();
+    expect(spark!.line.startsWith('M')).toBe(true);
+    expect(spark!.area.endsWith('Z')).toBe(true);
+    expect(spark!.width).toBe(200);
+    expect(spark!.height).toBe(60);
+  });
+});
+
+describe('nodeSparkPoints', () => {
+  it('uses aggregated history when available', () => {
+    const pts = nodeSparkPoints(
+      [point('2026-05-29T00:00:00Z', 10), point('2026-05-29T00:01:00Z', 20)],
+      99,
+    );
+    expect(pts).toEqual([10, 20]);
+  });
+
+  it('falls back to the current snapshot cpu when history is empty', () => {
+    expect(nodeSparkPoints([], 42)).toEqual([42]);
+    expect(nodeSparkPoints(undefined, 42)).toEqual([42]);
+  });
+
+  it('returns [] when neither history nor current cpu is available', () => {
+    expect(nodeSparkPoints([], null)).toEqual([]);
+    expect(nodeSparkPoints(undefined, undefined)).toEqual([]);
+  });
+});

--- a/nodelite-server/web/src/lib/chart/sparkline.ts
+++ b/nodelite-server/web/src/lib/chart/sparkline.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure SVG sparkline helpers, ported from the legacy aggregateSeries /
+ * sparklineSvg / smoothPath in assets/index.html. No DOM — NodeCard renders
+ * the returned path strings inside an <svg>.
+ */
+
+import type { HistoryPoint } from '@/api';
+import type { NodeStatus } from '@/lib/map/projection';
+
+export const SPARK_BUCKET_MS = 60 * 1000;
+const SPARK_W = 200;
+const SPARK_H = 60;
+const SPARK_PAD_Y = 8;
+
+type NumericHistoryField = {
+  [K in keyof HistoryPoint]: HistoryPoint[K] extends number | null ? K : never;
+}[keyof HistoryPoint];
+
+/**
+ * Bucket history points by minute and average a numeric field. Skips
+ * null/non-finite values. Returns an ascending-time array of averages.
+ */
+export function aggregateSeries(
+  history: HistoryPoint[] | undefined,
+  field: NumericHistoryField,
+  bucketMs = SPARK_BUCKET_MS,
+): number[] {
+  if (!Array.isArray(history) || history.length === 0) return [];
+  const buckets = new Map<number, { sum: number; count: number }>();
+  for (const point of history) {
+    const rawValue = point[field];
+    if (rawValue == null) continue;
+    const value = Number(rawValue);
+    if (!Number.isFinite(value)) continue;
+    const ts = Date.parse(point.recorded_at);
+    if (!Number.isFinite(ts)) continue;
+    const bucket = Math.floor(ts / bucketMs) * bucketMs;
+    const item = buckets.get(bucket) || { sum: 0, count: 0 };
+    item.sum += value;
+    item.count += 1;
+    buckets.set(bucket, item);
+  }
+  return [...buckets.entries()]
+    .sort((left, right) => left[0] - right[0])
+    .map(([, item]) => item.sum / item.count);
+}
+
+export function sparklineColor(status: NodeStatus): string {
+  if (status === 'offline') return '#ef4444';
+  if (status === 'latency') return '#eab308';
+  return '#22c55e';
+}
+
+/** Catmull-Rom-ish smoothing → SVG path `d`. Mirrors legacy smoothPath. */
+export function smoothPath(coords: Array<[number, number]>): string {
+  if (!coords.length) return '';
+  const first = coords[0]!;
+  if (coords.length === 1) {
+    return `M${first[0].toFixed(1)},${first[1].toFixed(1)}`;
+  }
+  let path = `M${first[0].toFixed(1)},${first[1].toFixed(1)}`;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const p0 = coords[i - 1] || coords[i]!;
+    const p1 = coords[i]!;
+    const p2 = coords[i + 1]!;
+    const p3 = coords[i + 2] || p2;
+    const cp1x = p1[0] + (p2[0] - p0[0]) / 6;
+    const cp1y = p1[1] + (p2[1] - p0[1]) / 6;
+    const cp2x = p2[0] - (p3[0] - p1[0]) / 6;
+    const cp2y = p2[1] - (p3[1] - p1[1]) / 6;
+    path += ` C${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${p2[0].toFixed(1)},${p2[1].toFixed(1)}`;
+  }
+  return path;
+}
+
+export interface Sparkline {
+  width: number;
+  height: number;
+  line: string;
+  area: string;
+}
+
+/**
+ * Build the line + filled-area paths for a sparkline. Returns null when there
+ * are fewer than 2 points (the component renders a flat baseline instead).
+ */
+export function buildSparkline(points: number[]): Sparkline | null {
+  if (!Array.isArray(points) || points.length < 2) return null;
+  const w = SPARK_W;
+  const h = SPARK_H;
+  const padY = SPARK_PAD_Y;
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const span = Math.max(max - min, 1);
+  const stepX = w / (points.length - 1);
+  const coords = points.map(
+    (value, idx): [number, number] => [
+      idx * stepX,
+      h - padY - ((value - min) / span) * (h - padY * 2),
+    ],
+  );
+  const line = smoothPath(coords);
+  const area = `${line} L ${w},${h} L 0,${h} Z`;
+  return { width: w, height: h, line, area };
+}
+
+/**
+ * CPU history for the spark, falling back to the node's current snapshot
+ * value when no history is cached yet.
+ */
+export function nodeSparkPoints(
+  history: HistoryPoint[] | undefined,
+  currentCpu: number | null | undefined,
+): number[] {
+  const points = aggregateSeries(history, 'cpu_usage_percent');
+  if (points.length > 0) return points;
+  if (currentCpu == null) return [];
+  const current = Number(currentCpu);
+  return Number.isFinite(current) ? [current] : [];
+}

--- a/nodelite-server/web/src/lib/map/projection.spec.ts
+++ b/nodelite-server/web/src/lib/map/projection.spec.ts
@@ -6,6 +6,7 @@ import {
   clamp01,
   hashString,
   mapProject,
+  nodeFlag,
   nodePosition,
   nodeRegionKey,
   nodeStatusKey,
@@ -107,6 +108,22 @@ describe('nodeStatusKey', () => {
 
   it('returns online when latency is null', () => {
     expect(nodeStatusKey(makeNode({ online: true, latency_ms: null }))).toBe('online');
+  });
+});
+
+describe('nodeFlag', () => {
+  it('returns the region flag when known', () => {
+    const node = makeNode({
+      identity: { node_id: 'x', node_label: 'X', hostname: 'h', tags: ['us'] },
+    });
+    expect(nodeFlag(node)).toBe('🇺🇸');
+  });
+
+  it('falls back to a globe for unknown regions', () => {
+    const node = makeNode({
+      identity: { node_id: 'zzz', node_label: 'Z', hostname: 'host', tags: [] },
+    });
+    expect(nodeFlag(node)).toBe('🌐');
   });
 });
 

--- a/nodelite-server/web/src/lib/map/projection.ts
+++ b/nodelite-server/web/src/lib/map/projection.ts
@@ -42,6 +42,15 @@ export const REGION_HINTS: Record<string, readonly [number, number]> = {
   za: [0.55, 0.74], ng: [0.5, 0.6], eg: [0.55, 0.5],
 };
 
+/** Flag emoji per region key; falls back to a globe. */
+export const COUNTRY_FLAGS: Record<string, string> = {
+  cn: '🇨🇳', hk: '🇭🇰', tw: '🇹🇼', jp: '🇯🇵', kr: '🇰🇷', sg: '🇸🇬',
+  in: '🇮🇳', ae: '🇦🇪', au: '🇦🇺', ru: '🇷🇺', de: '🇩🇪', fr: '🇫🇷',
+  uk: '🇬🇧', gb: '🇬🇧', nl: '🇳🇱', es: '🇪🇸', it: '🇮🇹', us: '🇺🇸',
+  usa: '🇺🇸', ca: '🇨🇦', br: '🇧🇷', ar: '🇦🇷', mx: '🇲🇽', za: '🇿🇦',
+  ng: '🇳🇬', eg: '🇪🇬',
+};
+
 export function hashString(value: string): number {
   let h = 5381;
   for (let i = 0; i < value.length; i++) {
@@ -95,6 +104,12 @@ export function nodePosition(node: NodeListItem): { x: number; y: number } {
   const x = ((seed % 1000) / 1000) * 0.7 + 0.15;
   const y = (((seed >> 7) % 1000) / 1000) * 0.6 + 0.2;
   return { x, y };
+}
+
+export function nodeFlag(node: NodeListItem): string {
+  const region = nodeRegionKey(node);
+  if (region && COUNTRY_FLAGS[region]) return COUNTRY_FLAGS[region];
+  return '🌐';
 }
 
 export function nodeStatusKey(node: NodeListItem): NodeStatus {

--- a/nodelite-server/web/src/stores/nodeHistory.spec.ts
+++ b/nodelite-server/web/src/stores/nodeHistory.spec.ts
@@ -1,0 +1,100 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiAbortError, ApiError } from '@/api/client';
+import { apiClient } from '@/api';
+import { useNodeHistoryStore, SPARK_REFRESH_MS } from './nodeHistory';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, nodeHistory: vi.fn() },
+  };
+});
+
+const mockHistory = vi.mocked(apiClient.nodeHistory);
+
+describe('useNodeHistoryStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockHistory.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('fetches and stores points for a node', async () => {
+    mockHistory.mockResolvedValueOnce([]);
+    const store = useNodeHistoryStore();
+    await store.loadIfStale('a');
+    expect(mockHistory).toHaveBeenCalledWith('a', { windowHours: 3, maxPoints: 180 });
+    expect(store.points('a')).toEqual([]);
+  });
+
+  it('dedups concurrent loadIfStale for the same node', async () => {
+    let resolve: (v: never[]) => void = () => {};
+    mockHistory.mockReturnValueOnce(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    const store = useNodeHistoryStore();
+
+    const a = store.loadIfStale('a');
+    const b = store.loadIfStale('a'); // in-flight → no second request
+    const c = store.loadIfStale('a');
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+
+    resolve([]);
+    await Promise.all([a, b, c]);
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips refetch within the TTL but refetches once stale', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    mockHistory.mockResolvedValue([]);
+    const store = useNodeHistoryStore();
+
+    await store.loadIfStale('a');
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+
+    // within TTL → no refetch
+    vi.setSystemTime(1_000_000 + SPARK_REFRESH_MS - 1);
+    await store.loadIfStale('a');
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+
+    // past TTL → refetch
+    vi.setSystemTime(1_000_000 + SPARK_REFRESH_MS + 1);
+    await store.loadIfStale('a');
+    expect(mockHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('records non-abort errors and keeps points empty', async () => {
+    mockHistory.mockRejectedValueOnce(new ApiError(500, 'boom'));
+    const store = useNodeHistoryStore();
+    await store.loadIfStale('a');
+    expect(store.entries['a']?.error).toBeInstanceOf(ApiError);
+    expect(store.points('a')).toEqual([]);
+  });
+
+  it('swallows ApiAbortError silently', async () => {
+    mockHistory.mockRejectedValueOnce(new ApiAbortError('redirect'));
+    const store = useNodeHistoryStore();
+    await store.loadIfStale('a');
+    expect(store.entries['a']?.error).toBeNull();
+  });
+
+  it('forceReload bypasses the TTL', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000_000);
+    mockHistory.mockResolvedValue([]);
+    const store = useNodeHistoryStore();
+
+    await store.loadIfStale('a');
+    await store.forceReload('a');
+    expect(mockHistory).toHaveBeenCalledTimes(2);
+  });
+});

--- a/nodelite-server/web/src/stores/nodeHistory.ts
+++ b/nodelite-server/web/src/stores/nodeHistory.ts
@@ -1,0 +1,82 @@
+import { defineStore } from 'pinia';
+import { reactive } from 'vue';
+import { apiClient, type HistoryPoint } from '@/api';
+import { ApiAbortError } from '@/api/client';
+
+/** Home-page sparkline window, matching legacy HOME_SPARK_* constants. */
+export const SPARK_WINDOW_HOURS = 3;
+export const SPARK_MAX_POINTS = 180;
+export const SPARK_REFRESH_MS = 60 * 1000;
+
+export interface NodeHistoryEntry {
+  points: HistoryPoint[];
+  fetchedAt: number;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Per-node history cache for the dashboard sparklines. NodeCard calls
+ * loadIfStale on mount; the store dedups concurrent fetches for the same id
+ * (a Set guard — the TTL check alone doesn't help on first paint when every
+ * card's fetchedAt is still 0) and skips refetching within the TTL.
+ */
+export const useNodeHistoryStore = defineStore('nodeHistory', () => {
+  const entries = reactive<Record<string, NodeHistoryEntry>>({});
+  // Not reactive — purely a concurrency guard so N cards mounting at once
+  // don't fire N requests for the same node.
+  const pending = new Set<string>();
+
+  function points(nodeId: string): HistoryPoint[] {
+    return entries[nodeId]?.points ?? [];
+  }
+
+  function ensure(nodeId: string): NodeHistoryEntry {
+    const existing = entries[nodeId];
+    if (existing) return existing;
+    const created: NodeHistoryEntry = {
+      points: [],
+      fetchedAt: 0,
+      loading: false,
+      error: null,
+    };
+    entries[nodeId] = created;
+    return created;
+  }
+
+  async function fetchNow(nodeId: string): Promise<void> {
+    if (pending.has(nodeId)) return;
+    pending.add(nodeId);
+    const entry = ensure(nodeId);
+    entry.loading = true;
+    entry.error = null;
+    try {
+      entry.points = await apiClient.nodeHistory(nodeId, {
+        windowHours: SPARK_WINDOW_HOURS,
+        maxPoints: SPARK_MAX_POINTS,
+      });
+      entry.fetchedAt = Date.now();
+    } catch (e) {
+      if (!(e instanceof ApiAbortError)) {
+        entry.error = e instanceof Error ? e : new Error(String(e));
+      }
+    } finally {
+      entry.loading = false;
+      pending.delete(nodeId);
+    }
+  }
+
+  async function loadIfStale(nodeId: string, ttlMs = SPARK_REFRESH_MS): Promise<void> {
+    const entry = entries[nodeId];
+    if (entry && entry.fetchedAt > 0 && Date.now() - entry.fetchedAt < ttlMs) {
+      return;
+    }
+    await fetchNow(nodeId);
+  }
+
+  async function forceReload(nodeId: string): Promise<void> {
+    await fetchNow(nodeId);
+  }
+
+  return { entries, points, loadIfStale, forceReload };
+});

--- a/nodelite-server/web/src/views/DashboardView.spec.ts
+++ b/nodelite-server/web/src/views/DashboardView.spec.ts
@@ -99,6 +99,7 @@ describe('DashboardView', () => {
     expect(wrapper.find('[data-test="sidebar-nav"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="node-map"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="overview-stats"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="node-list"]').exists()).toBe(true);
   });
 
   it('theme toggle flips the html data-theme attribute', async () => {

--- a/nodelite-server/web/src/views/DashboardView.vue
+++ b/nodelite-server/web/src/views/DashboardView.vue
@@ -3,6 +3,7 @@ import { computed, onMounted } from 'vue';
 import SidebarNav from '@/components/SidebarNav.vue';
 import OverviewStats from '@/components/OverviewStats.vue';
 import NodeMap from '@/components/NodeMap.vue';
+import NodeList from '@/components/NodeList.vue';
 import { useTheme } from '@/composables/useTheme';
 import { usePolling } from '@/composables/usePolling';
 import { useLanguage } from '@/i18n/language';
@@ -108,7 +109,7 @@ const localeLabels: Record<SupportedLocale, string> = {
       <section class="overview">
         <NodeMap />
         <OverviewStats />
-        <!-- NodeList (PR 2c) mounts here. -->
+        <NodeList />
       </section>
     </main>
   </div>


### PR DESCRIPTION
## Summary

Final Dashboard PR. Adds the node list/cards with per-node CPU sparklines. Builds on 2a (#179) + 2b (#180). 5 commits, squash on merge. This completes the Dashboard view (sidebar + header + map + stats + node grid).

### What's in

- **`lib/chart/sparkline.ts`** — pure SVG sparkline helpers: `aggregateSeries` (minute-bucket average keyed off `recorded_at`), `sparklineColor`, `smoothPath` (Catmull-Rom → SVG `d`), `buildSparkline` (line + filled-area paths; null under 2 points), `nodeSparkPoints` (history CPU with snapshot fallback). 12 unit tests.
- **`stores/nodeHistory.ts`** — `useNodeHistoryStore`: per-node history cache. `loadIfStale` skips refetch within the TTL (60s, matching legacy `HOME_SPARK_REFRESH_MS`) and a **`Set` in-flight guard dedups concurrent fetches** for the same id — important on first paint when N cards mount at once (the TTL check alone wouldn't help since every `fetchedAt` is 0). 6 unit tests (fetch/dedup/TTL/error/abort/forceReload).
- **`components/NodeCard.vue`** — `RouterLink` to `/nodes/:id`, flag + title, status badge, RTT/Load/CPU metrics (CPU coloured by the legacy 50/80% bands, em-dash when null), and an SVG sparkline. `onMounted` triggers `loadIfStale`.
- **`components/NodeList.vue`** — keyed `v-for` of NodeCard (Vue reconciliation replaces the legacy manual `renderedNodeCards` DOM diff), empty state when there are no nodes.
- **`api/index.spec.ts`** — covers the `nodeHistory` URL builder (added in 2a).
- **`projection.ts`** — added `COUNTRY_FLAGS` + `nodeFlag` (region flag, globe fallback).
- **`__fixtures__/nodes.ts`** — `makeNode` now honors explicitly-passed `null` (latency/snapshot/online) by key presence instead of `??`.

### Notes

- **Spark fetch isn't a burst**: the `Set` dedup means duplicate mounts for the same node collapse to one request; the TTL keeps refetches bounded. (No `requestIdleCallback` ladder — the dedup + TTL is the floor we agreed on; can add staggering later if profiling shows a need.)
- **Sparkline is SVG**, not canvas — pure path strings, fully unit-tested (no jsdom canvas issue).
- Component specs stub `RouterLink` (`RouterLinkStub`) and mock `nodeHistory`.

## Test plan

- [x] `pnpm lint` / `typecheck` / `test` (117 tests, 21 files) / `build` — all clean
- [ ] Manual smoke (`cargo run` + `pnpm dev`): node cards render with metrics + sparklines; clicking a card navigates to `/nodes/:id` (Stage 3 placeholder); empty backend shows the waiting state

## Next

- Stage 2.5 — Settings/Alerts/Account tab views (the sidebar buttons stay disabled until then)
- Stage 3 — NodeDetail (+ extract a shared layout to stop header duplication, per the saved memo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)