### PR TITLE
Stage 3a — Shared AppLayout + NodeDetail shell + identity/tab routing

### DIFF
--- a/nodelite-server/web/src/api/__fixtures__/nodes.ts
+++ b/nodelite-server/web/src/api/__fixtures__/nodes.ts
@@ -1,4 +1,10 @@
-import type { BootstrapResponse, NodeListItem, OverviewData } from '@/api';
+import type {
+  AgentLogEntry,
+  BootstrapResponse,
+  NodeListItem,
+  NodeStatus,
+  OverviewData,
+} from '@/api';
 
 export function makeBootstrap(
   overrides: Partial<BootstrapResponse> = {},
@@ -34,6 +40,70 @@ export function makeNode(overrides: Partial<NodeListItem> = {}): NodeListItem {
     snapshot: 'snapshot' in overrides ? (overrides.snapshot ?? null) : defaultSnapshot,
     latency_ms: 'latency_ms' in overrides ? (overrides.latency_ms ?? null) : 5,
     online: 'online' in overrides ? (overrides.online ?? false) : true,
+  };
+}
+
+export function makeNodeStatus(overrides: Partial<NodeStatus> = {}): NodeStatus {
+  return {
+    identity: {
+      node_id: 'node-a',
+      node_label: 'Node A',
+      hostname: 'host-a',
+      os: 'linux',
+      kernel_version: '6.1.0',
+      cpu_model: 'Test CPU',
+      cpu_cores: 4,
+      agent_version: '1.0.0',
+      boot_time: '2026-05-28T00:00:00Z',
+      tags: [],
+      ...overrides.identity,
+    },
+    remote_ip: 'remote_ip' in overrides ? (overrides.remote_ip ?? null) : '203.0.113.7',
+    snapshot:
+      'snapshot' in overrides
+        ? (overrides.snapshot ?? null)
+        : {
+            collected_at: '2026-05-29T00:00:00Z',
+            cpu_usage_percent: 12.5,
+            load: { one: 0.3, five: 0.4, fifteen: 0.5 },
+            memory: {
+              total_bytes: 8_000_000_000,
+              used_bytes: 2_000_000_000,
+              available_bytes: 6_000_000_000,
+              swap_total_bytes: 0,
+              swap_used_bytes: 0,
+            },
+            uptime_secs: 90_000,
+            disks: [
+              {
+                device: '/dev/sda1',
+                mount_point: '/',
+                fs_type: 'ext4',
+                total_bytes: 100_000_000_000,
+                available_bytes: 60_000_000_000,
+                used_bytes: 40_000_000_000,
+                used_percent: 40,
+              },
+            ],
+            network: {
+              total_rx_bytes: 1000,
+              total_tx_bytes: 2000,
+              rx_bytes_per_sec: 10,
+              tx_bytes_per_sec: 20,
+            },
+          },
+    last_seen: 'last_seen' in overrides ? (overrides.last_seen ?? null) : '2026-05-29T00:00:00Z',
+    latency_ms: 'latency_ms' in overrides ? (overrides.latency_ms ?? null) : 5,
+    online: 'online' in overrides ? (overrides.online ?? false) : true,
+  };
+}
+
+export function makeLogEntry(overrides: Partial<AgentLogEntry> = {}): AgentLogEntry {
+  return {
+    occurred_at: '2026-05-29T00:00:00Z',
+    level: 'info',
+    message: 'hello',
+    ...overrides,
   };
 }
 

--- a/nodelite-server/web/src/api/index.spec.ts
+++ b/nodelite-server/web/src/api/index.spec.ts
@@ -44,4 +44,51 @@ describe('apiClient.nodeHistory', () => {
     const url = fetchMock.mock.calls[0]![0] as string;
     expect(url).toBe('/api/nodes/n/history?max_points=60');
   });
+
+  it('supports a start/end range query', async () => {
+    await apiClient.nodeHistory('n', { start: 1000, end: 2000, maxPoints: 720 });
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toBe('/api/nodes/n/history?max_points=720&start=1000&end=2000');
+  });
+});
+
+describe('apiClient.nodeStatus', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({}));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches the full node status, encoding the id', async () => {
+    await apiClient.nodeStatus('a b');
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/nodes/a%20b');
+  });
+});
+
+describe('apiClient.nodeLogs', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to limit=200', async () => {
+    await apiClient.nodeLogs('n');
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/nodes/n/logs?limit=200');
+  });
+
+  it('honors a custom limit', async () => {
+    await apiClient.nodeLogs('n', 50);
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/nodes/n/logs?limit=50');
+  });
 });

--- a/nodelite-server/web/src/api/index.ts
+++ b/nodelite-server/web/src/api/index.ts
@@ -5,20 +5,28 @@
 
 import { api } from './client';
 import type {
+  AgentLogEntry,
   BootstrapResponse,
   HistoryPoint,
   HistoryQuery,
   NodeListItem,
+  NodeStatus,
   OverviewData,
 } from './types';
 
 export type {
+  AgentLogEntry,
   BootstrapResponse,
+  DiskUsage,
   HistoryPoint,
   HistoryQuery,
+  LogLevel,
+  NodeIdentity,
   NodeListItem,
   NodeListIdentity,
   NodeListSnapshot,
+  NodeSnapshot,
+  NodeStatus,
   OverviewData,
 } from './types';
 
