### PR TITLE
Stage 3b — Chart engine (pure SVG model + MetricChart + linked hover)

### DIFF
--- a/nodelite-server/web/src/components/MetricChart.spec.ts
+++ b/nodelite-server/web/src/components/MetricChart.spec.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import type { ChartPoint } from '@/lib/chart/chartData';
+import MetricChart from './MetricChart.vue';
+
+const FAKE_DICT = {
+  en: { 'node.waiting_history': 'Waiting for enough history samples…' },
+  'zh-CN': { 'node.waiting_history': '等待足够的历史样本…' },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function pts(values: Array<number | null>): ChartPoint[] {
+  return values.map((value, i) => ({ ts: i * 60_000, value }));
+}
+
+function mountChart(props: Record<string, unknown>) {
+  return mount(MetricChart, { props, global: { plugins: [getI18n()] } });
+}
+
+describe('MetricChart', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the empty placeholder when there are no numeric points', () => {
+    const wrapper = mountChart({ points: pts([null, null]), valueKind: 'percent' });
+    expect(wrapper.find('[data-test="metric-chart-empty"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="metric-chart-svg"]').exists()).toBe(false);
+  });
+
+  it('renders an area chart: svg with a line + area path + grid labels', () => {
+    const wrapper = mountChart({
+      points: pts([10, 50, 90]),
+      valueKind: 'percent',
+      color: 'var(--chart-cpu)',
+      label: 'CPU',
+    });
+    expect(wrapper.find('[data-test="metric-chart-svg"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="metric-chart-line"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="metric-chart-area"]').exists()).toBe(true);
+    expect(wrapper.findAll('text').length).toBeGreaterThan(0);
+  });
+
+  it('renders a multi-series chart with a line per series and no area', () => {
+    const wrapper = mountChart({
+      series: [
+        { label: 'down', color: 'var(--chart-network-down)', points: pts([100, 200, 300]) },
+        { label: 'up', color: 'var(--chart-network-up)', points: pts([10, 20, 30]) },
+      ],
+      valueKind: 'rate',
+    });
+    expect(wrapper.findAll('[data-test="metric-chart-line"]')).toHaveLength(2);
+    expect(wrapper.find('[data-test="metric-chart-area"]').exists()).toBe(false);
+  });
+});

--- a/nodelite-server/web/src/components/MetricChart.vue
+++ b/nodelite-server/web/src/components/MetricChart.vue
@@ -1,0 +1,246 @@
+<script setup lang="ts">
+import { computed, ref, useId } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { ChartPoint } from '@/lib/chart/chartData';
+import type { ChartValueKind } from '@/lib/chart/format';
+import {
+  buildAreaChart,
+  buildMultiAreaChart,
+  type MultiSeriesInput,
+} from '@/lib/chart/svgModel';
+import { useChart } from '@/composables/useChart';
+
+/*
+ * points/series/minValue/maxValue are intentionally default-less: `undefined`
+ * is the meaningful "not provided" (series presence selects area vs multi
+ * mode; a min/max default would distort auto-scaling). An array factory
+ * default would also break withDefaults' typing here.
+ */
+/* eslint-disable vue/require-default-prop */
+const props = withDefaults(
+  defineProps<{
+    /** Single-series area chart points (the default variant). */
+    points?: ChartPoint[];
+    /** Multi-series lines (network down/up). Takes precedence over points. */
+    series?: MultiSeriesInput[];
+    valueKind?: ChartValueKind;
+    color?: string;
+    label?: string;
+    clipSpikes?: boolean;
+    minValue?: number;
+    maxValue?: number;
+    height?: number;
+  }>(),
+  {
+    valueKind: 'number',
+    color: 'var(--accent-blue)',
+    label: '',
+    clipSpikes: false,
+    height: 180,
+  },
+);
+/* eslint-enable vue/require-default-prop */
+
+const { locale, t } = useI18n();
+const containerRef = ref<HTMLElement | null>(null);
+const gradId = `metric-grad-${useId()}`;
+
+const isMulti = computed(() => Array.isArray(props.series));
+
+const { model, hover, onPointerMove, onPointerLeave } = useChart(
+  containerRef,
+  ({ width, height }) => {
+    const base = {
+      width,
+      height,
+      valueKind: props.valueKind,
+      clipSpikes: props.clipSpikes,
+      ...(props.minValue !== undefined ? { minValue: props.minValue } : {}),
+      ...(props.maxValue !== undefined ? { maxValue: props.maxValue } : {}),
+    };
+    if (props.series) {
+      return buildMultiAreaChart(props.series, base);
+    }
+    return buildAreaChart(props.points ?? [], {
+      ...base,
+      color: props.color,
+      label: props.label,
+    });
+  },
+  {
+    fallbackHeight: props.height,
+    formatTime: (ts) => new Date(ts).toLocaleString(locale.value),
+  },
+);
+</script>
+
+<template>
+  <div
+    ref="containerRef"
+    class="metric-chart"
+    :style="{ minHeight: `${height}px` }"
+    data-test="metric-chart"
+    @pointermove="onPointerMove"
+    @pointerleave="onPointerLeave"
+  >
+    <div v-if="model.empty" class="metric-chart__empty" data-test="metric-chart-empty">
+      {{ t('node.waiting_history') }}
+    </div>
+
+    <template v-else>
+      <svg
+        :viewBox="`0 0 ${model.width} ${model.height}`"
+        preserveAspectRatio="xMinYMin meet"
+        class="metric-chart__svg"
+        aria-hidden="true"
+        data-test="metric-chart-svg"
+      >
+        <defs v-if="!isMulti">
+          <linearGradient :id="gradId" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" :stop-color="color" stop-opacity="0.32" />
+            <stop offset="100%" :stop-color="color" stop-opacity="0" />
+          </linearGradient>
+        </defs>
+
+        <g class="metric-chart__grid">
+          <template v-for="(g, i) in model.grid" :key="i">
+            <line
+              :x1="model.padLeft"
+              :x2="model.width - model.padRight"
+              :y1="g.y"
+              :y2="g.y"
+              stroke="currentColor"
+              stroke-opacity="0.09"
+              stroke-width="1"
+            />
+            <text
+              :x="model.padLeft - 8"
+              :y="g.y + 3"
+              text-anchor="end"
+              fill="currentColor"
+              opacity="0.64"
+              font-size="11"
+            >
+              {{ g.label }}
+            </text>
+          </template>
+        </g>
+
+        <template v-for="(s, i) in model.series" :key="i">
+          <path
+            v-if="s.area"
+            :d="s.area"
+            :fill="`url(#${gradId})`"
+            data-test="metric-chart-area"
+          />
+          <line
+            v-if="s.avgY !== null"
+            :x1="model.padLeft"
+            :x2="model.width - model.padRight"
+            :y1="s.avgY"
+            :y2="s.avgY"
+            :stroke="s.color"
+            :stroke-opacity="s.avgOpacity"
+            stroke-width="1.2"
+            stroke-dasharray="6 5"
+          />
+          <path
+            :d="s.line"
+            fill="none"
+            :stroke="s.color"
+            stroke-width="1.45"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            vector-effect="non-scaling-stroke"
+            data-test="metric-chart-line"
+          />
+        </template>
+
+        <g v-if="hover" class="metric-chart__hover">
+          <line
+            :x1="hover.lineX"
+            :x2="hover.lineX"
+            :y1="hover.lineY1"
+            :y2="hover.lineY2"
+            stroke="currentColor"
+            stroke-opacity="0.46"
+            stroke-width="1"
+          />
+          <circle
+            v-for="(c, i) in hover.circles"
+            :key="i"
+            :cx="c.cx"
+            :cy="c.cy"
+            r="4"
+            stroke-width="2"
+            :stroke="c.color"
+            fill="var(--bg-card)"
+          />
+        </g>
+      </svg>
+
+      <div
+        v-if="hover"
+        class="chart-tooltip"
+        data-test="metric-chart-tooltip"
+        :style="{ left: `${hover.tooltip.left}px`, top: `${hover.tooltip.top}px`, transform: hover.tooltip.transform }"
+      >
+        <div class="chart-tooltip__time">{{ hover.tooltip.time }}</div>
+        <div v-for="(row, i) in hover.tooltip.rows" :key="i" class="chart-tooltip__row">
+          <span>
+            <span class="chart-tooltip__swatch" :style="{ background: row.color }" />
+            {{ row.label }}
+          </span>
+          <strong>{{ row.value }}</strong>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.metric-chart {
+  position: relative;
+  width: 100%;
+  color: var(--text-muted);
+}
+.metric-chart__svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.metric-chart__empty {
+  padding: 20px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.chart-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  min-width: 120px;
+  z-index: 5;
+  color: var(--text-primary);
+}
+.chart-tooltip__time {
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+.chart-tooltip__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.chart-tooltip__swatch {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  margin-right: 4px;
+}
+</style>

--- a/nodelite-server/web/src/composables/useChart.spec.ts
+++ b/nodelite-server/web/src/composables/useChart.spec.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, ref } from 'vue';
+import type { ChartPoint } from '@/lib/chart/chartData';
+import { buildAreaChart } from '@/lib/chart/svgModel';
+import { useChart } from './useChart';
+
+function pts(values: number[]): ChartPoint[] {
+  return values.map((value, i) => ({ ts: i * 60_000, value }));
+}
+
+const Host = defineComponent({
+  setup() {
+    const containerRef = ref<HTMLElement | null>(null);
+    const chart = useChart(
+      containerRef,
+      ({ width, height }) =>
+        buildAreaChart(pts([10, 50, 90]), {
+          width,
+          height,
+          valueKind: 'percent',
+          color: 'var(--chart-cpu)',
+          label: 'CPU',
+        }),
+      { fallbackHeight: 200, formatTime: (ts) => `@${ts}` },
+    );
+    return { containerRef, ...chart };
+  },
+  render() {
+    return h('div', { ref: 'containerRef' });
+  },
+});
+
+describe('useChart (standalone hover wiring)', () => {
+  beforeEach(() => {
+    // jsdom returns a zero rect; pretend the chart is 600x200 on screen.
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 600,
+      height: 200,
+      left: 0,
+      top: 0,
+      right: 600,
+      bottom: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds a model sized from the measured container', () => {
+    const wrapper = mount(Host);
+    expect(wrapper.vm.model.width).toBe(600);
+    expect(wrapper.vm.model.height).toBe(200);
+    expect(wrapper.vm.model.empty).toBe(false);
+  });
+
+  it('sets hover on pointer move and clears it on leave', async () => {
+    const wrapper = mount(Host);
+    expect(wrapper.vm.hover).toBeNull();
+
+    wrapper.vm.onPointerMove({ clientX: 300 } as PointerEvent);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.hover).not.toBeNull();
+    expect(wrapper.vm.hover!.tooltip.rows[0]!.label).toBe('CPU');
+
+    wrapper.vm.onPointerLeave();
+    expect(wrapper.vm.hover).toBeNull();
+  });
+});

