### PR TITLE
Stage 3c — NodeDetail overview / network / hardware tabs

### DIFF
--- a/nodelite-server/web/src/components/NodeDisks.spec.ts
+++ b/nodelite-server/web/src/components/NodeDisks.spec.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import type { DiskUsage } from '@/api';
+import NodeDisks from './NodeDisks.vue';
+
+const FAKE_DICT = {
+  en: {
+    'node.no_disks': 'No disk metrics reported yet.',
+    'node.disk.device': 'Device',
+    'node.disk.mount': 'Mount',
+    'node.disk.filesystem': 'Filesystem',
+    'node.disk.usage': 'Usage',
+    'node.disk.capacity': 'Capacity',
+  },
+  'zh-CN': { 'node.no_disks': '暂无磁盘指标。' },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function disk(over: Partial<DiskUsage>): DiskUsage {
+  return {
+    device: '/dev/sda1',
+    mount_point: '/',
+    fs_type: 'ext4',
+    total_bytes: 100_000_000_000,
+    available_bytes: 60_000_000_000,
+    used_bytes: 40_000_000_000,
+    used_percent: 40,
+    ...over,
+  };
+}
+
+function mountDisks(node: ReturnType<typeof makeNodeStatus> | null) {
+  return mount(NodeDisks, { props: { node }, global: { plugins: [getI18n()] } });
+}
+
+describe('NodeDisks', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the empty placeholder when there are no disks', () => {
+    const node = makeNodeStatus({ snapshot: null });
+    const wrapper = mountDisks(node);
+    expect(wrapper.find('[data-test="node-disks-empty"]').exists()).toBe(true);
+  });
+
+  it('renders one row per unique disk with usage + capacity', () => {
+    const node = makeNodeStatus();
+    node.snapshot!.disks = [
+      disk({ device: '/dev/sda1', total_bytes: 100, used_percent: 40 }),
+      disk({ device: '/dev/sda1', total_bytes: 100 }), // dup → filtered
+      disk({ device: '/dev/sdb1', total_bytes: 200, used_percent: 95 }),
+    ];
+    const wrapper = mountDisks(node);
+    const rows = wrapper.findAll('[data-test="disk-row"]');
+    expect(rows).toHaveLength(2);
+    expect(wrapper.text()).toContain('40%');
+    expect(wrapper.text()).toContain('95%');
+    // high usage gets the bad severity class
+    expect(wrapper.find('.disks-bar > span.bad').exists()).toBe(true);
+  });
+});