@@ -26,7 +34,8 @@ export const apiClient = {
   bootstrap: () => api<BootstrapResponse>('/api/bootstrap'),
   overview: () => api<OverviewData>('/api/overview'),
   listNodes: () => api<NodeListItem[]>('/api/nodes'),
-  getNode: (id: string) => api<NodeListItem>(`/api/nodes/${encodeURIComponent(id)}`),
+  /** Full per-node status (NodeStatus), not the lightweight list shape. */
+  nodeStatus: (id: string) => api<NodeStatus>(`/api/nodes/${encodeURIComponent(id)}`),
   nodeHistory: (id: string, query: HistoryQuery = {}) => {
     const params = new URLSearchParams();
     if (query.windowHours !== undefined) {
@@ -35,10 +44,18 @@ export const apiClient = {
     if (query.maxPoints !== undefined) {
       params.set('max_points', String(query.maxPoints));
     }
+    if (query.start !== undefined) {
+      params.set('start', String(query.start));
+    }
+    if (query.end !== undefined) {
+      params.set('end', String(query.end));
+    }
     const qs = params.toString();
     const suffix = qs ? `?${qs}` : '';
-    return api<HistoryPoint[]>(
-      `/api/nodes/${encodeURIComponent(id)}/history${suffix}`,
-    );
+    return api<HistoryPoint[]>(`/api/nodes/${encodeURIComponent(id)}/history${suffix}`);
   },
+  nodeLogs: (id: string, limit = 200) =>
+    api<AgentLogEntry[]>(
+      `/api/nodes/${encodeURIComponent(id)}/logs?limit=${encodeURIComponent(String(limit))}`,
+    ),
 };

--- a/nodelite-server/web/src/api/types.ts
+++ b/nodelite-server/web/src/api/types.ts
@@ -67,4 +67,81 @@ export interface HistoryPoint {
 export interface HistoryQuery {
   windowHours?: number;
   maxPoints?: number;
+  /** Unix seconds; start + end must be supplied together for a range query. */
+  start?: number;
+  end?: number;
+}
+
+/** Full per-node identity — GET /api/nodes/{id}, nodelite-proto NodeIdentity */
+export interface NodeIdentity {
+  node_id: string;
+  node_label: string;
+  hostname: string;
+  os: string;
+  kernel_version: string | null;
+  cpu_model: string | null;
+  cpu_cores: number;
+  agent_version: string;
+  boot_time: string | null;
+  tags: string[];
+}
+
+export interface LoadAverage {
+  one: number;
+  five: number;
+  fifteen: number;
+}
+
+export interface MemoryUsage {
+  total_bytes: number;
+  used_bytes: number;
+  available_bytes: number;
+  swap_total_bytes: number;
+  swap_used_bytes: number;
+}
+
+export interface DiskUsage {
+  device: string;
+  mount_point: string;
+  fs_type: string;
+  total_bytes: number;
+  available_bytes: number;
+  used_bytes: number;
+  used_percent: number;
+}
+
+export interface NetworkCounters {
+  total_rx_bytes: number;
+  total_tx_bytes: number;
+  rx_bytes_per_sec: number | null;
+  tx_bytes_per_sec: number | null;
+}
+
+export interface NodeSnapshot {
+  collected_at: string;
+  cpu_usage_percent: number | null;
+  load: LoadAverage;
+  memory: MemoryUsage;
+  uptime_secs: number;
+  disks: DiskUsage[];
+  network: NetworkCounters;
+}
+
+/** GET /api/nodes/{id} — full nodelite-proto NodeStatus */
+export interface NodeStatus {
+  identity: NodeIdentity;
+  remote_ip: string | null;
+  snapshot: NodeSnapshot | null;
+  last_seen: string | null;
+  latency_ms: number | null;
+  online: boolean;
+}
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+/** GET /api/nodes/{id}/logs — nodelite-proto AgentLogEntry */
+export interface AgentLogEntry {
+  occurred_at: string;
+  level: LogLevel;
+  message: string;
 }

--- a/nodelite-server/web/src/components/AppLayout.spec.ts
+++ b/nodelite-server/web/src/components/AppLayout.spec.ts
@@ -1,41 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
-import { createPinia, setActivePinia } from 'pinia';
 import { createMemoryHistory, createRouter, type Router } from 'vue-router';
 import { createApp, defineComponent, h } from 'vue';
 
-import DashboardView from './DashboardView.vue';
-import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
-import { __resetWorldGeoJsonForTest } from '@/composables/useWorldGeoJson';
+import AppLayout from './AppLayout.vue';
+import { setupI18n, getI18n, __resetI18nForTest, LANGUAGE_STORAGE_KEY } from '@/i18n';
 
 const FAKE_DICT = {
   en: {
-    'index.heading': 'Overview',
-    'index.subtitle': 'Global server monitoring · {count} online',
     'common.theme_toggle': 'Toggle theme',
     'common.language': 'Language',
     'index.nav.overview': 'Overview',
     'index.nav.settings': 'Settings',
     'index.nav.alerts': 'Alerts',
     'index.nav.account': 'Account',
-    'index.stat.total': 'Total Servers',
-    'index.stat.online': 'Online',
-    'index.stat.offline': 'Offline',
-    'index.stat.latency': 'Avg Latency',
   },
   'zh-CN': {
-    'index.heading': '概览',
-    'index.subtitle': '全球服务器监控 · {count} 在线',
     'common.theme_toggle': '切换主题',
     'common.language': '语言',
     'index.nav.overview': '概览',
     'index.nav.settings': '设置',
     'index.nav.alerts': '告警',
     'index.nav.account': '账户',
-    'index.stat.total': '服务器总数',
-    'index.stat.online': '在线',
-    'index.stat.offline': '离线',
-    'index.stat.latency': '平均延迟',
   },
 };
 
@@ -51,26 +37,25 @@ function makeRouter(): Router {
   });
 }
 
-async function mountDashboard() {
-  const pinia = createPinia();
-  setActivePinia(pinia);
+async function mountLayout() {
   const router = makeRouter();
   await router.push('/');
   await router.isReady();
-  const wrapper = mount(DashboardView, {
-    global: { plugins: [pinia, router, getI18n()] },
+  const wrapper = mount(AppLayout, {
+    global: { plugins: [router, getI18n()] },
+    slots: {
+      title: '<h1 data-test="slot-title">Hi</h1>',
+      default: '<div data-test="slot-body">Body</div>',
+    },
   });
   await flushPromises();
   return wrapper;
 }
 
-describe('DashboardView', () => {
+describe('AppLayout', () => {
   beforeEach(async () => {
     window.localStorage.clear();
     __resetI18nForTest();
-    __resetWorldGeoJsonForTest();
-    // jsdom has no canvas 2D context; NodeMap's paint no-ops with null.
-    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -86,21 +71,32 @@ describe('DashboardView', () => {
   afterEach(() => {
     window.localStorage.clear();
     __resetI18nForTest();
-    __resetWorldGeoJsonForTest();
     vi.unstubAllGlobals();
-    vi.restoreAllMocks();
     delete document.documentElement.dataset.theme;
   });
 
-  it('renders inside AppLayout with map, stats, and node list', async () => {
-    const wrapper = await mountDashboard();
-    // AppLayout chrome (theme/lang coverage lives in AppLayout.spec).
+  it('renders sidebar, the title slot, and the body slot', async () => {
+    const wrapper = await mountLayout();
     expect(wrapper.find('[data-test="app-shell"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="sidebar-nav"]').exists()).toBe(true);
-    // Dashboard body.
-    expect(wrapper.find('[data-test="dashboard-view"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="node-map"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="overview-stats"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="node-list"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="slot-title"]').text()).toBe('Hi');
+    expect(wrapper.find('[data-test="slot-body"]').text()).toBe('Body');
+  });
+
+  it('theme toggle flips the html data-theme attribute', async () => {
+    document.documentElement.dataset.theme = 'dark';
+    const wrapper = await mountLayout();
+
+    await wrapper.find('[data-test="theme-toggle"]').trigger('click');
+    expect(document.documentElement.dataset.theme).toBe('light');
+
+    await wrapper.find('[data-test="theme-toggle"]').trigger('click');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+
+  it('language select writes the chosen locale to localStorage', async () => {
+    const wrapper = await mountLayout();
+    await wrapper.find('[data-test="language-select"]').setValue('zh-CN');
+    expect(window.localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('zh-CN');
   });
 });

--- a/nodelite-server/web/src/components/AppLayout.vue
+++ b/nodelite-server/web/src/components/AppLayout.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import SidebarNav from '@/components/SidebarNav.vue';
+import { useTheme } from '@/composables/useTheme';
+import { useLanguage } from '@/i18n/language';
+import { SUPPORTED_LOCALES, type SupportedLocale } from '@/i18n';
+
+// Shared chrome for every top-level view: sidebar rail + a header whose
+// left side is a per-view #title slot and right side holds the global
+// theme + language controls. Body goes in the default slot. Lives in one
+// place so DashboardView / NodeDetailView don't each reimplement it.
+const { theme, toggleTheme } = useTheme();
+const { currentLocale, setLocale } = useLanguage();
+
+function onLanguageChange(event: Event): void {
+  setLocale((event.target as HTMLSelectElement).value);
+}
+
+const localeLabels: Record<SupportedLocale, string> = {
+  en: 'English',
+  'zh-CN': '中文',
+};
+</script>
+
+<template>
+  <div class="app" data-test="app-shell">
+    <SidebarNav />
+
+    <main class="main">
+      <header class="page-header">
+        <div class="page-title">
+          <slot name="title" />
+        </div>
+        <div class="page-actions">
+          <select
+            class="lang-select"
+            :aria-label="$t('common.language')"
+            data-test="language-select"
+            :value="currentLocale"
+            @change="onLanguageChange"
+          >
+            <option v-for="locale in SUPPORTED_LOCALES" :key="locale" :value="locale">
+              {{ localeLabels[locale] }}
+            </option>
+          </select>
+          <button
+            type="button"
+            class="theme-toggle"
+            :title="$t('common.theme_toggle')"
+            :aria-label="$t('common.theme_toggle')"
+            data-test="theme-toggle"
+            @click="toggleTheme"
+          >
+            <svg
+              v-if="theme === 'dark'"
+              class="sun"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <circle cx="12" cy="12" r="4" />
+              <path
+                d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
+              />
+            </svg>
+            <svg
+              v-else
+              class="moon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+          </button>
+        </div>
+      </header>
+
+      <slot />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.app {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  min-height: 100vh;
+  background: var(--bg-app);
+  color: var(--text-primary);
+}
+.main {
+  padding: 24px clamp(20px, 3vw, 36px) 40px;
+  max-width: 1680px;
+  width: 100%;
+}
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+  margin-bottom: 22px;
+}
+.page-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.lang-select {
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+.theme-toggle {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  border: 1px solid var(--border-soft);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  display: grid;
+  place-items: center;
+  transition:
+    background 150ms ease,
+    color 150ms ease;
+}
+.theme-toggle:hover {
+  color: var(--text-primary);
+  background: var(--bg-card-soft);
+}
+.theme-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+</style>

--- a/nodelite-server/web/src/lib/format.spec.ts
+++ b/nodelite-server/web/src/lib/format.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { fmtBytes, fmtLatency, fmtPercent, fmtRate, uptimeParts } from './format';
+
+describe('fmtBytes', () => {
+  it('scales by 1024 with legacy decimal rules', () => {
+    expect(fmtBytes(0)).toBe('0 B');
+    expect(fmtBytes(512)).toBe('512 B');
+    expect(fmtBytes(1024)).toBe('1.0 KB');
+    expect(fmtBytes(1536)).toBe('1.5 KB');
+    expect(fmtBytes(150 * 1024)).toBe('150 KB'); // >=100 → 0 decimals
+    expect(fmtBytes(8_000_000_000)).toBe('7.5 GB');
+  });
+
+  it('returns null for null/NaN', () => {
+    expect(fmtBytes(null)).toBeNull();
+    expect(fmtBytes(undefined)).toBeNull();
+    expect(fmtBytes(Number.NaN)).toBeNull();
+  });
+});
+
+describe('fmtRate', () => {
+  it('converts bytes/sec to bits/sec scaled by 1000', () => {
+    expect(fmtRate(0)).toBe('0 bps');
+    expect(fmtRate(10)).toBe('80 bps'); // 10 * 8 = 80 bps (i===0 → 0 decimals)
+    expect(fmtRate(125)).toBe('1.0 Kbps'); // 1000 bps → 1.0 Kbps
+    expect(fmtRate(125_000)).toBe('1.0 Mbps'); // 1,000,000 bps
+  });
+
+  it('returns null for null', () => {
+    expect(fmtRate(null)).toBeNull();
+  });
+});
+
+describe('fmtPercent', () => {
+  it('formats one decimal', () => {
+    expect(fmtPercent(63.74)).toBe('63.7%');
+    expect(fmtPercent(0)).toBe('0.0%');
+  });
+  it('returns null for null/NaN', () => {
+    expect(fmtPercent(null)).toBeNull();
+    expect(fmtPercent(Number.NaN)).toBeNull();
+  });
+});
+
+describe('fmtLatency', () => {
+  it('rounds to whole ms', () => {
+    expect(fmtLatency(8.6)).toBe('9 ms');
+    expect(fmtLatency(0)).toBe('0 ms');
+  });
+  it('returns null for null', () => {
+    expect(fmtLatency(null)).toBeNull();
+  });
+});
+
+describe('uptimeParts', () => {
+  it('breaks seconds into days/hours/minutes', () => {
+    expect(uptimeParts(0)).toEqual({ days: 0, hours: 0, minutes: 0 });
+    expect(uptimeParts(90 * 60)).toEqual({ days: 0, hours: 1, minutes: 30 });
+    expect(uptimeParts((25 * 60 + 5) * 60)).toEqual({ days: 1, hours: 1, minutes: 5 });
+  });
+  it('returns null for null/NaN', () => {
+    expect(uptimeParts(null)).toBeNull();
+    expect(uptimeParts(Number.NaN)).toBeNull();
+  });
+});

--- a/nodelite-server/web/src/lib/format.ts
+++ b/nodelite-server/web/src/lib/format.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure value formatters, ported from the legacy fmt* helpers in
+ * assets/node.html:1567-1612. i18n-free: null/NaN inputs return null so the
+ * caller can render `value ?? $t('common.not_available')`. Uptime returns a
+ * structured breakdown the caller maps to the node.uptime.* i18n keys.
+ */
+
+function scaleUnit(value: number, units: readonly string[], step: number): string {
+  let v = value;
+  let i = 0;
+  while (v >= step && i < units.length - 1) {
+    v /= step;
+    i += 1;
+  }
+  const decimals = v >= 100 || i === 0 ? 0 : 1;
+  return `${v.toFixed(decimals)} ${units[i]}`;
+}
+
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const;
+const RATE_UNITS = ['bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps'] as const;
+
+export function fmtBytes(bytes: number | null | undefined): string | null {
+  if (bytes == null || !Number.isFinite(Number(bytes))) return null;
+  return scaleUnit(Number(bytes), BYTE_UNITS, 1024);
+}
+
+/** Bytes/sec → bits/sec rate (×8), scaled by 1000 like the legacy fmtRate. */
+export function fmtRate(bytesPerSec: number | null | undefined): string | null {
+  if (bytesPerSec == null || !Number.isFinite(Number(bytesPerSec))) return null;
+  return scaleUnit(Number(bytesPerSec) * 8, RATE_UNITS, 1000);
+}
+
+export function fmtPercent(value: number | null | undefined): string | null {
+  if (value == null || !Number.isFinite(Number(value))) return null;
+  return `${Number(value).toFixed(1)}%`;
+}
+
+export function fmtLatency(value: number | null | undefined): string | null {
+  if (value == null || !Number.isFinite(Number(value))) return null;
+  return `${Math.round(Number(value))} ms`;
+}
+
+export interface UptimeParts {
+  days: number;
+  hours: number;
+  minutes: number;
+}
+
+/**
+ * Break uptime seconds into days/hours/minutes. Returns null for null/NaN.
+ * The caller picks the i18n key: days>0 → node.uptime.days_hours,
+ * hours>0 → node.uptime.hours_minutes, else node.uptime.minutes.
+ */
+export function uptimeParts(seconds: number | null | undefined): UptimeParts | null {
+  if (seconds == null || !Number.isFinite(Number(seconds))) return null;
+  const totalMinutes = Math.floor(Number(seconds) / 60);
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+  return { days, hours, minutes };
+}

--- a/nodelite-server/web/src/lib/nodeMeta.spec.ts
+++ b/nodelite-server/web/src/lib/nodeMeta.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import { ipFromNode, locationFromNode } from './nodeMeta';
+
+describe('locationFromNode', () => {
+  it('reads a loc/region/city tag', () => {
+    const node = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, tags: ['region:eu-west'] },
+    });
+    expect(locationFromNode(node)).toBe('eu-west');
+  });
+
+  it('returns null when no location tag', () => {
+    const node = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, tags: ['env:prod'] },
+    });
+    expect(locationFromNode(node)).toBeNull();
+  });
+});
+
+describe('ipFromNode', () => {
+  it('prefers an ip/addr tag', () => {
+    const node = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, tags: ['ip:10.0.0.5'] },
+      remote_ip: '203.0.113.7',
+    });
+    expect(ipFromNode(node)).toBe('10.0.0.5');
+  });
+
+  it('falls back to remote_ip', () => {
+    const node = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, tags: [] },
+      remote_ip: '203.0.113.7',
+    });
+    expect(ipFromNode(node)).toBe('203.0.113.7');
+  });
+
+  it('returns null when neither is present', () => {
+    const node = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, tags: [] },
+      remote_ip: null,
+    });
+    expect(ipFromNode(node)).toBeNull();
+  });
+});