--- a/nodelite-server/web/src/composables/useChart.ts
+++ b/nodelite-server/web/src/composables/useChart.ts
@@ -1,0 +1,112 @@
+import { computed, onBeforeUnmount, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue';
+import { computeHover, nearestByKey, type HoverModel } from '@/lib/chart/hover';
+import type { ChartModel } from '@/lib/chart/svgModel';
+import { useChartHoverGroup } from './useChartHoverGroup';
+
+export interface UseChartOptions {
+  fallbackWidth?: number;
+  fallbackHeight: number;
+  formatTime: (ts: number) => string;
+}
+
+export interface UseChartReturn {
+  model: ComputedRef<ChartModel>;
+  hover: Ref<HoverModel | null>;
+  onPointerMove: (event: PointerEvent) => void;
+  onPointerLeave: () => void;
+}
+
+/**
+ * Wires a chart's reactive size + hover to the pure builders. Owns width/
+ * height (ResizeObserver, so the legacy no-observer gap is closed) and feeds
+ * them to `buildModel`. Hover: a standalone chart resolves by mouse-x; a
+ * grouped chart publishes the anchor ts to the shared group and every member
+ * (incl. the source) renders its crosshair by ts (linked hover).
+ */
+export function useChart(
+  containerRef: Ref<HTMLElement | null>,
+  buildModel: (size: { width: number; height: number }) => ChartModel,
+  opts: UseChartOptions,
+): UseChartReturn {
+  const width = ref(opts.fallbackWidth ?? 600);
+  const height = ref(opts.fallbackHeight);
+  const model = computed(() => buildModel({ width: width.value, height: height.value }));
+  const hover = ref<HoverModel | null>(null);
+  const group = useChartHoverGroup();
+
+  let observer: ResizeObserver | null = null;
+
+  function measure(): void {
+    const el = containerRef.value;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    if (rect.width > 0) width.value = Math.round(rect.width);
+    if (rect.height > 0) height.value = Math.round(rect.height);
+  }
+
+  onMounted(() => {
+    measure();
+    if (typeof ResizeObserver !== 'undefined' && containerRef.value) {
+      observer = new ResizeObserver(() => measure());
+      observer.observe(containerRef.value);
+    }
+  });
+
+  onBeforeUnmount(() => {
+    observer?.disconnect();
+    observer = null;
+    if (group) group.set(null);
+  });
+
+  function renderByTs(ts: number | null): void {
+    if (ts == null) {
+      hover.value = null;
+      return;
+    }
+    const el = containerRef.value;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    hover.value = computeHover(model.value, ts, 'ts', rect, opts.formatTime);
+  }
+
+  if (group) {
+    watch(group.activeTs, (ts) => renderByTs(ts));
+  }
+
+  function onPointerMove(event: PointerEvent): void {
+    const el = containerRef.value;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    if (rect.width <= 0) return;
+    const viewX = Math.min(
+      model.value.width,
+      Math.max(0, ((event.clientX - rect.left) / rect.width) * model.value.width),
+    );
+    if (group) {
+      // Find the anchor ts under the cursor and broadcast; the watch above
+      // (on every member, incl. this one) renders the crosshair by ts.
+      let anchorTs: number | null = null;
+      for (const series of model.value.series) {
+        const p = nearestByKey(series.points, viewX, 'x');
+        if (p && p.ts != null) {
+          anchorTs = p.ts;
+          break;
+        }
+      }
+      if (anchorTs == null) {
+        hover.value = computeHover(model.value, viewX, 'x', rect, opts.formatTime);
+      } else {
+        group.set(anchorTs);
+      }
+    } else {
+      hover.value = computeHover(model.value, viewX, 'x', rect, opts.formatTime);
+    }
+  }
+
+  function onPointerLeave(): void {
+    if (group) group.set(null);
+    else hover.value = null;
+  }
+
+  return { model, hover, onPointerMove, onPointerLeave };
+}

--- a/nodelite-server/web/src/composables/useChartHoverGroup.ts
+++ b/nodelite-server/web/src/composables/useChartHoverGroup.ts
@@ -1,0 +1,31 @@
+import { inject, provide, ref, type InjectionKey, type Ref } from 'vue';
+
+/**
+ * Linked-hover group (reactive replacement for legacy createHoverGroup,
+ * node.html:2222). Charts in the same group share an `activeTs`: hovering one
+ * sets it, and every member renders its crosshair at that timestamp. A parent
+ * (e.g. MonitorCharts/OverviewCharts) calls provideChartHoverGroup once;
+ * MetricChart injects it (optional — a standalone chart has no group).
+ */
+export interface ChartHoverGroup {
+  activeTs: Ref<number | null>;
+  set(ts: number | null): void;
+}
+
+const CHART_HOVER_GROUP: InjectionKey<ChartHoverGroup> = Symbol('chartHoverGroup');
+
+export function provideChartHoverGroup(): ChartHoverGroup {
+  const activeTs = ref<number | null>(null);
+  const group: ChartHoverGroup = {
+    activeTs,
+    set: (ts) => {
+      activeTs.value = ts;
+    },
+  };
+  provide(CHART_HOVER_GROUP, group);
+  return group;
+}
+
+export function useChartHoverGroup(): ChartHoverGroup | null {
+  return inject(CHART_HOVER_GROUP, null);
+}

--- a/nodelite-server/web/src/lib/chart/chartData.spec.ts
+++ b/nodelite-server/web/src/lib/chart/chartData.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { HistoryPoint } from '@/api';
+import {
+  aggregateHistory,
+  averageValue,
+  buildChartData,
+  chartBounds,
+  chartBucketMs,
+  chartDisplayBounds,
+  chartPoints,
+  quantile,
+} from './chartData';
+
+function hp(recorded_at: string, over: Partial<HistoryPoint> = {}): HistoryPoint {
+  return {
+    node_id: 'n',
+    recorded_at,
+    cpu_usage_percent: null,
+    memory_used_percent: 0,
+    rx_bytes_per_sec: null,
+    tx_bytes_per_sec: null,
+    latency_ms: null,
+    disk_used_percent: null,
+    ...over,
+  };
+}
+
+describe('quantile', () => {
+  it('returns null for empty', () => {
+    expect(quantile([], 0.98)).toBeNull();
+  });
+  it('picks the p98-ish index', () => {
+    const vals = Array.from({ length: 100 }, (_, i) => i + 1); // 1..100
+    expect(quantile(vals, 0.98)).toBe(98);
+  });
+});
+
+describe('chartBounds', () => {
+  it('uses actual min/max without clipping by default', () => {
+    const b = chartBounds([1, 2, 100]);
+    expect(b.displayMin).toBe(1);
+    expect(b.displayMax).toBe(100);
+    expect(b.clipped).toBe(false);
+  });
+
+  it('clips the spike at p98 when enabled and >=12 points', () => {
+    // 1..50 spread + a single 1000 spike → p98 lands at ~50, between min/max.
+    const vals = [...Array.from({ length: 50 }, (_, i) => i + 1), 1000];
+    const b = chartBounds(vals, true);
+    expect(b.clipped).toBe(true);
+    expect(b.displayMax).toBeLessThan(1000);
+    expect(b.actualMax).toBe(1000);
+  });
+
+  it('does not clip with fewer than 12 points', () => {
+    expect(chartBounds([1, 2, 1000], true).clipped).toBe(false);
+  });
+});
+
+describe('chartDisplayBounds', () => {
+  it('expands to include min/max options and guards zero span', () => {
+    const b = chartDisplayBounds([5, 5], { minValue: 0, maxValue: 10 });
+    expect(b.displayMin).toBe(0);
+    expect(b.displayMax).toBe(10);
+  });
+  it('forces a 1-unit span when flat', () => {
+    const b = chartDisplayBounds([5, 5]);
+    expect(b.displayMax).toBe(b.displayMin + 1);
+  });
+});
+
+describe('chartBucketMs', () => {
+  it('scales bucket width by span', () => {
+    expect(chartBucketMs(3 * 3600 * 1000)).toBe(30 * 1000);
+    expect(chartBucketMs(20 * 3600 * 1000)).toBe(60 * 1000);
+    expect(chartBucketMs(2 * 24 * 3600 * 1000)).toBe(5 * 60 * 1000);
+    expect(chartBucketMs(5 * 24 * 3600 * 1000)).toBe(15 * 60 * 1000);
+    expect(chartBucketMs(30 * 24 * 3600 * 1000)).toBe(30 * 60 * 1000);
+  });
+});
+
+describe('aggregateHistory', () => {
+  it('returns [] for empty', () => {
+    expect(aggregateHistory([])).toEqual([]);
+    expect(aggregateHistory(undefined)).toEqual([]);
+  });
+
+  it('averages points within the same bucket, ascending, nulls skipped', () => {
+    const out = aggregateHistory(
+      [
+        hp('2026-05-29T00:00:10Z', { cpu_usage_percent: 10 }),
+        hp('2026-05-29T00:00:50Z', { cpu_usage_percent: 30 }), // same minute → 20
+        hp('2026-05-29T00:01:05Z', { cpu_usage_percent: null }), // skipped → null bucket
+      ],
+      60 * 1000,
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0]!.cpu_usage_percent).toBe(20);
+    expect(out[1]!.cpu_usage_percent).toBeNull();
+  });
+
+  it('skips points with unparseable timestamps', () => {
+    expect(aggregateHistory([hp('not-a-date', { cpu_usage_percent: 5 })])).toEqual([]);
+  });
+});
+
+describe('chartPoints / averageValue / buildChartData', () => {
+  it('projects a field into {ts,value}', () => {
+    const agg = aggregateHistory([hp('2026-05-29T00:00:00Z', { memory_used_percent: 42 })]);
+    const pts = chartPoints(agg, 'memory_used_percent');
+    expect(pts[0]).toEqual({ ts: agg[0]!.ts, value: 42 });
+  });
+
+  it('averages values, counting null as 0 (legacy Number(null)===0 quirk)', () => {
+    // node.html:2105 maps value via Number() then filters isFinite; null→0
+    // passes, so a null point drags the mean. Kept for parity.
+    expect(averageValue([{ ts: 1, value: 10 }, { ts: 2, value: null }, { ts: 3, value: 30 }])).toBe(
+      40 / 3,
+    );
+    expect(averageValue([{ ts: 1, value: null }])).toBe(0);
+  });
+
+  it('builds all five metric series', () => {
+    const data = buildChartData([
+      hp('2026-05-29T00:00:00Z', {
+        cpu_usage_percent: 1,
+        memory_used_percent: 2,
+        rx_bytes_per_sec: 3,
+        tx_bytes_per_sec: 4,
+        latency_ms: 5,
+      }),
+    ]);
+    expect(data.cpuPts[0]!.value).toBe(1);
+    expect(data.memPts[0]!.value).toBe(2);
+    expect(data.dlPts[0]!.value).toBe(3);
+    expect(data.upPts[0]!.value).toBe(4);
+    expect(data.rttPts[0]!.value).toBe(5);
+  });
+});