--- a/nodelite-server/web/src/components/NodeDisks.vue
+++ b/nodelite-server/web/src/components/NodeDisks.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { NodeStatus } from '@/api';
+import { fmtBytes } from '@/lib/format';
+import { uniqueDisks } from '@/lib/disks';
+
+const props = defineProps<{ node: NodeStatus | null }>();
+
+const { t } = useI18n();
+
+const disks = computed(() =>
+  uniqueDisks(props.node?.snapshot?.disks).map((d) => {
+    const pct = d.used_percent ?? 0;
+    return {
+      device: d.device,
+      mount_point: d.mount_point,
+      fs_type: d.fs_type,
+      pct,
+      barWidth: Math.max(2, Math.min(100, pct)),
+      severity: pct >= 90 ? 'bad' : pct >= 70 ? 'warn' : '',
+      capacity: `${fmtBytes(d.used_bytes) ?? '—'} / ${fmtBytes(d.total_bytes) ?? '—'}`,
+    };
+  }),
+);
+</script>
+
+<template>
+  <div data-test="node-disks">
+    <p v-if="disks.length === 0" class="placeholder" data-test="node-disks-empty">
+      {{ t('node.no_disks') }}
+    </p>
+    <table v-else class="disks-table">
+      <thead>
+        <tr>
+          <th>{{ t('node.disk.device') }}</th>
+          <th>{{ t('node.disk.mount') }}</th>
+          <th>{{ t('node.disk.filesystem') }}</th>
+          <th>{{ t('node.disk.usage') }}</th>
+          <th class="numeric">{{ t('node.disk.capacity') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(d, i) in disks" :key="i" data-test="disk-row">
+          <td>{{ d.device }}</td>
+          <td>{{ d.mount_point }}</td>
+          <td>{{ d.fs_type }}</td>
+          <td>
+            <span class="disks-bar">
+              <span :class="d.severity" :style="{ width: `${d.barWidth}%` }" />
+            </span>
+            {{ d.pct.toFixed(0) }}%
+          </td>
+          <td class="numeric">{{ d.capacity }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<style scoped>
+.placeholder {
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 18px;
+  margin: 0;
+}
+.disks-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.disks-table th,
+.disks-table td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.disks-table th {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+.disks-table .numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.disks-bar {
+  display: inline-block;
+  width: 90px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--bg-card-soft);
+  overflow: hidden;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+.disks-bar > span {
+  display: block;
+  height: 100%;
+  background: var(--accent-green);
+}
+.disks-bar > span.warn {
+  background: var(--accent-yellow);
+}
+.disks-bar > span.bad {
+  background: var(--accent-red);
+}
+</style>

--- a/nodelite-server/web/src/components/NodeInfoPanel.spec.ts
+++ b/nodelite-server/web/src/components/NodeInfoPanel.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import NodeInfoPanel from './NodeInfoPanel.vue';
+
+const FAKE_DICT = {
+  en: {
+    'node.info.title': 'Server Info',
+    'node.info.os': 'OS',
+    'node.info.kernel': 'Kernel',
+    'node.info.cpu': 'CPU',
+    'node.info.memory': 'Memory',
+    'node.info.disk': 'Disk',
+    'node.info.virtualization': 'Agent',
+    'node.info.uptime': 'Uptime',
+    'node.info.cores': '{count} Core(s)',
+    'node.uptime.days_hours': '{days}d {hours}h {minutes}m',
+    'node.uptime.hours_minutes': '{hours}h {minutes}m',
+    'node.uptime.minutes': '{minutes}m',
+    'common.unknown': 'Unknown',
+    'common.unknown_os': 'unknown os',
+    'common.not_available': 'n/a',
+  },
+  'zh-CN': { 'node.info.title': '服务器信息' },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountPanel(node: ReturnType<typeof makeNodeStatus> | null) {
+  return mount(NodeInfoPanel, { props: { node }, global: { plugins: [getI18n()] } });
+}
+
+describe('NodeInfoPanel', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders nothing in the rows when node is null', () => {
+    const wrapper = mountPanel(null);
+    expect(wrapper.findAll('[data-test="info-value"]')).toHaveLength(0);
+  });
+
+  it('renders OS / CPU / memory / disk / agent / uptime rows', () => {
+    const node = makeNodeStatus({
+      identity: {
+        ...makeNodeStatus().identity,
+        os: 'linux',
+        kernel_version: '6.1.0',
+        cpu_cores: 4,
+        cpu_model: 'Test CPU',
+        agent_version: '1.2.3',
+      },
+    });
+    const wrapper = mountPanel(node);
+    const text = wrapper.text();
+    expect(text).toContain('linux');
+    expect(text).toContain('4 Core(s) · Test CPU');
+    expect(text).toContain('1.2.3');
+    // memory total 8 GB, uptime 90000s → 1d 1h 0m
+    expect(text).toContain('7.5 GB');
+    expect(text).toContain('1d 1h 0m');
+  });
+
+  it('shows n/a when memory total is missing', () => {
+    const node = makeNodeStatus({ snapshot: null });
+    const wrapper = mountPanel(node);
+    expect(wrapper.text()).toContain('n/a');
+  });
+});

--- a/nodelite-server/web/src/components/NodeInfoPanel.vue
+++ b/nodelite-server/web/src/components/NodeInfoPanel.vue
@@ -12,9 +12,10 @@ const { t } = useI18n();
 function uptimeText(seconds: number | null | undefined): string {
   const parts = uptimeParts(seconds);
   if (!parts) return t('common.not_available');
-  if (parts.days > 0) return t('node.uptime.days_hours', parts);
-  if (parts.hours > 0) return t('node.uptime.hours_minutes', parts);
-  return t('node.uptime.minutes', parts);
+  const named = { days: parts.days, hours: parts.hours, minutes: parts.minutes };
+  if (parts.days > 0) return t('node.uptime.days_hours', named);
+  if (parts.hours > 0) return t('node.uptime.hours_minutes', named);
+  return t('node.uptime.minutes', named);
 }
 
 const rows = computed<Array<{ label: string; value: string }>>(() => {

--- a/nodelite-server/web/src/components/NodeInfoPanel.vue
+++ b/nodelite-server/web/src/components/NodeInfoPanel.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { NodeStatus } from '@/api';
+import { fmtBytes, uptimeParts } from '@/lib/format';
+import { totalDiskBytes, uniqueDisks } from '@/lib/disks';
+
+const props = defineProps<{ node: NodeStatus | null }>();
+
+const { t } = useI18n();
+
+function uptimeText(seconds: number | null | undefined): string {
+  const parts = uptimeParts(seconds);
+  if (!parts) return t('common.not_available');
+  if (parts.days > 0) return t('node.uptime.days_hours', parts);
+  if (parts.hours > 0) return t('node.uptime.hours_minutes', parts);
+  return t('node.uptime.minutes', parts);
+}
+
+const rows = computed<Array<{ label: string; value: string }>>(() => {
+  const node = props.node;
+  if (!node) return [];
+  const id = node.identity;
+  const snapshot = node.snapshot;
+  const disks = uniqueDisks(snapshot?.disks);
+  const totalDisk = totalDiskBytes(disks);
+
+  const cpuLine = id.cpu_cores
+    ? `${t('node.info.cores', { count: id.cpu_cores })}${id.cpu_model ? ` · ${id.cpu_model}` : ''}`
+    : (id.cpu_model ?? t('common.unknown'));
+
+  return [
+    { label: t('node.info.os'), value: id.os || t('common.unknown_os') },
+    { label: t('node.info.kernel'), value: id.kernel_version || t('common.unknown') },
+    { label: t('node.info.cpu'), value: cpuLine },
+    {
+      label: t('node.info.memory'),
+      value: snapshot?.memory.total_bytes
+        ? (fmtBytes(snapshot.memory.total_bytes) ?? t('common.not_available'))
+        : t('common.not_available'),
+    },
+    {
+      label: t('node.info.disk'),
+      value: totalDisk ? (fmtBytes(totalDisk) ?? t('common.not_available')) : t('common.not_available'),
+    },
+    { label: t('node.info.virtualization'), value: id.agent_version || t('common.unknown') },
+    { label: t('node.info.uptime'), value: uptimeText(snapshot?.uptime_secs) },
+  ];
+});
+</script>
+
+<template>
+  <article class="panel info-card" data-test="node-info-panel">
+    <div class="panel-head">
+      <div class="panel-title">{{ t('node.info.title') }}</div>
+    </div>
+    <div class="info-rows">
+      <template v-for="(row, i) in rows" :key="i">
+        <div class="label">{{ row.label }}</div>
+        <div class="value" data-test="info-value">{{ row.value }}</div>
+      </template>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.panel-head {
+  margin-bottom: 12px;
+}
+.panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.info-rows {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 16px;
+  font-size: 13px;
+}
+.info-rows .label {
+  color: var(--text-muted);
+}
+.info-rows .value {
+  color: var(--text-primary);
+  text-align: right;
+  word-break: break-word;
+}
+</style>

--- a/nodelite-server/web/src/components/NodeSummaryCards.spec.ts
+++ b/nodelite-server/web/src/components/NodeSummaryCards.spec.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import NodeSummaryCards from './NodeSummaryCards.vue';
+
+const FAKE_DICT = {
+  en: { 'node.disk_usage': 'Disk Usage', 'node.load': 'Load' },
+  'zh-CN': { 'node.disk_usage': '磁盘使用', 'node.load': '负载' },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountCards(node: ReturnType<typeof makeNodeStatus> | null) {
+  return mount(NodeSummaryCards, { props: { node }, global: { plugins: [getI18n()] } });
+}
+
+describe('NodeSummaryCards', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders disk percent and load average', () => {
+    // fixture: 40 GB used / 100 GB → 40%, load.one 0.3
+    const wrapper = mountCards(makeNodeStatus());
+    expect(wrapper.find('[data-test="summary-disk-pct"]').text()).toBe('40%');
+    expect(wrapper.find('[data-test="summary-load"]').text()).toBe('0.30');
+  });
+
+  it('shows dashes when there is no snapshot', () => {
+    const wrapper = mountCards(makeNodeStatus({ snapshot: null }));
+    expect(wrapper.find('[data-test="summary-disk-pct"]').text()).toBe('—');
+    expect(wrapper.find('[data-test="summary-load"]').text()).toBe('—');
+  });
+});

--- a/nodelite-server/web/src/components/NodeSummaryCards.vue
+++ b/nodelite-server/web/src/components/NodeSummaryCards.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { NodeStatus } from '@/api';
+import { fmtBytes } from '@/lib/format';
+import { totalDiskBytes, uniqueDisks, usedDiskBytes } from '@/lib/disks';
+
+const props = defineProps<{ node: NodeStatus | null }>();
+
+const { t } = useI18n();
+
+const disk = computed(() => {
+  const disks = uniqueDisks(props.node?.snapshot?.disks);
+  const total = totalDiskBytes(disks);
+  const used = usedDiskBytes(disks);
+  const pct = total ? (used / total) * 100 : null;
+  return {
+    pctText: pct == null ? '—' : `${pct.toFixed(0)}%`,
+    fillWidth: pct == null ? 0 : Math.max(2, Math.min(100, pct)),
+    severity: pct == null ? '' : pct >= 90 ? 'bad' : pct >= 70 ? 'warn' : '',
+    used: total ? (fmtBytes(used) ?? '—') : '—',
+    total: total ? (fmtBytes(total) ?? '—') : '—',
+  };
+});
+
+const load = computed(() => props.node?.snapshot?.load ?? null);
+</script>
+
+<template>
+  <div class="summary-cards" data-test="node-summary-cards">
+    <article class="panel small-card">
+      <div class="label">{{ t('node.disk_usage') }}</div>
+      <div class="value" data-test="summary-disk-pct">{{ disk.pctText }}</div>
+      <div class="progress-bar">
+        <div class="progress-fill" :class="disk.severity" :style="{ width: `${disk.fillWidth}%` }" />
+      </div>
+      <div class="sub">
+        <span class="num">{{ disk.used }}</span><span>/</span><span class="num">{{ disk.total }}</span>
+      </div>
+    </article>
+
+    <article class="panel small-card">
+      <div class="label">{{ t('node.load') }}</div>
+      <div class="value" data-test="summary-load">{{ load ? load.one.toFixed(2) : '—' }}</div>
+      <div v-if="load" class="sub">
+        <span class="num">{{ load.one.toFixed(2) }}</span>
+        <span class="num">{{ load.five.toFixed(2) }}</span>
+        <span class="num">{{ load.fifteen.toFixed(2) }}</span>
+        <span>1/5/15m</span>
+      </div>
+    </article>
+  </div>
+</template>
+
+<style scoped>
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+}
+.small-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 16px 18px;
+}
+.small-card .label {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.small-card .value {
+  font-size: 26px;
+  font-weight: 600;
+  margin: 6px 0;
+  letter-spacing: -0.02em;
+}
+.progress-bar {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--bg-card-soft);
+  overflow: hidden;
+  margin: 6px 0;
+}
+.progress-fill {
+  height: 100%;
+  background: var(--accent-green);
+}
+.progress-fill.warn {
+  background: var(--accent-yellow);
+}
+.progress-fill.bad {
+  background: var(--accent-red);
+}
+.small-card .sub {
+  display: flex;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.small-card .sub .num {
+  color: var(--text-secondary);
+}
+</style>

--- a/nodelite-server/web/src/components/OverviewCharts.spec.ts
+++ b/nodelite-server/web/src/components/OverviewCharts.spec.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import type { HistoryPoint } from '@/api';
+import OverviewCharts from './OverviewCharts.vue';
+
+const FAKE_DICT = {
+  en: {
+    'node.cpu_usage': 'CPU Usage',
+    'node.memory_usage': 'Memory Usage',
+    'node.network_traffic': 'Network Traffic',
+    'node.latency_history': 'RTT',
+    'node.chart.average': 'Avg {value}',
+    'index.node.download': 'Down',
+    'index.node.upload': 'Up',
+    'node.waiting_history': 'Waiting…',
+  },
+  'zh-CN': { 'node.cpu_usage': 'CPU 使用率' },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function hp(recorded_at: string, over: Partial<HistoryPoint> = {}): HistoryPoint {
+  return {
+    node_id: 'n',
+    recorded_at,
+    cpu_usage_percent: 10,
+    memory_used_percent: 20,
+    rx_bytes_per_sec: 100,
+    tx_bytes_per_sec: 50,
+    latency_ms: 5,
+    disk_used_percent: null,
+    ...over,
+  };
+}
+
+describe('OverviewCharts', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders four chart cards, each with a MetricChart', () => {
+    const wrapper = mount(OverviewCharts, {
+      props: {
+        node: makeNodeStatus({ snapshot: { ...makeNodeStatus().snapshot!, cpu_usage_percent: 42 } }),
+        history: [hp('2026-05-29T00:00:00Z'), hp('2026-05-29T00:01:00Z', { cpu_usage_percent: 60 })],
+      },
+      global: { plugins: [getI18n()] },
+    });
+    expect(wrapper.findAll('.chart-card')).toHaveLength(4);
+    expect(wrapper.findAll('[data-test="metric-chart"]')).toHaveLength(4);
+  });
+
+  it('shows the current cpu/memory/latency values from the snapshot', () => {
+    const wrapper = mount(OverviewCharts, {
+      props: {
+        node: makeNodeStatus({
+          snapshot: {
+            ...makeNodeStatus().snapshot!,
+            cpu_usage_percent: 42,
+            memory: { total_bytes: 100, used_bytes: 25, available_bytes: 75, swap_total_bytes: 0, swap_used_bytes: 0 },
+          },
+          latency_ms: 7,
+        }),
+        history: [hp('2026-05-29T00:00:00Z')],
+      },
+      global: { plugins: [getI18n()] },
+    });
+    expect(wrapper.find('[data-test="now-cpu"]').text()).toBe('42%');
+    expect(wrapper.find('[data-test="now-memory"]').text()).toBe('25%');
+    expect(wrapper.find('[data-test="now-rtt"]').text()).toBe('7.0 ms');
+  });
+});