--- a/nodelite-server/web/src/lib/nodeMeta.ts
+++ b/nodelite-server/web/src/lib/nodeMeta.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure tag parsers for node identity metadata, ported from
+ * assets/node.html:1694-1709. Nodes encode IP/location as `key:value` tags.
+ */
+
+import type { NodeStatus } from '@/api';
+
+/** Location from a `loc|location|region|city:value` tag, else null. */
+export function locationFromNode(node: NodeStatus): string | null {
+  for (const tag of node.identity.tags || []) {
+    const m = String(tag).match(/^(?:loc|location|region|city)[:=](.+)$/i);
+    if (m && m[1]) return m[1];
+  }
+  return null;
+}
+
+/** IP from an `ip|addr|address:value` tag, falling back to remote_ip. */
+export function ipFromNode(node: NodeStatus): string | null {
+  for (const tag of node.identity.tags || []) {
+    const m = String(tag).match(/^(?:ip|addr|address)[:=](.+)$/i);
+    if (m && m[1]) return m[1];
+  }
+  return node.remote_ip || null;
+}

--- a/nodelite-server/web/src/stores/nodeStatus.spec.ts
+++ b/nodelite-server/web/src/stores/nodeStatus.spec.ts
@@ -1,0 +1,90 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiAbortError, ApiError } from '@/api/client';
+import { apiClient } from '@/api';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import { useNodeStatusStore } from './nodeStatus';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, nodeStatus: vi.fn() },
+  };
+});
+
+const mockStatus = vi.mocked(apiClient.nodeStatus);
+
+describe('useNodeStatusStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockStatus.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads the node status for an id', async () => {
+    const status = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, node_id: 'a' },
+    });
+    mockStatus.mockResolvedValueOnce(status);
+    const store = useNodeStatusStore();
+
+    await store.load('a');
+    expect(mockStatus).toHaveBeenCalledWith('a');
+    expect(store.data).toEqual(status);
+    expect(store.nodeId).toBe('a');
+  });
+
+  it('clears stale data when switching to a different node', async () => {
+    mockStatus.mockResolvedValueOnce(makeNodeStatus());
+    const store = useNodeStatusStore();
+    await store.load('a');
+    expect(store.data).not.toBeNull();
+
+    // Switch to b: data should clear immediately, before the fetch resolves.
+    let resolve: (v: ReturnType<typeof makeNodeStatus>) => void = () => {};
+    mockStatus.mockReturnValueOnce(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    const pending = store.load('b');
+    expect(store.nodeId).toBe('b');
+    expect(store.data).toBeNull();
+    resolve(makeNodeStatus());
+    await pending;
+  });
+
+  it('refresh re-fetches the current node', async () => {
+    mockStatus.mockResolvedValue(makeNodeStatus());
+    const store = useNodeStatusStore();
+    await store.load('a');
+    await store.refresh();
+    expect(mockStatus).toHaveBeenCalledTimes(2);
+    expect(mockStatus).toHaveBeenLastCalledWith('a');
+  });
+
+  it('refresh is a no-op when no node is active', async () => {
+    const store = useNodeStatusStore();
+    await store.refresh();
+    expect(mockStatus).not.toHaveBeenCalled();
+  });
+
+  it('records non-abort errors', async () => {
+    mockStatus.mockRejectedValueOnce(new ApiError(404, 'node not found'));
+    const store = useNodeStatusStore();
+    await store.load('missing');
+    expect(store.error).toBeInstanceOf(ApiError);
+    expect(store.data).toBeNull();
+  });
+
+  it('swallows ApiAbortError silently', async () => {
+    mockStatus.mockRejectedValueOnce(new ApiAbortError('redirect'));
+    const store = useNodeStatusStore();
+    await store.load('a');
+    expect(store.error).toBeNull();
+  });
+});