--- a/nodelite-server/web/src/lib/chart/chartData.ts
+++ b/nodelite-server/web/src/lib/chart/chartData.ts
@@ -1,0 +1,186 @@
+/**
+ * Pure chart data layer, ported from assets/node.html:2035-2147.
+ * Buckets/averages history, computes display bounds (with p98 spike
+ * clipping), and projects per-metric point series. No DOM.
+ */
+
+import type { HistoryPoint } from '@/api';
+
+export interface ChartPoint {
+  ts: number;
+  value: number | null;
+}
+
+export interface ChartBounds {
+  actualMin: number;
+  actualMax: number;
+  displayMin: number;
+  displayMax: number;
+  clipped: boolean;
+}
+
+export interface DisplayBoundsOptions {
+  clipSpikes?: boolean;
+  minValue?: number;
+  maxValue?: number;
+}
+
+export function quantile(values: number[], ratio: number): number | null {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * ratio) - 1));
+  return sorted[idx] ?? null;
+}
+
+export function chartBounds(values: number[], clipSpikes = false): ChartBounds {
+  const actualMin = Math.min(...values);
+  const actualMax = Math.max(...values);
+  let displayMax = actualMax;
+  let clipped = false;
+  if (clipSpikes && values.length >= 12) {
+    const clippedMax = quantile(values, 0.98);
+    if (clippedMax != null && clippedMax > actualMin && clippedMax < actualMax) {
+      displayMax = clippedMax;
+      clipped = true;
+    }
+  }
+  return { actualMin, actualMax, displayMin: actualMin, displayMax, clipped };
+}
+
+export function chartDisplayBounds(
+  values: number[],
+  options: DisplayBoundsOptions = {},
+): ChartBounds {
+  const bounds = chartBounds(values, options.clipSpikes);
+  if (Number.isFinite(Number(options.minValue))) {
+    bounds.displayMin = Math.min(bounds.displayMin, Number(options.minValue));
+  }
+  if (Number.isFinite(Number(options.maxValue))) {
+    bounds.displayMax = Math.max(bounds.displayMax, Number(options.maxValue));
+  }
+  if (bounds.displayMax <= bounds.displayMin) {
+    bounds.displayMax = bounds.displayMin + 1;
+  }
+  return bounds;
+}
+
+const HOUR_MS = 3600 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Bucket width chosen by the selected span (node.html:2055). */
+export function chartBucketMs(spanMs: number): number {
+  if (spanMs <= 6 * HOUR_MS) return 30 * 1000;
+  if (spanMs <= DAY_MS) return 60 * 1000;
+  if (spanMs <= 3 * DAY_MS) return 5 * 60 * 1000;
+  if (spanMs <= 7 * DAY_MS) return 15 * 60 * 1000;
+  return 30 * 60 * 1000;
+}
+
+interface Acc {
+  sum: number;
+  count: number;
+}
+function add(acc: Acc, value: number | null | undefined): void {
+  if (value == null) return;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return;
+  acc.sum += n;
+  acc.count += 1;
+}
+function avg(acc: Acc): number | null {
+  return acc.count > 0 ? acc.sum / acc.count : null;
+}
+
+export interface AggregatedPoint {
+  ts: number;
+  recorded_at: string;
+  cpu_usage_percent: number | null;
+  memory_used_percent: number | null;
+  rx_bytes_per_sec: number | null;
+  tx_bytes_per_sec: number | null;
+  latency_ms: number | null;
+}
+
+/**
+ * Time-bucket + average the history. Default bucket 60s. Parses recorded_at
+ * to epoch ms (legacy pre-stored `_ts`); points with unparseable times are
+ * skipped.
+ */
+export function aggregateHistory(
+  history: HistoryPoint[] | undefined,
+  bucketMs = 60 * 1000,
+): AggregatedPoint[] {
+  if (!Array.isArray(history) || history.length === 0) return [];
+  const buckets = new Map<
+    number,
+    { ts: number; cpu: Acc; memory: Acc; rx: Acc; tx: Acc; latency: Acc }
+  >();
+  for (const point of history) {
+    const ms = Date.parse(point.recorded_at);
+    if (!Number.isFinite(ms)) continue;
+    const bucket = Math.floor(ms / bucketMs) * bucketMs;
+    const item =
+      buckets.get(bucket) ??
+      {
+        ts: bucket,
+        cpu: { sum: 0, count: 0 },
+        memory: { sum: 0, count: 0 },
+        rx: { sum: 0, count: 0 },
+        tx: { sum: 0, count: 0 },
+        latency: { sum: 0, count: 0 },
+      };
+    add(item.cpu, point.cpu_usage_percent);
+    add(item.memory, point.memory_used_percent);
+    add(item.rx, point.rx_bytes_per_sec);
+    add(item.tx, point.tx_bytes_per_sec);
+    add(item.latency, point.latency_ms);
+    buckets.set(bucket, item);
+  }
+  return [...buckets.values()]
+    .sort((l, r) => l.ts - r.ts)
+    .map((item) => ({
+      ts: item.ts,
+      recorded_at: new Date(item.ts).toISOString(),
+      cpu_usage_percent: avg(item.cpu),
+      memory_used_percent: avg(item.memory),
+      rx_bytes_per_sec: avg(item.rx),
+      tx_bytes_per_sec: avg(item.tx),
+      latency_ms: avg(item.latency),
+    }));
+}
+
+type AggregatedField = Exclude<keyof AggregatedPoint, 'ts' | 'recorded_at'>;
+
+export function chartPoints(history: AggregatedPoint[], field: AggregatedField): ChartPoint[] {
+  return history.map((p) => ({ ts: p.ts, value: p[field] }));
+}
+
+export function averageValue(points: ChartPoint[]): number | null {
+  const values = points.map((p) => Number(p.value)).filter((v) => Number.isFinite(v));
+  if (values.length === 0) return null;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+export interface ChartData {
+  chartHistory: AggregatedPoint[];
+  cpuPts: ChartPoint[];
+  memPts: ChartPoint[];
+  dlPts: ChartPoint[];
+  upPts: ChartPoint[];
+  rttPts: ChartPoint[];
+}
+
+export function buildChartData(
+  history: HistoryPoint[] | undefined,
+  bucketMs = 60 * 1000,
+): ChartData {
+  const chartHistory = aggregateHistory(history, bucketMs);
+  return {
+    chartHistory,
+    cpuPts: chartPoints(chartHistory, 'cpu_usage_percent'),
+    memPts: chartPoints(chartHistory, 'memory_used_percent'),
+    dlPts: chartPoints(chartHistory, 'rx_bytes_per_sec'),
+    upPts: chartPoints(chartHistory, 'tx_bytes_per_sec'),
+    rttPts: chartPoints(chartHistory, 'latency_ms'),
+  };
+}

--- a/nodelite-server/web/src/lib/chart/format.spec.ts
+++ b/nodelite-server/web/src/lib/chart/format.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { formatChartValue } from './format';
+
+describe('formatChartValue', () => {
+  it('returns em dash for non-finite values', () => {
+    expect(formatChartValue(undefined, 'percent')).toBe('—');
+    expect(formatChartValue(Number.NaN, 'number')).toBe('—');
+  });
+
+  it('treats null as 0 (Number(null)===0), matching legacy', () => {
+    // Charts filter out null points before formatting, so this only affects
+    // direct calls; kept faithful to node.html:2122.
+    expect(formatChartValue(null, 'percent')).toBe('0.0%');
+  });
+
+  it('formats percent (0 decimals at >=10, else 1)', () => {
+    expect(formatChartValue(63.7, 'percent')).toBe('64%');
+    expect(formatChartValue(4.2, 'percent')).toBe('4.2%');
+  });
+
+  it('formats latency in ms (0 decimals at >=10, else 1)', () => {
+    expect(formatChartValue(42.6, 'latency')).toBe('43 ms');
+    expect(formatChartValue(4.2, 'latency')).toBe('4.2 ms');
+  });
+
+  it('formats rate via fmtRate (bytes/sec → bits)', () => {
+    expect(formatChartValue(125_000, 'rate')).toBe('1.0 Mbps');
+  });
+
+  it('formats plain numbers (0 decimals at >=100, else 1)', () => {
+    expect(formatChartValue(150, 'number')).toBe('150');
+    expect(formatChartValue(1.5, 'number')).toBe('1.5');
+  });
+});

--- a/nodelite-server/web/src/lib/chart/format.ts
+++ b/nodelite-server/web/src/lib/chart/format.ts
@@ -1,0 +1,24 @@
+/**
+ * Chart value formatting, ported from assets/node.html:2121-2128. Pure.
+ * Distinct from lib/format.ts: this formats a single charted value by metric
+ * kind and always returns a display string ("—" for non-finite).
+ */
+
+import { fmtRate } from '@/lib/format';
+
+export type ChartValueKind = 'percent' | 'rate' | 'latency' | 'number';
+
+export function formatChartValue(value: number | null | undefined, kind: ChartValueKind): string {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return '—';
+  if (kind === 'percent') {
+    return `${numeric >= 10 ? numeric.toFixed(0) : numeric.toFixed(1)}%`;
+  }
+  if (kind === 'rate') {
+    return fmtRate(numeric) ?? '—';
+  }
+  if (kind === 'latency') {
+    return `${numeric.toFixed(numeric >= 10 ? 0 : 1)} ms`;
+  }
+  return numeric >= 100 ? numeric.toFixed(0) : numeric.toFixed(1);
+}

--- a/nodelite-server/web/src/lib/chart/geometry.spec.ts
+++ b/nodelite-server/web/src/lib/chart/geometry.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { chartPadLeft, chartY, smoothPath } from './geometry';
+
+describe('chartY', () => {
+  const bounds = { displayMin: 0, displayMax: 100 };
+
+  it('maps the max to the top padding edge', () => {
+    // height 120, padTop 12, padBottom 20 → plot height 88; max → y = padTop = 12
+    expect(chartY(100, bounds, 120, 12, 20)).toBeCloseTo(12, 5);
+  });
+
+  it('maps the min to the bottom padding edge', () => {
+    expect(chartY(0, bounds, 120, 12, 20)).toBeCloseTo(100, 5); // height - padBottom
+  });
+
+  it('clamps out-of-range values into the band', () => {
+    expect(chartY(200, bounds, 120, 12, 20)).toBeCloseTo(12, 5);
+    expect(chartY(-50, bounds, 120, 12, 20)).toBeCloseTo(100, 5);
+  });
+
+  it('guards a zero span', () => {
+    const flat = { displayMin: 5, displayMax: 5 };
+    expect(Number.isFinite(chartY(5, flat, 120, 12, 20))).toBe(true);
+  });
+});
+
+describe('chartPadLeft', () => {
+  it('widens for rate and latency axes', () => {
+    expect(chartPadLeft('rate')).toBe(86);
+    expect(chartPadLeft('latency')).toBe(70);
+    expect(chartPadLeft('percent')).toBe(62);
+    expect(chartPadLeft('number')).toBe(62);
+  });
+});
+
+describe('smoothPath', () => {
+  it('returns empty for no coords and a moveTo for one', () => {
+    expect(smoothPath([])).toBe('');
+    expect(smoothPath([[3, 4]])).toBe('M3.0,4.0');
+  });
+
+  it('emits cubic segments for multiple coords', () => {
+    const d = smoothPath([
+      [0, 0],
+      [10, 5],
+      [20, 0],
+    ]);
+    expect(d.startsWith('M0.0,0.0')).toBe(true);
+    expect((d.match(/ C/g) ?? []).length).toBe(2);
+  });
+});

--- a/nodelite-server/web/src/lib/chart/geometry.ts
+++ b/nodelite-server/web/src/lib/chart/geometry.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure chart geometry, ported from assets/node.html (chartY :2174,
+ * chartPadLeft :2198, smoothPath :2330). No DOM.
+ */
+
+import type { ChartValueKind } from './format';
+
+export interface ChartBounds {
+  displayMin: number;
+  displayMax: number;
+}
+
+/** Map a value to a y pixel within the padded plot area. */
+export function chartY(
+  value: number,
+  bounds: ChartBounds,
+  height: number,
+  padTop: number,
+  padBottom: number,
+): number {
+  const span = Math.max(bounds.displayMax - bounds.displayMin, 1);
+  const v = Math.min(Math.max(Number(value), bounds.displayMin), bounds.displayMax);
+  return height - padBottom - ((v - bounds.displayMin) / span) * (height - padTop - padBottom);
+}
+
+/** Left padding by metric kind — wider for long rate/latency axis labels. */
+export function chartPadLeft(kind: ChartValueKind): number {
+  if (kind === 'rate') return 86;
+  if (kind === 'latency') return 70;
+  return 62;
+}
+
+/** Catmull-Rom → cubic-Bézier smoothing producing an SVG path `d`. */
+export function smoothPath(coords: Array<[number, number]>): string {
+  if (!coords.length) return '';
+  const first = coords[0]!;
+  if (coords.length === 1) {
+    return `M${first[0].toFixed(1)},${first[1].toFixed(1)}`;
+  }
+  let path = `M${first[0].toFixed(1)},${first[1].toFixed(1)}`;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const p0 = coords[i - 1] || coords[i]!;
+    const p1 = coords[i]!;
+    const p2 = coords[i + 1]!;
+    const p3 = coords[i + 2] || p2;
+    const cp1x = p1[0] + (p2[0] - p0[0]) / 6;
+    const cp1y = p1[1] + (p2[1] - p0[1]) / 6;
+    const cp2x = p2[0] - (p3[0] - p1[0]) / 6;
+    const cp2y = p2[1] - (p3[1] - p1[1]) / 6;
+    path += ` C${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${p2[0].toFixed(1)},${p2[1].toFixed(1)}`;
+  }
+  return path;
+}