--- a/nodelite-server/web/src/components/OverviewCharts.vue
+++ b/nodelite-server/web/src/components/OverviewCharts.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { HistoryPoint, NodeStatus } from '@/api';
+import { buildChartData, averageValue, type ChartPoint } from '@/lib/chart/chartData';
+import { formatChartValue, type ChartValueKind } from '@/lib/chart/format';
+import { provideChartHoverGroup } from '@/composables/useChartHoverGroup';
+import MetricChart from './MetricChart.vue';
+
+const props = defineProps<{ node: NodeStatus | null; history: HistoryPoint[] }>();
+
+const { t } = useI18n();
+
+// The four overview charts share a hover group → crosshairs link by timestamp.
+provideChartHoverGroup();
+
+const data = computed(() => buildChartData(props.history));
+
+function avgText(pts: ChartPoint[], kind: ChartValueKind): string {
+  const avg = averageValue(pts);
+  if (avg == null) return t('node.chart.average', { value: '—' });
+  return t('node.chart.average', { value: formatChartValue(avg, kind) });
+}
+
+const nowCpu = computed(() =>
+  props.node?.snapshot?.cpu_usage_percent == null
+    ? '—'
+    : formatChartValue(props.node.snapshot.cpu_usage_percent, 'percent'),
+);
+const nowMemory = computed(() => {
+  const mem = props.node?.snapshot?.memory;
+  return mem?.total_bytes ? formatChartValue((mem.used_bytes / mem.total_bytes) * 100, 'percent') : '—';
+});
+const nowLatency = computed(() =>
+  props.node?.latency_ms == null ? '—' : formatChartValue(props.node.latency_ms, 'latency'),
+);
+
+const networkSeries = computed(() => [
+  { label: t('index.node.download'), color: 'var(--chart-network-down)', points: data.value.dlPts },
+  { label: t('index.node.upload'), color: 'var(--chart-network-up)', points: data.value.upPts },
+]);
+</script>
+
+<template>
+  <div class="overview-charts" data-test="overview-charts">
+    <article class="panel chart-card">
+      <header class="chart-card__head">
+        <span class="chart-card__title">{{ t('node.cpu_usage') }}</span>
+        <span class="chart-card__meta">
+          <strong data-test="now-cpu">{{ nowCpu }}</strong>
+          <small>{{ avgText(data.cpuPts, 'percent') }}</small>
+        </span>
+      </header>
+      <MetricChart
+        :points="data.cpuPts"
+        value-kind="percent"
+        color="var(--chart-cpu)"
+        :label="t('node.cpu_usage')"
+        :min-value="0"
+      />
+    </article>
+
+    <article class="panel chart-card">
+      <header class="chart-card__head">
+        <span class="chart-card__title">{{ t('node.memory_usage') }}</span>
+        <span class="chart-card__meta">
+          <strong data-test="now-memory">{{ nowMemory }}</strong>
+          <small>{{ avgText(data.memPts, 'percent') }}</small>
+        </span>
+      </header>
+      <MetricChart
+        :points="data.memPts"
+        value-kind="percent"
+        color="var(--chart-memory)"
+        :label="t('node.memory_usage')"
+        :min-value="0"
+      />
+    </article>
+
+    <article class="panel chart-card">
+      <header class="chart-card__head">
+        <span class="chart-card__title">{{ t('node.network_traffic') }}</span>
+      </header>
+      <MetricChart :series="networkSeries" value-kind="rate" :min-value="0" />
+    </article>
+
+    <article class="panel chart-card chart-card--rtt">
+      <header class="chart-card__head">
+        <span class="chart-card__title">{{ t('node.latency_history') }}</span>
+        <span class="chart-card__meta">
+          <strong data-test="now-rtt">{{ nowLatency }}</strong>
+          <small>{{ avgText(data.rttPts, 'latency') }}</small>
+        </span>
+      </header>
+      <MetricChart
+        :points="data.rttPts"
+        value-kind="latency"
+        color="var(--chart-latency)"
+        :label="t('node.latency_history')"
+        :min-value="0"
+        :height="96"
+      />
+    </article>
+  </div>
+</template>
+
+<style scoped>
+.overview-charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+}
+.chart-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 16px 18px;
+}
+.chart-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.chart-card__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.chart-card__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+.chart-card__meta strong {
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+}
+.chart-card__meta small {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+</style>

--- a/nodelite-server/web/src/lib/disks.spec.ts
+++ b/nodelite-server/web/src/lib/disks.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { DiskUsage } from '@/api';
+import { totalDiskBytes, uniqueDisks, usedDiskBytes } from './disks';
+
+function disk(over: Partial<DiskUsage>): DiskUsage {
+  return {
+    device: '/dev/sda1',
+    mount_point: '/',
+    fs_type: 'ext4',
+    total_bytes: 100,
+    available_bytes: 60,
+    used_bytes: 40,
+    used_percent: 40,
+    ...over,
+  };
+}
+
+describe('uniqueDisks', () => {
+  it('dedupes by device + total size', () => {
+    const out = uniqueDisks([
+      disk({ device: '/dev/sda1', total_bytes: 100 }),
+      disk({ device: '/dev/sda1', total_bytes: 100 }), // dup
+      disk({ device: '/dev/sdb1', total_bytes: 200 }),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('returns [] for undefined', () => {
+    expect(uniqueDisks(undefined)).toEqual([]);
+  });
+});
+
+describe('totalDiskBytes / usedDiskBytes', () => {
+  it('sums across disks', () => {
+    const disks = [disk({ total_bytes: 100, used_bytes: 40 }), disk({ total_bytes: 200, used_bytes: 50 })];
+    expect(totalDiskBytes(disks)).toBe(300);
+    expect(usedDiskBytes(disks)).toBe(90);
+  });
+});

--- a/nodelite-server/web/src/lib/disks.ts
+++ b/nodelite-server/web/src/lib/disks.ts
@@ -1,0 +1,24 @@
+/**
+ * Disk helpers ported from node.html:1838. The agent can report the same
+ * device twice; dedupe by device + total size. Pure.
+ */
+
+import type { DiskUsage } from '@/api';
+
+export function uniqueDisks(disks: DiskUsage[] | undefined): DiskUsage[] {
+  const seen = new Set<string>();
+  return (Array.isArray(disks) ? disks : []).filter((disk) => {
+    const key = `${disk.device || ''}:${disk.total_bytes || 0}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function totalDiskBytes(disks: DiskUsage[]): number {
+  return disks.reduce((sum, d) => sum + (d.total_bytes || 0), 0);
+}
+
+export function usedDiskBytes(disks: DiskUsage[]): number {
+  return disks.reduce((sum, d) => sum + (d.used_bytes || 0), 0);
+}

--- a/nodelite-server/web/src/stores/detailHistory.spec.ts
+++ b/nodelite-server/web/src/stores/detailHistory.spec.ts
@@ -1,0 +1,109 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiAbortError, ApiError } from '@/api/client';
+import { apiClient } from '@/api';
+import {
+  useDetailHistoryStore,
+  NODE_HISTORY_REFRESH_MS,
+  RETENTION_WINDOW_HOURS,
+  OVERVIEW_HISTORY_MAX_POINTS,
+} from './detailHistory';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, nodeHistory: vi.fn() },
+  };
+});
+
+const mockHistory = vi.mocked(apiClient.nodeHistory);
+
+describe('useDetailHistoryStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockHistory.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('loads overview history with the 14-day window', async () => {
+    mockHistory.mockResolvedValueOnce([]);
+    const store = useDetailHistoryStore();
+    await store.load('a');
+    expect(mockHistory).toHaveBeenCalledWith('a', {
+      windowHours: RETENTION_WINDOW_HOURS,
+      maxPoints: OVERVIEW_HISTORY_MAX_POINTS,
+    });
+  });
+
+  it('clears stale points when switching nodes', async () => {
+    mockHistory.mockResolvedValueOnce([
+      { node_id: 'a', recorded_at: '2026-05-29T00:00:00Z', cpu_usage_percent: 1, memory_used_percent: 2, rx_bytes_per_sec: null, tx_bytes_per_sec: null, latency_ms: null, disk_used_percent: null },
+    ]);
+    const store = useDetailHistoryStore();
+    await store.load('a');
+    expect(store.points.length).toBe(1);
+
+    let resolve: (v: never[]) => void = () => {};
+    mockHistory.mockReturnValueOnce(new Promise((r) => (resolve = r)));
+    const pending = store.load('b');
+    expect(store.nodeId).toBe('b');
+    expect(store.points).toEqual([]);
+    resolve([]);
+    await pending;
+  });
+
+  it('throttles refresh to >=15s but refetches once stale', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    mockHistory.mockResolvedValue([]);
+    const store = useDetailHistoryStore();
+
+    await store.load('a');
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(1_000_000 + NODE_HISTORY_REFRESH_MS - 1);
+    await store.refresh();
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(1_000_000 + NODE_HISTORY_REFRESH_MS + 1);
+    await store.refresh();
+    expect(mockHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('fetches the new node when switched mid-flight (id-aware guard)', async () => {
+    let resolveA: (v: never[]) => void = () => {};
+    mockHistory.mockReturnValueOnce(new Promise((r) => (resolveA = r))).mockResolvedValueOnce([]);
+    const store = useDetailHistoryStore();
+    const a = store.load('a');
+    const b = store.load('b');
+    expect(mockHistory).toHaveBeenCalledTimes(2);
+    await b;
+    expect(store.nodeId).toBe('b');
+    resolveA([]);
+    await a;
+  });
+
+  it('records non-abort errors and swallows ApiAbortError', async () => {
+    mockHistory.mockRejectedValueOnce(new ApiError(503, 'down'));
+    const store = useDetailHistoryStore();
+    await store.load('a');
+    expect(store.error).toBeInstanceOf(ApiError);
+
+    setActivePinia(createPinia());
+    const store2 = useDetailHistoryStore();
+    mockHistory.mockRejectedValueOnce(new ApiAbortError('redirect'));
+    await store2.load('a');
+    expect(store2.error).toBeNull();
+  });
+
+  it('refresh is a no-op with no active node', async () => {
+    const store = useDetailHistoryStore();
+    await store.refresh();
+    expect(mockHistory).not.toHaveBeenCalled();
+  });
+});

--- a/nodelite-server/web/src/stores/detailHistory.spec.ts
+++ b/nodelite-server/web/src/stores/detailHistory.spec.ts
@@ -106,4 +106,29 @@ describe('useDetailHistoryStore', () => {
     await store.refresh();
     expect(mockHistory).not.toHaveBeenCalled();
   });
+
+  it('loadIfStale throttles same-node re-entry but fetches on node switch', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000_000);
+    mockHistory.mockResolvedValue([]);
+    const store = useDetailHistoryStore();
+
+    await store.loadIfStale('a'); // first load
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+
+    // same node, within throttle window → no refetch (the parity fix)
+    vi.setSystemTime(2_000_000 + NODE_HISTORY_REFRESH_MS - 1);
+    await store.loadIfStale('a');
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+
+    // different node → always fetches
+    await store.loadIfStale('b');
+    expect(mockHistory).toHaveBeenCalledTimes(2);
+    expect(store.nodeId).toBe('b');
+
+    // same node again but now stale → refetches
+    vi.setSystemTime(2_000_000 + NODE_HISTORY_REFRESH_MS * 4);
+    await store.loadIfStale('b');
+    expect(mockHistory).toHaveBeenCalledTimes(3);
+  });
 });

--- a/nodelite-server/web/src/stores/detailHistory.ts
+++ b/nodelite-server/web/src/stores/detailHistory.ts
@@ -50,13 +50,35 @@ export const useDetailHistoryStore = defineStore('detailHistory', () => {
     }
   }
 
-  /** Switch to a node (clears stale points) and fetch its overview history. */
+  function switchTo(id: string): boolean {
+    if (nodeId.value === id) return false;
+    nodeId.value = id;
+    points.value = [];
+    error.value = null;
+    fetchedAt.value = 0;
+    return true;
+  }
+
+  /** Switch to a node (clears stale points) and force-fetch its history. */
   async function load(id: string): Promise<void> {
-    if (nodeId.value !== id) {
-      nodeId.value = id;
-      points.value = [];
-      error.value = null;
-      fetchedAt.value = 0;
+    switchTo(id);
+    await fetchFor(id);
+  }
+
+  /**
+   * Switch-or-throttled load for tab entry: a new node always fetches; the
+   * same node only refetches once >=15s stale. Mirrors legacy
+   * fetchOverviewHistory, which throttles regardless of caller — so
+   * re-entering a history tab within the window doesn't re-pull the 14-day
+   * series.
+   */
+  async function loadIfStale(id: string): Promise<void> {
+    if (switchTo(id)) {
+      await fetchFor(id);
+      return;
+    }
+    if (fetchedAt.value > 0 && Date.now() - fetchedAt.value < NODE_HISTORY_REFRESH_MS) {
+      return;
     }
     await fetchFor(id);
   }
@@ -71,5 +93,5 @@ export const useDetailHistoryStore = defineStore('detailHistory', () => {
     await fetchFor(id);
   }
 
-  return { nodeId, points, loading, error, load, refresh };
+  return { nodeId, points, loading, error, load, loadIfStale, refresh };
 });

--- a/nodelite-server/web/src/stores/detailHistory.ts
+++ b/nodelite-server/web/src/stores/detailHistory.ts
@@ -1,0 +1,75 @@
+import { defineStore } from 'pinia';
+import { ref, shallowRef } from 'vue';
+import { apiClient, type HistoryPoint } from '@/api';
+import { ApiAbortError } from '@/api/client';
+
+/** Node-detail overview history window, matching legacy node.html:1414-1418. */
+export const RETENTION_WINDOW_HOURS = 24 * 14; // 336h / 14 days
+export const OVERVIEW_HISTORY_MAX_POINTS = 1440;
+export const NODE_HISTORY_REFRESH_MS = 15 * 1000;
+
+/**
+ * Overview-history for the active node (the 14-day low-res sample that
+ * feeds the detail charts). Single active node; like nodeStatus, switching
+ * ids clears stale points and an id-aware in-flight guard dedups same-node
+ * polls without swallowing a node switch. Refetch is throttled to >=15s.
+ */
+export const useDetailHistoryStore = defineStore('detailHistory', () => {
+  const nodeId = ref<string | null>(null);
+  const points = shallowRef<HistoryPoint[]>([]);
+  const loading = ref(false);
+  const error = ref<Error | null>(null);
+  const fetchedAt = ref(0);
+  const inFlightId = ref<string | null>(null);
+
+  async function fetchFor(id: string): Promise<void> {
+    if (inFlightId.value === id) return;
+    inFlightId.value = id;
+    loading.value = true;
+    error.value = null;
+    try {
+      const result = await apiClient.nodeHistory(id, {
+        windowHours: RETENTION_WINDOW_HOURS,
+        maxPoints: OVERVIEW_HISTORY_MAX_POINTS,
+      });
+      if (nodeId.value === id) {
+        points.value = result;
+        fetchedAt.value = Date.now();
+      }
+    } catch (e) {
+      if (e instanceof ApiAbortError) return;
+      if (nodeId.value === id) {
+        error.value = e instanceof Error ? e : new Error(String(e));
+        fetchedAt.value = Date.now();
+      }
+    } finally {
+      if (inFlightId.value === id) {
+        inFlightId.value = null;
+        loading.value = false;
+      }
+    }
+  }
+
+  /** Switch to a node (clears stale points) and fetch its overview history. */
+  async function load(id: string): Promise<void> {
+    if (nodeId.value !== id) {
+      nodeId.value = id;
+      points.value = [];
+      error.value = null;
+      fetchedAt.value = 0;
+    }
+    await fetchFor(id);
+  }
+
+  /** Poll-driven refresh of the current node, throttled to >=15s. */
+  async function refresh(): Promise<void> {
+    const id = nodeId.value;
+    if (id === null) return;
+    if (fetchedAt.value > 0 && Date.now() - fetchedAt.value < NODE_HISTORY_REFRESH_MS) {
+      return;
+    }
+    await fetchFor(id);
+  }
+
+  return { nodeId, points, loading, error, load, refresh };
+});

--- a/nodelite-server/web/src/styles/theme.css
+++ b/nodelite-server/web/src/styles/theme.css
@@ -28,6 +28,12 @@
   --accent-purple: #a855f7;
   --map-land-dot: rgba(148, 163, 184, 0.48);
   --map-land-stroke: rgba(15, 23, 42, 0.34);
+  /* Chart series colors (node.html:75-79; theme-independent). */
+  --chart-cpu: #22c55e;
+  --chart-memory: #3b82f6;
+  --chart-network-down: #22c55e;
+  --chart-network-up: #a855f7;
+  --chart-latency: #eab308;
   font-family: 'Inter', 'PingFang SC', 'Helvetica Neue', 'Segoe UI', system-ui, -apple-system, sans-serif;
 }
 

--- a/nodelite-server/web/src/views/NodeDetailView.spec.ts
+++ b/nodelite-server/web/src/views/NodeDetailView.spec.ts
@@ -13,11 +13,16 @@ vi.mock('@/api', async () => {
   const actual = await vi.importActual<typeof import('@/api')>('@/api');
   return {
     ...actual,
-    apiClient: { ...actual.apiClient, nodeStatus: vi.fn() },
+    apiClient: {
+      ...actual.apiClient,
+      nodeStatus: vi.fn(),
+      nodeHistory: vi.fn().mockResolvedValue([]),
+    },
   };
 });
 
 const mockStatus = vi.mocked(apiClient.nodeStatus);
+const mockHistory = vi.mocked(apiClient.nodeHistory);
 
 const FAKE_DICT = {
   en: {
@@ -30,6 +35,37 @@ const FAKE_DICT = {
     'node.meta.ip': 'IP: {ip}',
     'node.meta.uptime_days': 'Up {days}d',
     'node.meta.uptime_hours': 'Up {hours}h',
+    'node.info.title': 'Server Info',
+    'node.info.os': 'OS',
+    'node.info.kernel': 'Kernel',
+    'node.info.cpu': 'CPU',
+    'node.info.memory': 'Memory',
+    'node.info.disk': 'Disk',
+    'node.info.virtualization': 'Agent',
+    'node.info.uptime': 'Uptime',
+    'node.info.cores': '{count} Core(s)',
+    'node.uptime.days_hours': '{days}d {hours}h {minutes}m',
+    'node.uptime.hours_minutes': '{hours}h {minutes}m',
+    'node.uptime.minutes': '{minutes}m',
+    'node.disk_usage': 'Disk Usage',
+    'node.load': 'Load',
+    'node.no_disks': 'No disk metrics.',
+    'node.disk.device': 'Device',
+    'node.disk.mount': 'Mount',
+    'node.disk.filesystem': 'FS',
+    'node.disk.usage': 'Usage',
+    'node.disk.capacity': 'Capacity',
+    'node.cpu_usage': 'CPU Usage',
+    'node.memory_usage': 'Memory Usage',
+    'node.network_traffic': 'Network Traffic',
+    'node.latency_history': 'RTT',
+    'node.chart.average': 'Avg {value}',
+    'node.waiting_history': 'Waiting…',
+    'index.node.download': 'Down',
+    'index.node.upload': 'Up',
+    'common.unknown': 'Unknown',
+    'common.unknown_os': 'unknown os',
+    'common.not_available': 'n/a',
     'common.online': 'Online',
     'common.offline': 'Offline',
     'common.latency_warn': 'High latency',
@@ -128,5 +164,29 @@ describe('NodeDetailView', () => {
     await flushPromises();
     expect(wrapper.find('[data-test="node-tab-pane"]').attributes('data-pane')).toBe('monitor');
     expect(wrapper.find('[data-test="tab-monitor"]').classes()).toContain('active');
+  });
+
+  it('renders overview content (info panel + summary + charts) and loads history', async () => {
+    const { wrapper } = await mountDetail('srv-1');
+    expect(wrapper.find('[data-test="node-info-panel"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="node-summary-cards"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="overview-charts"]').exists()).toBe(true);
+    // overview is a history tab → overview history fetched on mount
+    expect(mockHistory).toHaveBeenCalledWith('srv-1', expect.objectContaining({ windowHours: 336 }));
+  });
+
+  it('shows the network pane on the network tab', async () => {
+    const { wrapper, router } = await mountDetail('srv-1');
+    await router.replace({ hash: '#network' });
+    await flushPromises();
+    expect(wrapper.find('[data-test="network-pane"]').exists()).toBe(true);
+  });
+
+  it('shows disks on the hardware tab', async () => {
+    const { wrapper, router } = await mountDetail('srv-1');
+    await router.replace({ hash: '#hardware' });
+    await flushPromises();
+    expect(wrapper.find('[data-test="node-disks"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="node-info-panel"]').exists()).toBe(true);
   });
 });

--- a/nodelite-server/web/src/views/NodeDetailView.vue
+++ b/nodelite-server/web/src/views/NodeDetailView.vue
@@ -2,11 +2,20 @@
 import { computed, onMounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import AppLayout from '@/components/AppLayout.vue';
+import NodeInfoPanel from '@/components/NodeInfoPanel.vue';
+import NodeSummaryCards from '@/components/NodeSummaryCards.vue';
+import OverviewCharts from '@/components/OverviewCharts.vue';
+import NodeDisks from '@/components/NodeDisks.vue';
+import MetricChart from '@/components/MetricChart.vue';
 import { usePolling } from '@/composables/usePolling';
 import { nodeStatusKey } from '@/lib/map/projection';
 import { ipFromNode, locationFromNode } from '@/lib/nodeMeta';
-import { uptimeParts } from '@/lib/format';
+import { uptimeParts, fmtBytes, fmtRate } from '@/lib/format';
+import { buildChartData } from '@/lib/chart/chartData';
+import { formatChartValue } from '@/lib/chart/format';
+import { useI18n } from 'vue-i18n';
 import { useNodeStatusStore } from '@/stores/nodeStatus';
+import { useDetailHistoryStore } from '@/stores/detailHistory';
 
 const NODE_DETAIL_REFRESH_MS = 5000;
 
@@ -21,7 +30,9 @@ function isTabId(value: string): value is TabId {
 
 const route = useRoute();
 const router = useRouter();
+const { t } = useI18n();
 const store = useNodeStatusStore();
+const historyStore = useDetailHistoryStore();
 
 const nodeId = computed(() => String(route.params.id ?? ''));
 const node = computed(() => store.data);
@@ -56,16 +67,55 @@ const ip = computed(() => (node.value ? ipFromNode(node.value) : null));
 const location = computed(() => (node.value ? locationFromNode(node.value) : null));
 const uptime = computed(() => uptimeParts(node.value?.snapshot?.uptime_secs));
 
+// Tabs that render history charts; only those trigger the overview-history
+// fetch (mirrors legacy detailHistoryNeedsData; monitor lands in 3d).
+const historyNeeded = computed(
+  () => activeTab.value === 'overview' || activeTab.value === 'network',
+);
+
+// Network tab values (legacy renderSummaryCards net block).
+const net = computed(() => {
+  const n = node.value?.snapshot?.network;
+  return {
+    downRate: fmtRate(n?.rx_bytes_per_sec) ?? '—',
+    upRate: fmtRate(n?.tx_bytes_per_sec) ?? '—',
+    downTotal: fmtBytes(n?.total_rx_bytes) ?? '—',
+    upTotal: fmtBytes(n?.total_tx_bytes) ?? '—',
+    latency: node.value?.latency_ms == null ? '—' : formatChartValue(node.value.latency_ms, 'latency'),
+  };
+});
+const networkSeries = computed(() => {
+  const data = buildChartData(historyStore.points);
+  return [
+    { label: t('index.node.download'), color: 'var(--chart-network-down)', points: data.dlPts },
+    { label: t('index.node.upload'), color: 'var(--chart-network-up)', points: data.upPts },
+  ];
+});
+
+function ensureHistory(): void {
+  if (historyNeeded.value && nodeId.value) void historyStore.load(nodeId.value);
+}
+
 onMounted(() => {
   void store.load(nodeId.value);
+  ensureHistory();
 });
 
-// Navigating between nodes (same component, new :id) reloads.
+// Navigating between nodes (same component, new :id) reloads both.
 watch(nodeId, (id) => {
   if (id) void store.load(id);
+  ensureHistory();
 });
 
-usePolling(() => store.refresh(), NODE_DETAIL_REFRESH_MS);
+// Switching into a history tab lazily loads the overview history.
+watch(historyNeeded, (needed) => {
+  if (needed) ensureHistory();
+});
+
+usePolling(() => {
+  void store.refresh();
+  if (historyNeeded.value) void historyStore.refresh();
+}, NODE_DETAIL_REFRESH_MS);
 </script>
 
 <template>
@@ -110,7 +160,48 @@ usePolling(() => store.refresh(), NODE_DETAIL_REFRESH_MS);
       </nav>
 
       <section class="tab-pane" :data-pane="activeTab" data-test="node-tab-pane">
-        <p class="placeholder">{{ activeTab }} — coming in Stage 3c/3d</p>
+        <template v-if="activeTab === 'overview'">
+          <div class="overview-grid">
+            <NodeInfoPanel :node="node" />
+            <NodeSummaryCards :node="node" />
+          </div>
+          <OverviewCharts :node="node" :history="historyStore.points" />
+        </template>
+
+        <template v-else-if="activeTab === 'network'">
+          <div class="net-stats" data-test="network-pane">
+            <div class="net-stat">
+              <span class="net-stat__label">↓ {{ $t('index.node.download') }}</span>
+              <strong>{{ net.downRate }}</strong>
+              <small>total {{ net.downTotal }}</small>
+            </div>
+            <div class="net-stat">
+              <span class="net-stat__label">↑ {{ $t('index.node.upload') }}</span>
+              <strong>{{ net.upRate }}</strong>
+              <small>total {{ net.upTotal }}</small>
+            </div>
+            <div class="net-stat">
+              <span class="net-stat__label">{{ $t('node.latency_history') }}</span>
+              <strong>{{ net.latency }}</strong>
+            </div>
+          </div>
+          <article class="panel">
+            <MetricChart :series="networkSeries" value-kind="rate" :min-value="0" :height="240" />
+          </article>
+        </template>
+
+        <template v-else-if="activeTab === 'hardware'">
+          <div class="overview-grid">
+            <NodeInfoPanel :node="node" />
+          </div>
+          <article class="panel">
+            <NodeDisks :node="node" />
+          </article>
+        </template>
+
+        <p v-else class="placeholder" data-test="pane-placeholder">
+          {{ activeTab }} — coming in Stage 3d
+        </p>
       </section>
     </div>
   </AppLayout>
@@ -197,5 +288,50 @@ usePolling(() => store.refresh(), NODE_DETAIL_REFRESH_MS);
 .placeholder {
   color: var(--text-muted);
   font-size: 13px;
+}
+.overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+  gap: 14px;
+  margin-bottom: 14px;
+  align-items: start;
+}
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 16px 18px;
+}
+.net-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+  margin-bottom: 14px;
+}
+.net-stat {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.net-stat__label {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.net-stat strong {
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+}
+.net-stat small {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+@media (max-width: 880px) {
+  .overview-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 </style>

--- a/nodelite-server/web/src/views/NodeDetailView.vue
+++ b/nodelite-server/web/src/views/NodeDetailView.vue
@@ -93,7 +93,9 @@ const networkSeries = computed(() => {
 });
 
 function ensureHistory(): void {
-  if (historyNeeded.value && nodeId.value) void historyStore.load(nodeId.value);
+  // loadIfStale (not load) so re-entering a history tab within the throttle
+  // window reuses the cached series, matching legacy fetchOverviewHistory.
+  if (historyNeeded.value && nodeId.value) void historyStore.loadIfStale(nodeId.value);
 }
 
 onMounted(() => {


### PR DESCRIPTION
## Summary

Third Stage 3 PR: fills the NodeDetail overview, network, and hardware tabs with real content on top of the 3b chart engine. 4 commits, squash on merge. Monitor (brush/zoom) + logs land in 3d.

### What's in

- **`detailHistory` store** — fetches the active node's 14-day overview history (336h / 1440 points, `node.html:1414`) that feeds the charts. Same single-active-node pattern as `nodeStatus`: id-switch clears stale points, id-aware in-flight guard, `refresh()` throttled to ≥15s.
- **`lib/disks.ts`** — pure `uniqueDisks` (dedupe by device+size) + total/used sums.
- **`NodeInfoPanel`** — server info rows (os/kernel/cpu/memory/disk/agent/uptime); reused in overview + hardware.
- **`NodeDisks`** — disks table with usage bars + severity (warn≥70 / bad≥90).
- **`NodeSummaryCards`** — disk-usage progress + load (1/5/15m) cards.
- **`OverviewCharts`** — the four detail charts (cpu/mem percent, network down/up rate, rtt latency) from `buildChartData`, each with a now/avg header, **all sharing one hover group** so crosshairs link by timestamp. Options mirror `renderOverviewCharts` (`minValue:0`).
- **`theme.css`** — added the `--chart-*` series colours (theme-independent, `node.html:75-79`).
- **NodeDetailView wiring** — overview = info + summary + charts; network = rate/total/latency stats + a network chart; hardware = info + disks. **Lazy history**: loads only on a history tab (overview/network), reloads on node switch, refreshed by the 5s poll (store throttle bounds actual fetches) — mirrors `detailHistoryNeedsData` / `refreshTabData`.

### Notes

- jsdom has no layout, so MetricChart sizes to its 600px fallback in tests; chart pixel math is covered by the 3b pure-fn specs. Component specs assert structure + the now-values + that history loads on a history tab.
- Zoom/clip chart controls + the monitor brush are 3d (the overview chart cards render without them here).

## Test plan

- [x] `pnpm lint` / `typecheck` / `test` (218 tests, 39 files) / `build` — all clean
- [ ] Manual smoke (`cargo run` + `pnpm dev`): open a node → overview shows info/summary + 4 charts with live values; hover shows a linked crosshair across the cpu/mem/net/rtt charts; network tab shows rates + chart; hardware tab shows the disks table; numbers match the dashboard card

## Next

- **3d** — monitor (brush window select + zoom modal) + logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)