--- a/nodelite-server/web/src/stores/nodeStatus.spec.ts
+++ b/nodelite-server/web/src/stores/nodeStatus.spec.ts
@@ -87,4 +87,58 @@ describe('useNodeStatusStore', () => {
     await store.load('a');
     expect(store.error).toBeNull();
   });
+
+  it('fetches the new node when switched while a request is in flight', async () => {
+    // a is still pending when we navigate to b. The id-aware guard must NOT
+    // swallow b's fetch (the bug: a plain loading guard left data null until
+    // the next poll).
+    const statusA = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, node_id: 'a' },
+    });
+    const statusB = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, node_id: 'b' },
+    });
+    let resolveA: (v: ReturnType<typeof makeNodeStatus>) => void = () => {};
+    mockStatus
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveA = r;
+        }),
+      )
+      .mockResolvedValueOnce(statusB);
+
+    const store = useNodeStatusStore();
+    const loadA = store.load('a'); // in flight
+    const loadB = store.load('b'); // must still fetch b
+
+    expect(mockStatus).toHaveBeenCalledTimes(2);
+    expect(mockStatus).toHaveBeenLastCalledWith('b');
+
+    await loadB;
+    expect(store.nodeId).toBe('b');
+    expect(store.data?.identity.node_id).toBe('b');
+
+    // a's late response is discarded (we're on b now).
+    resolveA(statusA);
+    await loadA;
+    expect(store.data?.identity.node_id).toBe('b');
+  });
+
+  it('dedups concurrent fetches for the same node', async () => {
+    let resolve: (v: ReturnType<typeof makeNodeStatus>) => void = () => {};
+    mockStatus.mockReturnValueOnce(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    const store = useNodeStatusStore();
+
+    const first = store.load('a');
+    const second = store.load('a'); // same id, in flight → no second request
+    expect(mockStatus).toHaveBeenCalledTimes(1);
+
+    resolve(makeNodeStatus());
+    await Promise.all([first, second]);
+    expect(mockStatus).toHaveBeenCalledTimes(1);
+  });
 });