--- a/nodelite-server/web/src/lib/chart/hover.spec.ts
+++ b/nodelite-server/web/src/lib/chart/hover.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { ChartPoint } from './chartData';
+import { buildAreaChart, buildMultiAreaChart } from './svgModel';
+import { computeHover, nearestByKey } from './hover';
+import type { HoverPoint } from './svgModel';
+
+function hoverPts(xs: number[]): HoverPoint[] {
+  return xs.map((x) => ({ x, y: 0, value: x, ts: x * 1000 }));
+}
+
+function pts(values: number[]): ChartPoint[] {
+  return values.map((value, i) => ({ ts: i * 60_000, value }));
+}
+
+describe('nearestByKey', () => {
+  const points = hoverPts([0, 10, 20, 30]);
+
+  it('returns null for empty', () => {
+    expect(nearestByKey([], 5, 'x')).toBeNull();
+  });
+
+  it('finds the nearest by x', () => {
+    expect(nearestByKey(points, 12, 'x')!.x).toBe(10);
+    expect(nearestByKey(points, 16, 'x')!.x).toBe(20);
+    expect(nearestByKey(points, 100, 'x')!.x).toBe(30);
+    expect(nearestByKey(points, -5, 'x')!.x).toBe(0);
+  });
+
+  it('finds the nearest by ts', () => {
+    // ts = x*1000
+    expect(nearestByKey(points, 9000, 'ts')!.ts).toBe(10_000);
+  });
+});
+
+describe('computeHover', () => {
+  const model = buildAreaChart(pts([10, 50, 90]), {
+    width: 600,
+    height: 200,
+    valueKind: 'percent',
+    color: 'var(--chart-cpu)',
+    label: 'CPU',
+  });
+
+  it('returns null for a degenerate rect', () => {
+    expect(computeHover(model, 100, 'x', { width: 0, height: 0 }, () => '')).toBeNull();
+  });
+
+  it('places the crosshair at the nearest point and spans the plot', () => {
+    const anchorX = model.series[0]!.points[1]!.x;
+    const hover = computeHover(model, anchorX + 2, 'x', { width: 600, height: 200 }, () => 't');
+    expect(hover).not.toBeNull();
+    expect(hover!.lineX).toBeCloseTo(anchorX, 5);
+    expect(hover!.lineY1).toBe(model.padTop);
+    expect(hover!.lineY2).toBe(model.height - model.padBottom);
+    expect(hover!.circles).toHaveLength(1);
+    expect(hover!.tooltip.rows[0]).toMatchObject({ label: 'CPU', color: 'var(--chart-cpu)' });
+    expect(hover!.tooltip.rows[0]!.value).toContain('%');
+  });
+
+  it('builds one circle + row per series for multi-series', () => {
+    const multi = buildMultiAreaChart(
+      [
+        { label: 'down', color: 'cdown', points: pts([100, 200]) },
+        { label: 'up', color: 'cup', points: pts([10, 20]) },
+      ],
+      { width: 600, height: 220, valueKind: 'rate' },
+    );
+    const hover = computeHover(multi, multi.series[0]!.points[0]!.x, 'x', { width: 600, height: 220 }, () => 't');
+    expect(hover!.circles).toHaveLength(2);
+    expect(hover!.tooltip.rows.map((r) => r.label)).toEqual(['down', 'up']);
+  });
+
+  it('uses formatTime for the tooltip header from the anchor ts', () => {
+    const anchorX = model.series[0]!.points[0]!.x;
+    const hover = computeHover(model, anchorX, 'x', { width: 600, height: 200 }, (ts) => `@${ts}`);
+    expect(hover!.tooltip.time).toBe('@0');
+  });
+
+  it('flips the tooltip transform based on vertical position', () => {
+    // Anchor at the max value sits near the top → tooltip drops below (+14px).
+    const topModel = buildAreaChart(pts([0, 100]), {
+      width: 600,
+      height: 200,
+      valueKind: 'percent',
+      color: 'c',
+    });
+    const topPoint = topModel.series[0]!.points[1]!; // value 100 → y at padTop
+    const hover = computeHover(topModel, topPoint.x, 'x', { width: 600, height: 200 }, () => 't');
+    expect(hover!.tooltip.transform).toContain('14px');
+  });
+});