--- a/nodelite-server/web/src/stores/nodeStatus.ts
+++ b/nodelite-server/web/src/stores/nodeStatus.ts
@@ -1,0 +1,51 @@
+import { defineStore } from 'pinia';
+import { ref, shallowRef } from 'vue';
+import { apiClient, type NodeStatus } from '@/api';
+import { ApiAbortError } from '@/api/client';
+
+/**
+ * Active node's full status (GET /api/nodes/{id}). Single active node — the
+ * NodeDetail view drives load(id) on mount and refresh(id) on each poll.
+ * If the id changes (navigating between nodes), data is cleared so a stale
+ * node's snapshot never flashes under the new id.
+ */
+export const useNodeStatusStore = defineStore('nodeStatus', () => {
+  const nodeId = ref<string | null>(null);
+  const data = shallowRef<NodeStatus | null>(null);
+  const loading = ref(false);
+  const error = ref<Error | null>(null);
+
+  async function fetchFor(id: string): Promise<void> {
+    if (loading.value) return;
+    loading.value = true;
+    error.value = null;
+    try {
+      const result = await apiClient.nodeStatus(id);
+      // Guard against a late response for a node we've since navigated away from.
+      if (nodeId.value === id) data.value = result;
+    } catch (e) {
+      if (e instanceof ApiAbortError) return;
+      error.value = e instanceof Error ? e : new Error(String(e));
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /** Switch to a node: clears stale data if the id changed, then fetches. */
+  async function load(id: string): Promise<void> {
+    if (nodeId.value !== id) {
+      nodeId.value = id;
+      data.value = null;
+      error.value = null;
+    }
+    await fetchFor(id);
+  }
+
+  /** Re-fetch the current node (polling). No-op if no node is active. */
+  async function refresh(): Promise<void> {
+    if (nodeId.value === null) return;
+    await fetchFor(nodeId.value);
+  }
+
+  return { nodeId, data, loading, error, load, refresh };
+});

--- a/nodelite-server/web/src/stores/nodeStatus.ts
+++ b/nodelite-server/web/src/stores/nodeStatus.ts
@@ -14,20 +14,34 @@ export const useNodeStatusStore = defineStore('nodeStatus', () => {
   const data = shallowRef<NodeStatus | null>(null);
   const loading = ref(false);
   const error = ref<Error | null>(null);
+  // Id of the request currently in flight, for same-id dedup. Must be
+  // id-aware: a plain `loading` guard would swallow a node *switch* whose
+  // fetch arrives while a previous node's request is still pending.
+  const inFlightId = ref<string | null>(null);
 
   async function fetchFor(id: string): Promise<void> {
-    if (loading.value) return;
+    // Dedup only same-node concurrent fetches (polling). A different id
+    // (node switch) must always fetch, even with a request in flight.
+    if (inFlightId.value === id) return;
+    inFlightId.value = id;
     loading.value = true;
     error.value = null;
     try {
       const result = await apiClient.nodeStatus(id);
-      // Guard against a late response for a node we've since navigated away from.
+      // Discard a late response for a node we've since navigated away from.
       if (nodeId.value === id) data.value = result;
     } catch (e) {
       if (e instanceof ApiAbortError) return;
-      error.value = e instanceof Error ? e : new Error(String(e));
+      if (nodeId.value === id) {
+        error.value = e instanceof Error ? e : new Error(String(e));
+      }
     } finally {
-      loading.value = false;
+      // Only clear if we're still the latest in-flight request (a newer
+      // switch may have taken over inFlightId/loading).
+      if (inFlightId.value === id) {
+        inFlightId.value = null;
+        loading.value = false;
+      }
     }
   }
 

--- a/nodelite-server/web/src/views/DashboardView.vue
+++ b/nodelite-server/web/src/views/DashboardView.vue
@@ -1,19 +1,13 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue';
-import SidebarNav from '@/components/SidebarNav.vue';
+import AppLayout from '@/components/AppLayout.vue';
 import OverviewStats from '@/components/OverviewStats.vue';
 import NodeMap from '@/components/NodeMap.vue';
 import NodeList from '@/components/NodeList.vue';
-import { useTheme } from '@/composables/useTheme';
 import { usePolling } from '@/composables/usePolling';
-import { useLanguage } from '@/i18n/language';
-import { SUPPORTED_LOCALES, type SupportedLocale } from '@/i18n';
 import { useBootstrapStore } from '@/stores/bootstrap';
 import { useOverviewStore } from '@/stores/overview';
 import { useNodesStore } from '@/stores/nodes';
-
-const { theme, toggleTheme } = useTheme();
-const { currentLocale, setLocale } = useLanguage();
 
 const bootstrapStore = useBootstrapStore();
 const overviewStore = useOverviewStore();
@@ -34,155 +28,38 @@ usePolling(() => {
   void overviewStore.refresh();
   void nodesStore.refresh();
 }, DEFAULT_REFRESH_MS);
-
-function onLanguageChange(event: Event): void {
-  setLocale((event.target as HTMLSelectElement).value);
-}
-
-const localeLabels: Record<SupportedLocale, string> = {
-  en: 'English',
-  'zh-CN': '中文',
-};
 </script>
 
 <template>
-  <div class="app" data-test="app-shell">
-    <SidebarNav />
+  <AppLayout>
+    <template #title>
+      <h1 class="dash-title">{{ $t('index.heading') }}</h1>
+      <p class="dash-subtitle">{{ $t('index.subtitle', { count: onlineCount }) }}</p>
+    </template>
 
-    <main class="main" data-test="dashboard-view">
-      <header class="page-header">
-        <div class="page-title">
-          <h1>{{ $t('index.heading') }}</h1>
-          <p>{{ $t('index.subtitle', { count: onlineCount }) }}</p>
-        </div>
-        <div class="page-actions">
-          <select
-            class="lang-select"
-            :aria-label="$t('common.language')"
-            data-test="language-select"
-            :value="currentLocale"
-            @change="onLanguageChange"
-          >
-            <option v-for="locale in SUPPORTED_LOCALES" :key="locale" :value="locale">
-              {{ localeLabels[locale] }}
-            </option>
-          </select>
-          <button
-            type="button"
-            class="theme-toggle"
-            :title="$t('common.theme_toggle')"
-            :aria-label="$t('common.theme_toggle')"
-            data-test="theme-toggle"
-            @click="toggleTheme"
-          >
-            <svg
-              v-if="theme === 'dark'"
-              class="sun"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <circle cx="12" cy="12" r="4" />
-              <path
-                d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
-              />
-            </svg>
-            <svg
-              v-else
-              class="moon"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-            </svg>
-          </button>
-        </div>
-      </header>
-
-      <section class="overview">
-        <NodeMap />
-        <OverviewStats />
-        <NodeList />
-      </section>
-    </main>
-  </div>
+    <section class="overview" data-test="dashboard-view">
+      <NodeMap />
+      <OverviewStats />
+      <NodeList />
+    </section>
+  </AppLayout>
 </template>
 
 <style scoped>
-.app {
-  display: grid;
-  grid-template-columns: 72px minmax(0, 1fr);
-  min-height: 100vh;
-  background: var(--bg-app);
-  color: var(--text-primary);
-}
-.main {
-  padding: 24px clamp(20px, 3vw, 36px) 40px;
-  max-width: 1680px;
-  width: 100%;
-}
-.page-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 24px;
-  margin-bottom: 22px;
-}
-.page-title h1 {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-.page-title p {
-  margin: 4px 0 0;
-  color: var(--text-muted);
-  font-size: 13px;
-}
 .overview {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
-.page-actions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+.dash-title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
-.lang-select {
-  background: var(--bg-card);
-  color: var(--text-secondary);
-  border: 1px solid var(--border-soft);
-  border-radius: 10px;
-  padding: 6px 10px;
-  font-size: 12px;
-}
-.theme-toggle {
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
-  border: 1px solid var(--border-soft);
-  background: var(--bg-card);
-  color: var(--text-secondary);
-  display: grid;
-  place-items: center;
-  transition:
-    background 150ms ease,
-    color 150ms ease;
-}
-.theme-toggle:hover {
-  color: var(--text-primary);
-  background: var(--bg-card-soft);
-}
-.theme-toggle svg {
-  width: 18px;
-  height: 18px;
+.dash-subtitle {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
 }
 </style>

--- a/nodelite-server/web/src/views/NodeDetailView.spec.ts
+++ b/nodelite-server/web/src/views/NodeDetailView.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+import { createApp, defineComponent, h } from 'vue';
+
+import NodeDetailView from './NodeDetailView.vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { apiClient } from '@/api';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, nodeStatus: vi.fn() },
+  };
+});
+
+const mockStatus = vi.mocked(apiClient.nodeStatus);
+
+const FAKE_DICT = {
+  en: {
+    'node.tabs.overview': 'Overview',
+    'node.tabs.monitor': 'Monitor',
+    'node.tabs.network': 'Network',
+    'node.tabs.hardware': 'Hardware',
+    'node.tabs.logs': 'Logs',
+    'node.tabs.settings': 'Settings',
+    'node.meta.ip': 'IP: {ip}',
+    'node.meta.uptime_days': 'Up {days}d',
+    'node.meta.uptime_hours': 'Up {hours}h',
+    'common.online': 'Online',
+    'common.offline': 'Offline',
+    'common.latency_warn': 'High latency',
+    'common.language': 'Language',
+    'common.theme_toggle': 'Toggle theme',
+    'index.nav.overview': 'Overview',
+    'index.nav.settings': 'Settings',
+    'index.nav.alerts': 'Alerts',
+    'index.nav.account': 'Account',
+  },
+  'zh-CN': { 'common.online': '在线' },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'dashboard', component: Stub },
+      { path: '/nodes/:id', name: 'node-detail', component: NodeDetailView },
+    ],
+  });
+}
+
+async function mountDetail(id = 'srv-1') {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const router = makeRouter();
+  await router.push(`/nodes/${id}`);
+  await router.isReady();
+  const wrapper = mount(NodeDetailView, {
+    global: { plugins: [pinia, router, getI18n()] },
+  });
+  await flushPromises();
+  return { wrapper, router };
+}
+
+describe('NodeDetailView', () => {
+  beforeEach(async () => {
+    window.localStorage.clear();
+    __resetI18nForTest();
+    mockStatus.mockResolvedValue(
+      makeNodeStatus({
+        identity: { ...makeNodeStatus().identity, node_id: 'srv-1', node_label: 'Server One', tags: ['ip:10.0.0.9', 'region:eu'] },
+        online: true,
+        latency_ms: 12,
+      }),
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('loads the node status for the route id', async () => {
+    await mountDetail('srv-1');
+    expect(mockStatus).toHaveBeenCalledWith('srv-1');
+  });
+
+  it('renders the identity header from the loaded status', async () => {
+    const { wrapper } = await mountDetail('srv-1');
+    expect(wrapper.find('[data-test="node-detail-view"]').text()).toContain('Server One');
+    expect(wrapper.find('[data-test="node-status-badge"]').classes()).toContain('online');
+    expect(wrapper.find('[data-test="node-meta"]').text()).toContain('IP: 10.0.0.9');
+    expect(wrapper.find('[data-test="node-meta"]').text()).toContain('eu');
+  });
+
+  it('renders the five tabs with settings disabled', async () => {
+    const { wrapper } = await mountDetail();
+    for (const tab of ['overview', 'monitor', 'network', 'hardware', 'logs']) {
+      expect(wrapper.find(`[data-test="tab-${tab}"]`).exists()).toBe(true);
+    }
+    expect(wrapper.find('[data-test="tab-settings"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('defaults to the overview tab and switches via the URL hash', async () => {
+    const { wrapper } = await mountDetail();
+    expect(wrapper.find('[data-test="node-tab-pane"]').attributes('data-pane')).toBe('overview');
+    expect(wrapper.find('[data-test="tab-overview"]').classes()).toContain('active');
+
+    await wrapper.find('[data-test="tab-monitor"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="node-tab-pane"]').attributes('data-pane')).toBe('monitor');
+    expect(wrapper.find('[data-test="tab-monitor"]').classes()).toContain('active');
+  });
+});

--- a/nodelite-server/web/src/views/NodeDetailView.vue
+++ b/nodelite-server/web/src/views/NodeDetailView.vue
@@ -1,19 +1,201 @@
 <script setup lang="ts">
-import { useRoute } from 'vue-router';
+import { computed, onMounted, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import AppLayout from '@/components/AppLayout.vue';
+import { usePolling } from '@/composables/usePolling';
+import { nodeStatusKey } from '@/lib/map/projection';
+import { ipFromNode, locationFromNode } from '@/lib/nodeMeta';
+import { uptimeParts } from '@/lib/format';
+import { useNodeStatusStore } from '@/stores/nodeStatus';
+
+const NODE_DETAIL_REFRESH_MS = 5000;
+
+// Tabs the shell renders. `settings` is deferred (Stage 2.5) and rendered
+// disabled, mirroring the dashboard sidebar pattern.
+const TABS = ['overview', 'monitor', 'network', 'hardware', 'logs'] as const;
+type TabId = (typeof TABS)[number];
+
+function isTabId(value: string): value is TabId {
+  return (TABS as readonly string[]).includes(value);
+}
 
 const route = useRoute();
+const router = useRouter();
+const store = useNodeStatusStore();
+
+const nodeId = computed(() => String(route.params.id ?? ''));
+const node = computed(() => store.data);
+
+// Active tab is driven by the URL hash (e.g. /nodes/x#monitor), matching the
+// legacy hash sync; falls back to overview.
+const activeTab = computed<TabId>(() => {
+  const hash = route.hash.replace(/^#/, '');
+  return isTabId(hash) ? hash : 'overview';
+});
+
+function selectTab(tab: TabId): void {
+  void router.replace({ hash: `#${tab}` });
+}
+
+const status = computed(() => (node.value ? nodeStatusKey(node.value) : 'offline'));
+const statusLabelKey = computed(() => {
+  switch (status.value) {
+    case 'offline':
+      return 'common.offline';
+    case 'latency':
+      return 'common.latency_warn';
+    default:
+      return 'common.online';
+  }
+});
+
+const title = computed(
+  () => node.value?.identity.node_label || node.value?.identity.node_id || nodeId.value,
+);
+const ip = computed(() => (node.value ? ipFromNode(node.value) : null));
+const location = computed(() => (node.value ? locationFromNode(node.value) : null));
+const uptime = computed(() => uptimeParts(node.value?.snapshot?.uptime_secs));
+
+onMounted(() => {
+  void store.load(nodeId.value);
+});
+
+// Navigating between nodes (same component, new :id) reloads.
+watch(nodeId, (id) => {
+  if (id) void store.load(id);
+});
+
+usePolling(() => store.refresh(), NODE_DETAIL_REFRESH_MS);
 </script>
 
 <template>
-  <section class="view view--node" data-test="node-detail-view">
-    <h1>Node: {{ route.params.id }}</h1>
-    <p>Stage 3 will replace this placeholder with the full detail view.</p>
-  </section>
+  <AppLayout>
+    <template #title>
+      <div class="node-title" data-test="node-detail-view">
+        <h1 class="node-title__name">{{ title }}</h1>
+        <span class="badge" :class="status" data-test="node-status-badge">
+          {{ $t(statusLabelKey) }}
+        </span>
+        <div class="node-title__meta" data-test="node-meta">
+          <span v-if="ip">{{ $t('node.meta.ip', { ip }) }}</span>
+          <span v-if="location">{{ location }}</span>
+          <span v-if="uptime && uptime.days > 0">{{ $t('node.meta.uptime_days', { days: uptime.days }) }}</span>
+          <span v-else-if="uptime">{{ $t('node.meta.uptime_hours', { hours: uptime.hours }) }}</span>
+        </div>
+      </div>
+    </template>
+
+    <div class="node-detail">
+      <nav class="tabs" data-test="node-tabs">
+        <button
+          v-for="tab in TABS"
+          :key="tab"
+          type="button"
+          class="tab-button"
+          :class="{ active: activeTab === tab }"
+          :data-test="`tab-${tab}`"
+          @click="selectTab(tab)"
+        >
+          {{ $t(`node.tabs.${tab}`) }}
+        </button>
+        <button
+          type="button"
+          class="tab-button"
+          disabled
+          :title="`${$t('node.tabs.settings')} (Stage 2.5)`"
+          data-test="tab-settings"
+        >
+          {{ $t('node.tabs.settings') }}
+        </button>
+      </nav>
+
+      <section class="tab-pane" :data-pane="activeTab" data-test="node-tab-pane">
+        <p class="placeholder">{{ activeTab }} — coming in Stage 3c/3d</p>
+      </section>
+    </div>
+  </AppLayout>
 </template>
 
 <style scoped>
-.view--node {
-  padding: 24px;
-  color: var(--text-primary);
+.node-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.node-title__name {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.node-title__meta {
+  display: flex;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+  width: 100%;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--bg-card-soft);
+  color: var(--text-muted);
+}
+.badge::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.badge.online {
+  color: var(--accent-green);
+  background: var(--accent-green-soft);
+}
+.badge.latency {
+  color: var(--accent-yellow);
+  background: var(--accent-yellow-soft);
+}
+.badge.offline {
+  color: var(--accent-red);
+  background: var(--accent-red-soft);
+}
+.tabs {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--border-soft);
+  margin-bottom: 18px;
+}
+.tab-button {
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 500;
+}
+.tab-button:hover:not([disabled]) {
+  color: var(--text-secondary);
+}
+.tab-button.active {
+  color: var(--accent-blue);
+  border-bottom-color: var(--accent-blue);
+}
+.tab-button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.placeholder {
+  color: var(--text-muted);
+  font-size: 13px;
 }
 </style>


### PR DESCRIPTION
## Summary

First of four Stage 3 PRs porting the legacy node-detail page (`node.html`, 3,122 lines) to `/nodes/:id`. This PR is the foundation: the shared layout, API types, the node-status store, and the NodeDetail shell (identity header + tab routing with placeholder panes). 5 commits, squash on merge.

### What's in

- **`lib/format.ts`** — pure `fmtBytes`/`fmtRate`/`fmtPercent`/`fmtLatency`/`uptimeParts` (ported from `node.html:1567-1612`), i18n-free (null → null; uptime returns a parts breakdown). Reused across 3c/3d. 10 tests.
- **API types + wrappers** — `NodeStatus` (full identity/snapshot/disks/network/load), `AgentLogEntry`, `HistoryQuery` start/end range in `api/types.ts`; `apiClient.nodeStatus(id)` (replaces the unused, mistyped `getNode`), `nodeLogs(id, limit)`, and `nodeHistory` start/end forwarding. Fixtures `makeNodeStatus`/`makeLogEntry`.
- **`useNodeStatusStore`** — `load(id)`/`refresh()` over `GET /api/nodes/{id}`; switching ids clears stale data immediately and discards late responses for navigated-away nodes. 6 tests.
- **`AppLayout.vue`** — extracts the chrome from DashboardView: sidebar + header with a `#title` slot + global theme/language controls + body slot. **DashboardView refactored to use it** (this resolves the shared-layout item from the Stage 2a review). `data-test="app-shell"` lives on AppLayout's root, so the Playwright `waitForAppShell` stays valid. Theme/lang coverage moved to `AppLayout.spec`.
- **`NodeDetailView.vue`** — real shell via AppLayout: identity header (label + status badge + IP/location/uptime meta), tab nav (overview/monitor/network/hardware/logs; **settings disabled**, deferred to Stage 2.5), placeholder panes. Active tab from the URL hash (mirrors legacy), loads status on mount, reloads on `:id` change, polls every 5s.
- **`lib/nodeMeta.ts`** — pure `ipFromNode`/`locationFromNode` tag parsers + tests.

### Notes

- **Charts are SVG, not Canvas** (confirmed by exploring `node.html` — zero `getContext`/`<canvas>`/DPR). The chart engine (PR 3b) will extract pure SVG-model builders, not ctx-mutating functions. The migration doc §3's "Canvas" wording is wrong; it'll get a docs-pass correction, not a code change here.
- **AppLayout refactor touches Stage 2 code** (DashboardView + spec); behavior is identical — all existing tests stay green.

## Test plan

- [x] `pnpm lint` / `typecheck` / `test` (148 tests, 26 files) / `build` — all clean
- [ ] Manual smoke (`cargo run` + `pnpm dev`): click a node card → `/nodes/:id` shows identity header + tabs; tab clicks update the URL hash + active pane; status refreshes every 5s; dashboard still looks/behaves identical after the AppLayout extraction

## Next (Stage 3)

- **3b** — chart engine (pure SVG model lib + MetricChart + useChart with linked hover)
- **3c** — overview/network/hardware tabs
- **3d** — monitor (brush + zoom) + logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)