--- a/nodelite-server/web/src/lib/chart/hover.ts
+++ b/nodelite-server/web/src/lib/chart/hover.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure hover math, extracted from installChartHover (node.html:2230-2329).
+ * The imperative setAttribute/innerHTML mutation lives in useChart/MetricChart;
+ * this module only computes "given a target on this chart model, where do the
+ * crosshair, circles, and tooltip go".
+ */
+
+import { formatChartValue } from './format';
+import type { ChartModel, HoverPoint, ChartSeriesModel } from './svgModel';
+
+export type HoverKey = 'x' | 'ts';
+
+function keyOf(point: HoverPoint, key: HoverKey): number {
+  return Number(key === 'x' ? point.x : point.ts);
+}
+
+/** Binary-search the point nearest `target` by the chosen key. */
+export function nearestByKey(
+  points: HoverPoint[],
+  target: number,
+  key: HoverKey,
+): HoverPoint | null {
+  if (points.length === 0) return null;
+  let lo = 0;
+  let hi = points.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (keyOf(points[mid]!, key) < target) lo = mid + 1;
+    else hi = mid;
+  }
+  const right = points[lo]!;
+  const left = lo > 0 ? points[lo - 1]! : right;
+  return Math.abs(keyOf(right, key) - target) < Math.abs(keyOf(left, key) - target) ? right : left;
+}
+
+export interface HoverCircle {
+  cx: number;
+  cy: number;
+  color: string;
+}
+
+export interface HoverRow {
+  label: string;
+  color: string;
+  value: string;
+}
+
+export interface HoverModel {
+  lineX: number;
+  lineY1: number;
+  lineY2: number;
+  circles: HoverCircle[];
+  anchorTs: number | null;
+  tooltip: {
+    left: number;
+    top: number;
+    transform: string;
+    time: string;
+    rows: HoverRow[];
+  };
+}
+
+interface Match {
+  series: ChartSeriesModel;
+  point: HoverPoint;
+}
+
+/**
+ * Compute the crosshair + tooltip placement for a target on `model`.
+ * `target` is in chart-view units of `key` (an x pixel, or a ts). rect
+ * dimensions map view coords to the on-screen tooltip position.
+ * `formatTime` turns an epoch-ms ts into the tooltip header (i18n/locale
+ * lives in the caller). Returns null when there are no points.
+ */
+export function computeHover(
+  model: ChartModel,
+  target: number,
+  key: HoverKey,
+  rect: { width: number; height: number },
+  formatTime: (ts: number) => string,
+): HoverModel | null {
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  const matches: Match[] = [];
+  for (const series of model.series) {
+    const point = nearestByKey(series.points, target, key);
+    if (point) matches.push({ series, point });
+  }
+  if (matches.length === 0) return null;
+
+  const anchor = matches.reduce(
+    (best, m) =>
+      Math.abs(keyOf(m.point, key) - target) < Math.abs(keyOf(best.point, key) - target) ? m : best,
+    matches[0]!,
+  ).point;
+
+  const circles: HoverCircle[] = matches.map((m) => ({
+    cx: m.point.x,
+    cy: m.point.y,
+    color: m.series.color,
+  }));
+  const rows: HoverRow[] = matches.map((m) => ({
+    label: m.series.label,
+    color: m.series.color,
+    value: formatChartValue(m.point.value, m.series.kind),
+  }));
+
+  const left = Math.min(rect.width - 74, Math.max(74, (anchor.x / model.width) * rect.width));
+  const minCy = Math.min(...matches.map((m) => m.point.y));
+  const top = Math.max(10, (minCy / model.height) * rect.height);
+  const transform = top < 88 ? 'translate(-50%, 14px)' : 'translate(-50%, calc(-100% - 10px))';
+
+  return {
+    lineX: anchor.x,
+    lineY1: model.padTop,
+    lineY2: model.height - model.padBottom,
+    circles,
+    anchorTs: anchor.ts,
+    tooltip: {
+      left,
+      top,
+      transform,
+      time: anchor.ts != null ? formatTime(anchor.ts) : '',
+      rows,
+    },
+  };
+}

--- a/nodelite-server/web/src/lib/chart/sparkline.ts
+++ b/nodelite-server/web/src/lib/chart/sparkline.ts
@@ -6,6 +6,9 @@
 
 import type { HistoryPoint } from '@/api';
 import type { NodeStatus } from '@/lib/map/projection';
+import { smoothPath } from './geometry';
+
+export { smoothPath };
 
 export const SPARK_BUCKET_MS = 60 * 1000;
 const SPARK_W = 200;
@@ -49,28 +52,6 @@ export function sparklineColor(status: NodeStatus): string {
   if (status === 'offline') return '#ef4444';
   if (status === 'latency') return '#eab308';
   return '#22c55e';
-}
-
-/** Catmull-Rom-ish smoothing → SVG path `d`. Mirrors legacy smoothPath. */
-export function smoothPath(coords: Array<[number, number]>): string {
-  if (!coords.length) return '';
-  const first = coords[0]!;
-  if (coords.length === 1) {
-    return `M${first[0].toFixed(1)},${first[1].toFixed(1)}`;
-  }
-  let path = `M${first[0].toFixed(1)},${first[1].toFixed(1)}`;
-  for (let i = 0; i < coords.length - 1; i++) {
-    const p0 = coords[i - 1] || coords[i]!;
-    const p1 = coords[i]!;
-    const p2 = coords[i + 1]!;
-    const p3 = coords[i + 2] || p2;
-    const cp1x = p1[0] + (p2[0] - p0[0]) / 6;
-    const cp1y = p1[1] + (p2[1] - p0[1]) / 6;
-    const cp2x = p2[0] - (p3[0] - p1[0]) / 6;
-    const cp2y = p2[1] - (p3[1] - p1[1]) / 6;
-    path += ` C${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${p2[0].toFixed(1)},${p2[1].toFixed(1)}`;
-  }
-  return path;
 }
 
 export interface Sparkline {

--- a/nodelite-server/web/src/lib/chart/svgModel.spec.ts
+++ b/nodelite-server/web/src/lib/chart/svgModel.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type { ChartPoint } from './chartData';
+import { buildAreaChart, buildMultiAreaChart } from './svgModel';
+
+function pts(values: Array<number | null>): ChartPoint[] {
+  return values.map((value, i) => ({ ts: i * 60_000, value }));
+}
+
+describe('buildAreaChart', () => {
+  const opts = { width: 600, height: 200, valueKind: 'percent' as const, color: 'var(--chart-cpu)' };
+
+  it('flags empty when no numeric points', () => {
+    expect(buildAreaChart([], opts).empty).toBe(true);
+    expect(buildAreaChart(pts([null, null]), opts).empty).toBe(true);
+  });
+
+  it('builds one series with a line + area path and grid', () => {
+    const model = buildAreaChart(pts([10, 50, 90]), opts);
+    expect(model.empty).toBe(false);
+    expect(model.series).toHaveLength(1);
+    const s = model.series[0]!;
+    expect(s.line.startsWith('M')).toBe(true);
+    expect(s.area?.endsWith('Z')).toBe(true);
+    expect(s.points).toHaveLength(3);
+    expect(model.grid.length).toBeGreaterThan(0);
+    expect(model.grid[0]!.label).toContain('%');
+  });
+
+  it('positions the first point at padLeft and last at width-padRight', () => {
+    const model = buildAreaChart(pts([10, 90]), opts);
+    const s = model.series[0]!;
+    expect(s.points[0]!.x).toBeCloseTo(model.padLeft, 5);
+    expect(s.points[1]!.x).toBeCloseTo(model.width - model.padRight, 5);
+  });
+
+  it('carries ts on hover points', () => {
+    const model = buildAreaChart(pts([10, 90]), opts);
+    expect(model.series[0]!.points[1]!.ts).toBe(60_000);
+  });
+
+  it('uses fewer grid lines for short charts', () => {
+    const short = buildAreaChart(pts([10, 90]), { ...opts, height: 70 });
+    expect(short.grid).toHaveLength(3);
+    const tall = buildAreaChart(pts([10, 90]), opts);
+    expect(tall.grid).toHaveLength(5);
+  });
+});
+
+describe('buildMultiAreaChart', () => {
+  const opts = { width: 600, height: 220, valueKind: 'rate' as const };
+
+  it('flags empty when no series have numeric points', () => {
+    expect(buildMultiAreaChart([], opts).empty).toBe(true);
+    expect(
+      buildMultiAreaChart([{ label: 'dl', color: 'c', points: pts([null]) }], opts).empty,
+    ).toBe(true);
+  });
+
+  it('builds a line per valid series, no area fill, shared bounds', () => {
+    const model = buildMultiAreaChart(
+      [
+        { label: 'down', color: 'var(--chart-network-down)', points: pts([100, 200, 300]) },
+        { label: 'up', color: 'var(--chart-network-up)', points: pts([10, 20, 30]) },
+      ],
+      opts,
+    );
+    expect(model.empty).toBe(false);
+    expect(model.series).toHaveLength(2);
+    for (const s of model.series) {
+      expect(s.line.startsWith('M')).toBe(true);
+      expect(s.area).toBeUndefined();
+    }
+  });
+});

--- a/nodelite-server/web/src/lib/chart/svgModel.ts
+++ b/nodelite-server/web/src/lib/chart/svgModel.ts
@@ -1,0 +1,206 @@
+/**
+ * Pure SVG chart-model builders, ported from drawAreaChart (node.html:2350)
+ * and drawMultiAreaChart (:2404). Instead of producing innerHTML strings,
+ * these return a structured ChartModel (paths, grid, avg lines, hover
+ * coords) that MetricChart.vue renders declaratively. No DOM.
+ */
+
+import {
+  averageValue,
+  chartDisplayBounds,
+  type ChartBounds,
+  type ChartPoint,
+} from './chartData';
+import { formatChartValue, type ChartValueKind } from './format';
+import { chartPadLeft, chartY, smoothPath } from './geometry';
+
+const PAD_RIGHT = 14;
+const PAD_TOP = 12;
+const PAD_BOTTOM = 20;
+
+export interface HoverPoint {
+  x: number;
+  y: number;
+  value: number;
+  ts: number | null;
+}
+
+export interface ChartGridLine {
+  y: number;
+  label: string;
+}
+
+export interface ChartSeriesModel {
+  label: string;
+  color: string;
+  kind: ChartValueKind;
+  line: string;
+  /** Filled-area path; present only for single-series area charts. */
+  area?: string;
+  /** Dashed average-line y, or null when there's no finite average. */
+  avgY: number | null;
+  avgOpacity: number;
+  points: HoverPoint[];
+}
+
+export interface ChartModel {
+  width: number;
+  height: number;
+  padLeft: number;
+  padRight: number;
+  padTop: number;
+  padBottom: number;
+  grid: ChartGridLine[];
+  series: ChartSeriesModel[];
+  /** True when there's no numeric data to plot (render a placeholder). */
+  empty: boolean;
+}
+
+export interface ChartOptions {
+  width: number;
+  height: number;
+  valueKind?: ChartValueKind;
+  clipSpikes?: boolean;
+  minValue?: number;
+  maxValue?: number;
+  padLeft?: number;
+}
+
+export interface AreaChartOptions extends ChartOptions {
+  color: string;
+  label?: string;
+}
+
+export interface MultiSeriesInput {
+  label: string;
+  color: string;
+  points: ChartPoint[];
+}
+
+function isFiniteValue(p: ChartPoint): p is ChartPoint & { value: number } {
+  return p.value != null && Number.isFinite(Number(p.value));
+}
+
+function buildGrid(
+  bounds: ChartBounds,
+  width: number,
+  height: number,
+  padLeft: number,
+  kind: ChartValueKind,
+): ChartGridLine[] {
+  const ratios = height < 100 ? [0, 0.5, 1] : [0, 0.25, 0.5, 0.75, 1];
+  void width; // grid lines span padLeft..width-padRight in the template
+  return ratios.map((ratio) => {
+    const tick = bounds.displayMin + (bounds.displayMax - bounds.displayMin) * ratio;
+    return { y: chartY(tick, bounds, height, PAD_TOP, PAD_BOTTOM), label: formatChartValue(tick, kind) };
+  });
+}
+
+function emptyModel(opts: ChartOptions, padLeft: number): ChartModel {
+  return {
+    width: opts.width,
+    height: opts.height,
+    padLeft,
+    padRight: PAD_RIGHT,
+    padTop: PAD_TOP,
+    padBottom: PAD_BOTTOM,
+    grid: [],
+    series: [],
+    empty: true,
+  };
+}
+
+export function buildAreaChart(points: ChartPoint[], opts: AreaChartOptions): ChartModel {
+  const kind = opts.valueKind ?? 'number';
+  const padLeft = opts.padLeft ?? chartPadLeft(kind);
+  const numeric = (points ?? []).filter(isFiniteValue);
+  if (numeric.length === 0) return emptyModel(opts, padLeft);
+
+  const { width, height } = opts;
+  const values = numeric.map((p) => p.value);
+  const bounds = chartDisplayBounds(values, opts);
+  const plotWidth = width - padLeft - PAD_RIGHT;
+
+  const coords: HoverPoint[] = numeric.map((point, idx) => ({
+    x: padLeft + (plotWidth * idx) / Math.max(numeric.length - 1, 1),
+    y: chartY(point.value, bounds, height, PAD_TOP, PAD_BOTTOM),
+    value: point.value,
+    ts: point.ts,
+  }));
+  const line = smoothPath(coords.map((p) => [p.x, p.y]));
+  const area = `${line}L ${width - PAD_RIGHT},${height - PAD_BOTTOM} L ${padLeft},${height - PAD_BOTTOM} Z`;
+  const avg = averageValue(numeric);
+
+  return {
+    width,
+    height,
+    padLeft,
+    padRight: PAD_RIGHT,
+    padTop: PAD_TOP,
+    padBottom: PAD_BOTTOM,
+    grid: buildGrid(bounds, width, height, padLeft, kind),
+    series: [
+      {
+        label: opts.label ?? '',
+        color: opts.color,
+        kind,
+        line,
+        area,
+        avgY: avg == null ? null : chartY(avg, bounds, height, PAD_TOP, PAD_BOTTOM),
+        avgOpacity: 0.36,
+        points: coords,
+      },
+    ],
+    empty: false,
+  };
+}
+
+export function buildMultiAreaChart(series: MultiSeriesInput[], opts: ChartOptions): ChartModel {
+  const kind = opts.valueKind ?? 'number';
+  const padLeft = opts.padLeft ?? chartPadLeft(kind);
+  const valid = (series ?? []).filter((s) => Array.isArray(s.points) && s.points.length > 0);
+  if (valid.length === 0) return emptyModel(opts, padLeft);
+
+  const allValues = valid.flatMap((s) => s.points.filter(isFiniteValue).map((p) => p.value));
+  if (allValues.length === 0) return emptyModel(opts, padLeft);
+
+  const { width, height } = opts;
+  const bounds = chartDisplayBounds(allValues, opts);
+  const plotWidth = width - padLeft - PAD_RIGHT;
+  const longest = Math.max(...valid.map((s) => s.points.length));
+
+  const built: ChartSeriesModel[] = valid.map((s) => {
+    const coords: HoverPoint[] = [];
+    s.points.forEach((point, idx) => {
+      if (!isFiniteValue(point)) return;
+      coords.push({
+        x: padLeft + (plotWidth * idx) / Math.max(longest - 1, 1),
+        y: chartY(point.value, bounds, height, PAD_TOP, PAD_BOTTOM),
+        value: point.value,
+        ts: point.ts,
+      });
+    });
+    const avg = averageValue(s.points);
+    return {
+      label: s.label,
+      color: s.color,
+      kind,
+      line: smoothPath(coords.map((p) => [p.x, p.y])),
+      avgY: avg == null ? null : chartY(avg, bounds, height, PAD_TOP, PAD_BOTTOM),
+      avgOpacity: 0.3,
+      points: coords,
+    };
+  });
+
+  return {
+    width,
+    height,
+    padLeft,
+    padRight: PAD_RIGHT,
+    padTop: PAD_TOP,
+    padBottom: PAD_BOTTOM,
+    grid: buildGrid(bounds, width, height, padLeft, kind),
+    series: built,
+    empty: false,
+  };
+}

--- a/nodelite-server/web/src/lib/chart/svgModel.ts
+++ b/nodelite-server/web/src/lib/chart/svgModel.ts
@@ -81,15 +81,10 @@ function isFiniteValue(p: ChartPoint): p is ChartPoint & { value: number } {
   return p.value != null && Number.isFinite(Number(p.value));
 }
 
-function buildGrid(
-  bounds: ChartBounds,
-  width: number,
-  height: number,
-  padLeft: number,
-  kind: ChartValueKind,
-): ChartGridLine[] {
+// Grid lines span padLeft..width-padRight horizontally; that x-range is
+// applied in the template, so only y + label are computed here.
+function buildGrid(bounds: ChartBounds, height: number, kind: ChartValueKind): ChartGridLine[] {
   const ratios = height < 100 ? [0, 0.5, 1] : [0, 0.25, 0.5, 0.75, 1];
-  void width; // grid lines span padLeft..width-padRight in the template
   return ratios.map((ratio) => {
     const tick = bounds.displayMin + (bounds.displayMax - bounds.displayMin) * ratio;
     return { y: chartY(tick, bounds, height, PAD_TOP, PAD_BOTTOM), label: formatChartValue(tick, kind) };
@@ -138,7 +133,7 @@ export function buildAreaChart(points: ChartPoint[], opts: AreaChartOptions): Ch
     padRight: PAD_RIGHT,
     padTop: PAD_TOP,
     padBottom: PAD_BOTTOM,
-    grid: buildGrid(bounds, width, height, padLeft, kind),
+    grid: buildGrid(bounds, height, kind),
     series: [
       {
         label: opts.label ?? '',
@@ -199,7 +194,7 @@ export function buildMultiAreaChart(series: MultiSeriesInput[], opts: ChartOptio
     padRight: PAD_RIGHT,
     padTop: PAD_TOP,
     padBottom: PAD_BOTTOM,
-    grid: buildGrid(bounds, width, height, padLeft, kind),
+    grid: buildGrid(bounds, height, kind),
     series: built,
     empty: false,
   };


### PR DESCRIPTION
## Summary

Second Stage 3 PR: the chart engine the detail tabs (3c/3d) sit on. This is the riskiest piece, so it's reviewed in isolation with no tab logic. 5 commits, squash on merge.

**Charts are SVG**, not Canvas (confirmed in `node.html` — zero `getContext`/DPR), so the pure layer produces structured geometry/path strings, not ctx mutations. The hard parts (hover + linked-hover, layout measurement) are split into pure-math + reactive-binding halves.

### Pure layer (`src/lib/chart/`) — fully unit-tested

- **format.ts** — `formatChartValue(value, kind)` (node.html:2121). Faithful: `Number(null)===0` so null→"0.0%".
- **chartData.ts** — `quantile`, `chartBounds` (p98 spike clip), `chartDisplayBounds`, `chartBucketMs`, `aggregateHistory` (time-bucket average; parses `recorded_at`→ms), `chartPoints`, `averageValue`, `buildChartData`.
- **geometry.ts** — `chartY`, `chartPadLeft`, `smoothPath` (Catmull-Rom→Bézier). `sparkline.ts` now re-exports `smoothPath` from here (removed the duplicate).
- **svgModel.ts** — `buildAreaChart`/`buildMultiAreaChart` → a structured `ChartModel` (grid `{y,label}`, line/area path `d`, avg-line y, hover-point coords, `empty` flag).
- **hover.ts** — `nearestByKey` (binary search) + `computeHover` (crosshair line, per-series circles, tooltip rows + position/transform from rect dims; `formatTime` injected).

### Vue layer

- **useChart** — owns reactive width/height via `ResizeObserver` (closes the legacy no-observer gap) feeding the pure builder, plus hover wiring. Standalone charts resolve hover by mouse-x; grouped charts publish the anchor ts to a shared group and every member renders its crosshair by ts (**linked hover**, the reactive replacement for `createHoverGroup`).
- **useChartHoverGroup** — provide/inject reactive linked-hover group.
- **MetricChart.vue** — renders the `ChartModel` declaratively (grid, area gradient, avg line, line, crosshair/circles, tooltip) — no `innerHTML`/`setAttribute`. Area vs multi-series by prop; colors stay as `var(--chart-*)`; empty placeholder when no numeric data.

### Notes

- jsdom has no layout/canvas, so the pixel math is covered by the pure-fn specs; component specs assert SVG structure, and useChart's hover wiring is tested via a host component with a mocked `getBoundingClientRect`.
- Parity quirks kept faithful (commented): `averageValue` counts null as 0; spike clip needs ≥12 points + p98 strictly between min/max.

## Test plan

- [x] `pnpm lint` / `typecheck` / `test` (197 tests, 33 files) / `build` — all clean
- [ ] Manual smoke deferred to 3c, where MetricChart first mounts in a tab against real history (line + area render; hover crosshair + tooltip; sibling charts' crosshairs track by timestamp)

## Next

- **3c** — overview/network/hardware tabs (mounts MetricChart with real history)
- **3d** — monitor (brush + zoom) + logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)