### PR TITLE
Stage 3d — NodeDetail monitor + logs tabs (completes Stage 3)

### DIFF
--- a/nodelite-server/web/src/components/ChartModal.spec.ts
+++ b/nodelite-server/web/src/components/ChartModal.spec.ts
@@ -33,17 +33,9 @@ describe('ChartModal', () => {
     vi.unstubAllGlobals();
   });
 
-  it('renders nothing when closed', () => {
+  it('renders the chart + title and emits close (parent gates visibility)', async () => {
     const wrapper = mount(ChartModal, {
-      props: { open: false, title: 'CPU', points: pts([10, 90]), valueKind: 'percent' },
-      global: { plugins: [getI18n()] },
-    });
-    expect(wrapper.find('[data-test="chart-modal"]').exists()).toBe(false);
-  });
-
-  it('renders the chart + title when open and emits close', async () => {
-    const wrapper = mount(ChartModal, {
-      props: { open: true, title: 'CPU', points: pts([10, 90]), valueKind: 'percent', color: 'var(--chart-cpu)' },
+      props: { title: 'CPU', points: pts([10, 90]), valueKind: 'percent', color: 'var(--chart-cpu)' },
       global: { plugins: [getI18n()] },
     });
     expect(wrapper.find('[data-test="chart-modal"]').exists()).toBe(true);

--- a/nodelite-server/web/src/components/ChartModal.spec.ts
+++ b/nodelite-server/web/src/components/ChartModal.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import type { ChartPoint } from '@/lib/chart/chartData';
+import ChartModal from './ChartModal.vue';
+
+const FAKE_DICT = { en: { 'node.waiting_history': 'Waiting…' }, 'zh-CN': {} };
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function pts(values: number[]): ChartPoint[] {
+  return values.map((value, i) => ({ ts: i * 60_000, value }));
+}
+
+describe('ChartModal', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders nothing when closed', () => {
+    const wrapper = mount(ChartModal, {
+      props: { open: false, title: 'CPU', points: pts([10, 90]), valueKind: 'percent' },
+      global: { plugins: [getI18n()] },
+    });
+    expect(wrapper.find('[data-test="chart-modal"]').exists()).toBe(false);
+  });
+
+  it('renders the chart + title when open and emits close', async () => {
+    const wrapper = mount(ChartModal, {
+      props: { open: true, title: 'CPU', points: pts([10, 90]), valueKind: 'percent', color: 'var(--chart-cpu)' },
+      global: { plugins: [getI18n()] },
+    });
+    expect(wrapper.find('[data-test="chart-modal"]').exists()).toBe(true);
+    expect(wrapper.find('.chart-modal__title').text()).toBe('CPU');
+    expect(wrapper.find('[data-test="metric-chart"]').exists()).toBe(true);
+
+    await wrapper.find('[data-test="chart-modal-close"]').trigger('click');
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+});

--- a/nodelite-server/web/src/components/ChartModal.vue
+++ b/nodelite-server/web/src/components/ChartModal.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { ChartPoint } from '@/lib/chart/chartData';
 import type { ChartValueKind } from '@/lib/chart/format';
 import type { MultiSeriesInput } from '@/lib/chart/svgModel';
 import MetricChart from './MetricChart.vue';
 
-defineProps<{
+const props = defineProps<{
   open: boolean;
   title: string;
   points?: ChartPoint[];
@@ -14,6 +15,18 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{ close: [] }>();
+
+// Only include points OR series — exactOptionalPropertyTypes forbids passing
+// an explicit undefined to an optional prop, so omit the absent one.
+const chartProps = computed(() => ({
+  valueKind: props.valueKind,
+  color: props.color ?? 'var(--accent-blue)',
+  label: props.title,
+  minValue: 0,
+  height: 360,
+  ...(props.points ? { points: props.points } : {}),
+  ...(props.series ? { series: props.series } : {}),
+}));
 </script>
 
 <template>
@@ -32,15 +45,7 @@ const emit = defineEmits<{ close: [] }>();
           ✕
         </button>
       </header>
-      <MetricChart
-        :points="points"
-        :series="series"
-        :value-kind="valueKind"
-        :color="color ?? 'var(--accent-blue)'"
-        :label="title"
-        :min-value="0"
-        :height="360"
-      />
+      <MetricChart v-bind="chartProps" />
     </div>
   </div>
 </template>

--- a/nodelite-server/web/src/components/ChartModal.vue
+++ b/nodelite-server/web/src/components/ChartModal.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import type { ChartPoint } from '@/lib/chart/chartData';
+import type { ChartValueKind } from '@/lib/chart/format';
+import type { MultiSeriesInput } from '@/lib/chart/svgModel';
+import MetricChart from './MetricChart.vue';
+
+defineProps<{
+  open: boolean;
+  title: string;
+  points?: ChartPoint[];
+  series?: MultiSeriesInput[];
+  valueKind: ChartValueKind;
+  color?: string;
+}>();
+
+const emit = defineEmits<{ close: [] }>();
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="chart-modal"
+    data-test="chart-modal"
+    role="dialog"
+    aria-modal="true"
+    @click.self="emit('close')"
+  >
+    <div class="chart-modal__panel">
+      <header class="chart-modal__head">
+        <h2 class="chart-modal__title">{{ title }}</h2>
+        <button type="button" class="chart-modal__close" data-test="chart-modal-close" @click="emit('close')">
+          ✕
+        </button>
+      </header>
+      <MetricChart
+        :points="points"
+        :series="series"
+        :value-kind="valueKind"
+        :color="color ?? 'var(--accent-blue)'"
+        :label="title"
+        :min-value="0"
+        :height="360"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chart-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 16, 0.62);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  z-index: 50;
+}
+.chart-modal__panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 18px;
+  padding: 20px 22px;
+  width: min(960px, 100%);
+}
+.chart-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+.chart-modal__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+.chart-modal__close {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--border-soft);
+  background: var(--bg-card-soft);
+  color: var(--text-muted);
+}
+.chart-modal__close:hover {
+  color: var(--text-primary);
+}
+</style>

--- a/nodelite-server/web/src/components/ChartModal.vue
+++ b/nodelite-server/web/src/components/ChartModal.vue
@@ -5,8 +5,10 @@ import type { ChartValueKind } from '@/lib/chart/format';
 import type { MultiSeriesInput } from '@/lib/chart/svgModel';
 import MetricChart from './MetricChart.vue';
 
+// Visibility is owned by the parent via v-if (it already gates on having a
+// selected metric), so there's no `open` prop here — the modal renders its
+// content whenever mounted.
 const props = defineProps<{
-  open: boolean;
   title: string;
   points?: ChartPoint[];
   series?: MultiSeriesInput[];
@@ -31,7 +33,6 @@ const chartProps = computed(() => ({
 
 <template>
   <div
-    v-if="open"
     class="chart-modal"
     data-test="chart-modal"
     role="dialog"

--- a/nodelite-server/web/src/components/LogPanel.spec.ts
+++ b/nodelite-server/web/src/components/LogPanel.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { makeLogEntry } from '@/api/__fixtures__/nodes';
+import LogPanel from './LogPanel.vue';
+
+const FAKE_DICT = {
+  en: {
+    'node.logs.empty': 'No logs yet.',
+    'node.logs.load_failed': 'Failed: {error}',
+    'node.logs.level_info': 'Info',
+    'node.logs.level_warn': 'Warn',
+    'node.logs.level_error': 'Error',
+  },
+  'zh-CN': { 'node.logs.empty': '暂无日志。' },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountPanel(props: { entries: ReturnType<typeof makeLogEntry>[]; error: Error | null }) {
+  return mount(LogPanel, { props, global: { plugins: [getI18n()] } });
+}
+
+describe('LogPanel', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the empty state with no entries', () => {
+    const wrapper = mountPanel({ entries: [], error: null });
+    expect(wrapper.find('[data-test="log-empty"]').exists()).toBe(true);
+  });
+
+  it('shows the error state', () => {
+    const wrapper = mountPanel({ entries: [], error: new Error('boom') });
+    expect(wrapper.find('[data-test="log-error"]').text()).toContain('boom');
+  });
+
+  it('renders entries newest-first with level classes', () => {
+    const wrapper = mountPanel({
+      entries: [
+        makeLogEntry({ level: 'info', message: 'first' }),
+        makeLogEntry({ level: 'error', message: 'second' }),
+      ],
+      error: null,
+    });
+    const entries = wrapper.findAll('[data-test="log-entry"]');
+    expect(entries).toHaveLength(2);
+    // reversed → 'second' (error) first
+    expect(entries[0]!.text()).toContain('second');
+    expect(entries[0]!.find('.log-level').classes()).toContain('error');
+    expect(entries[1]!.text()).toContain('first');
+  });
+});

--- a/nodelite-server/web/src/components/LogPanel.vue
+++ b/nodelite-server/web/src/components/LogPanel.vue
@@ -21,7 +21,8 @@ function fmtDateTime(value: string): string {
 // Newest first, matching legacy renderAgentLogs (reversed).
 const rows = computed(() =>
   [...props.entries].reverse().map((entry, i) => ({
-    key: i,
+    // Stable-ish key from the timestamp; index disambiguates same-ms entries.
+    key: `${entry.occurred_at}#${i}`,
     level: entry.level,
     levelLabel: t(levelLabelKey(entry.level)),
     time: fmtDateTime(entry.occurred_at),

--- a/nodelite-server/web/src/components/LogPanel.vue
+++ b/nodelite-server/web/src/components/LogPanel.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { AgentLogEntry, LogLevel } from '@/api';
+
+const props = defineProps<{ entries: AgentLogEntry[]; error: Error | null }>();
+
+const { t, locale } = useI18n();
+
+function levelLabelKey(level: LogLevel): string {
+  if (level === 'warn') return 'node.logs.level_warn';
+  if (level === 'error') return 'node.logs.level_error';
+  return 'node.logs.level_info';
+}
+
+function fmtDateTime(value: string): string {
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? new Date(ms).toLocaleString(locale.value) : value;
+}
+
+// Newest first, matching legacy renderAgentLogs (reversed).
+const rows = computed(() =>
+  [...props.entries].reverse().map((entry, i) => ({
+    key: i,
+    level: entry.level,
+    levelLabel: t(levelLabelKey(entry.level)),
+    time: fmtDateTime(entry.occurred_at),
+    message: entry.message,
+  })),
+);
+</script>
+
+<template>
+  <div class="log-stream" data-test="log-panel">
+    <p v-if="error" class="placeholder" data-test="log-error">
+      {{ t('node.logs.load_failed', { error: error.message }) }}
+    </p>
+    <p v-else-if="rows.length === 0" class="placeholder" data-test="log-empty">
+      {{ t('node.logs.empty') }}
+    </p>
+    <article v-for="row in rows" v-else :key="row.key" class="log-entry" data-test="log-entry">
+      <div class="log-meta">
+        <span class="log-level" :class="row.level">{{ row.levelLabel }}</span>
+        <span class="log-time">{{ row.time }}</span>
+      </div>
+      <pre class="log-text">{{ row.message }}</pre>
+    </article>
+  </div>
+</template>
+
+<style scoped>
+.log-stream {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.placeholder {
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 24px;
+  margin: 0;
+}
+.log-entry {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  padding: 10px 14px;
+}
+.log-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.log-level {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 500;
+  background: var(--bg-card-soft);
+  color: var(--text-secondary);
+}
+.log-level.warn {
+  color: var(--accent-yellow);
+  background: var(--accent-yellow-soft);
+}
+.log-level.error {
+  color: var(--accent-red);
+  background: var(--accent-red-soft);
+}
+.log-text {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-primary);
+}
+</style>

--- a/nodelite-server/web/src/components/MonitorCharts.spec.ts
+++ b/nodelite-server/web/src/components/MonitorCharts.spec.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import type { HistoryPoint } from '@/api';
+import MonitorCharts from './MonitorCharts.vue';
+
+const FAKE_DICT = {
+  en: {
+    'node.cpu_usage': 'CPU Usage',
+    'node.memory_usage': 'Memory Usage',
+    'node.network_traffic': 'Network Traffic',
+    'node.latency_history': 'RTT',
+    'node.chart.zoom': 'Open enlarged chart',
+    'node.preset.last_3h': '3h',
+    'node.preset.last_24h': '24h',
+    'node.preset.last_3d': '3d',
+    'node.preset.last_7d': '7d',
+    'node.preset.last_14d': '14d',
+    'index.node.download': 'Down',
+    'index.node.upload': 'Up',
+    'node.waiting_history': 'Waiting…',
+  },
+  'zh-CN': { 'node.cpu_usage': 'CPU 使用率' },
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function hp(recorded_at: string): HistoryPoint {
+  return {
+    node_id: 'n',
+    recorded_at,
+    cpu_usage_percent: 10,
+    memory_used_percent: 20,
+    rx_bytes_per_sec: 100,
+    tx_bytes_per_sec: 50,
+    latency_ms: 5,
+    disk_used_percent: null,
+  };
+}
+
+function mountMonitor() {
+  return mount(MonitorCharts, {
+    props: {
+      node: makeNodeStatus(),
+      history: [hp('2026-05-29T00:00:00Z'), hp('2026-05-29T00:05:00Z')],
+      activeKey: 'last_24h' as const,
+    },
+    global: { plugins: [getI18n()] },
+  });
+}
+
+describe('MonitorCharts', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders five preset buttons with the active one marked', () => {
+    const wrapper = mountMonitor();
+    expect(wrapper.findAll('.preset-button')).toHaveLength(5);
+    expect(wrapper.find('[data-test="preset-last_24h"]').classes()).toContain('active');
+  });
+
+  it('renders four big charts', () => {
+    const wrapper = mountMonitor();
+    expect(wrapper.findAll('[data-test="metric-chart"]')).toHaveLength(4);
+  });
+
+  it('emits selectPreset when a preset is clicked', async () => {
+    const wrapper = mountMonitor();
+    await wrapper.find('[data-test="preset-last_7d"]').trigger('click');
+    expect(wrapper.emitted('selectPreset')?.[0]).toEqual(['last_7d']);
+  });
+
+  it('emits zoom with the metric when a zoom button is clicked', async () => {
+    const wrapper = mountMonitor();
+    await wrapper.find('[data-test="zoom-network"]').trigger('click');
+    expect(wrapper.emitted('zoom')?.[0]).toEqual(['network']);
+  });
+});

--- a/nodelite-server/web/src/components/MonitorCharts.vue
+++ b/nodelite-server/web/src/components/MonitorCharts.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { HistoryPoint, NodeStatus } from '@/api';
 import { buildChartData } from '@/lib/chart/chartData';
+import { networkSeries } from '@/lib/chart/svgModel';
 import { provideChartHoverGroup } from '@/composables/useChartHoverGroup';
 import { PRESET_WINDOWS, type PresetKey } from '@/composables/useChartSelection';
 import MetricChart from './MetricChart.vue';
@@ -27,9 +28,28 @@ provideChartHoverGroup();
 
 const data = computed(() => buildChartData(props.history));
 
-const networkSeries = computed(() => [
-  { label: t('index.node.download'), color: 'var(--chart-network-down)', points: data.value.dlPts },
-  { label: t('index.node.upload'), color: 'var(--chart-network-up)', points: data.value.upPts },
+// One config per chart; the network entry is multi-series, the rest area.
+const charts = computed(() => [
+  {
+    metric: 'cpu' as const,
+    title: t('node.cpu_usage'),
+    chartProps: { points: data.value.cpuPts, valueKind: 'percent' as const, color: 'var(--chart-cpu)', label: t('node.cpu_usage') },
+  },
+  {
+    metric: 'memory' as const,
+    title: t('node.memory_usage'),
+    chartProps: { points: data.value.memPts, valueKind: 'percent' as const, color: 'var(--chart-memory)', label: t('node.memory_usage') },
+  },
+  {
+    metric: 'network' as const,
+    title: t('node.network_traffic'),
+    chartProps: { series: networkSeries(data.value, t('index.node.download'), t('index.node.upload')), valueKind: 'rate' as const },
+  },
+  {
+    metric: 'latency' as const,
+    title: t('node.latency_history'),
+    chartProps: { points: data.value.rttPts, valueKind: 'latency' as const, color: 'var(--chart-latency)', label: t('node.latency_history') },
+  },
 ]);
 </script>
 
@@ -50,45 +70,21 @@ const networkSeries = computed(() => [
     </div>
 
     <div class="monitor__grid">
-      <article class="panel big-chart">
+      <article v-for="chart in charts" :key="chart.metric" class="panel big-chart">
         <header class="big-chart__head">
-          <span class="big-chart__title">{{ t('node.cpu_usage') }}</span>
+          <span class="big-chart__title">{{ chart.title }}</span>
           <button
             type="button"
             class="zoom-button"
             :aria-label="t('node.chart.zoom')"
             :title="t('node.chart.zoom')"
-            data-test="zoom-cpu"
-            @click="emit('zoom', 'cpu')"
+            :data-test="`zoom-${chart.metric}`"
+            @click="emit('zoom', chart.metric)"
           >
             ⤢
           </button>
         </header>
-        <MetricChart :points="data.cpuPts" value-kind="percent" color="var(--chart-cpu)" :label="t('node.cpu_usage')" :min-value="0" :height="220" />
-      </article>
-
-      <article class="panel big-chart">
-        <header class="big-chart__head">
-          <span class="big-chart__title">{{ t('node.memory_usage') }}</span>
-          <button type="button" class="zoom-button" :aria-label="t('node.chart.zoom')" :title="t('node.chart.zoom')" data-test="zoom-memory" @click="emit('zoom', 'memory')">⤢</button>
-        </header>
-        <MetricChart :points="data.memPts" value-kind="percent" color="var(--chart-memory)" :label="t('node.memory_usage')" :min-value="0" :height="220" />
-      </article>
-
-      <article class="panel big-chart">
-        <header class="big-chart__head">
-          <span class="big-chart__title">{{ t('node.network_traffic') }}</span>
-          <button type="button" class="zoom-button" :aria-label="t('node.chart.zoom')" :title="t('node.chart.zoom')" data-test="zoom-network" @click="emit('zoom', 'network')">⤢</button>
-        </header>
-        <MetricChart :series="networkSeries" value-kind="rate" :min-value="0" :height="220" />
-      </article>
-
-      <article class="panel big-chart">
-        <header class="big-chart__head">
-          <span class="big-chart__title">{{ t('node.latency_history') }}</span>
-          <button type="button" class="zoom-button" :aria-label="t('node.chart.zoom')" :title="t('node.chart.zoom')" data-test="zoom-latency" @click="emit('zoom', 'latency')">⤢</button>
-        </header>
-        <MetricChart :points="data.rttPts" value-kind="latency" color="var(--chart-latency)" :label="t('node.latency_history')" :min-value="0" :height="220" />
+        <MetricChart v-bind="chart.chartProps" :min-value="0" :height="220" />
       </article>
     </div>
   </div>

--- a/nodelite-server/web/src/components/MonitorCharts.vue
+++ b/nodelite-server/web/src/components/MonitorCharts.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { HistoryPoint, NodeStatus } from '@/api';
+import { buildChartData } from '@/lib/chart/chartData';
+import { provideChartHoverGroup } from '@/composables/useChartHoverGroup';
+import { PRESET_WINDOWS, type PresetKey } from '@/composables/useChartSelection';
+import MetricChart from './MetricChart.vue';
+
+export type MonitorMetric = 'cpu' | 'memory' | 'network' | 'latency';
+
+const props = defineProps<{
+  node: NodeStatus | null;
+  history: HistoryPoint[];
+  activeKey: PresetKey;
+}>();
+
+const emit = defineEmits<{
+  selectPreset: [key: PresetKey];
+  zoom: [metric: MonitorMetric];
+}>();
+
+const { t } = useI18n();
+
+// The four monitor charts link their crosshairs by timestamp.
+provideChartHoverGroup();
+
+const data = computed(() => buildChartData(props.history));
+
+const networkSeries = computed(() => [
+  { label: t('index.node.download'), color: 'var(--chart-network-down)', points: data.value.dlPts },
+  { label: t('index.node.upload'), color: 'var(--chart-network-up)', points: data.value.upPts },
+]);
+</script>
+
+<template>
+  <div class="monitor" data-test="monitor-charts">
+    <div class="monitor__presets" role="group" data-test="monitor-presets">
+      <button
+        v-for="preset in PRESET_WINDOWS"
+        :key="preset.key"
+        type="button"
+        class="preset-button"
+        :class="{ active: activeKey === preset.key }"
+        :data-test="`preset-${preset.key}`"
+        @click="emit('selectPreset', preset.key)"
+      >
+        {{ t(`node.preset.${preset.key}`) }}
+      </button>
+    </div>
+
+    <div class="monitor__grid">
+      <article class="panel big-chart">
+        <header class="big-chart__head">
+          <span class="big-chart__title">{{ t('node.cpu_usage') }}</span>
+          <button
+            type="button"
+            class="zoom-button"
+            :aria-label="t('node.chart.zoom')"
+            :title="t('node.chart.zoom')"
+            data-test="zoom-cpu"
+            @click="emit('zoom', 'cpu')"
+          >
+            ⤢
+          </button>
+        </header>
+        <MetricChart :points="data.cpuPts" value-kind="percent" color="var(--chart-cpu)" :label="t('node.cpu_usage')" :min-value="0" :height="220" />
+      </article>
+
+      <article class="panel big-chart">
+        <header class="big-chart__head">
+          <span class="big-chart__title">{{ t('node.memory_usage') }}</span>
+          <button type="button" class="zoom-button" :aria-label="t('node.chart.zoom')" :title="t('node.chart.zoom')" data-test="zoom-memory" @click="emit('zoom', 'memory')">⤢</button>
+        </header>
+        <MetricChart :points="data.memPts" value-kind="percent" color="var(--chart-memory)" :label="t('node.memory_usage')" :min-value="0" :height="220" />
+      </article>
+
+      <article class="panel big-chart">
+        <header class="big-chart__head">
+          <span class="big-chart__title">{{ t('node.network_traffic') }}</span>
+          <button type="button" class="zoom-button" :aria-label="t('node.chart.zoom')" :title="t('node.chart.zoom')" data-test="zoom-network" @click="emit('zoom', 'network')">⤢</button>
+        </header>
+        <MetricChart :series="networkSeries" value-kind="rate" :min-value="0" :height="220" />
+      </article>
+
+      <article class="panel big-chart">
+        <header class="big-chart__head">
+          <span class="big-chart__title">{{ t('node.latency_history') }}</span>
+          <button type="button" class="zoom-button" :aria-label="t('node.chart.zoom')" :title="t('node.chart.zoom')" data-test="zoom-latency" @click="emit('zoom', 'latency')">⤢</button>
+        </header>
+        <MetricChart :points="data.rttPts" value-kind="latency" color="var(--chart-latency)" :label="t('node.latency_history')" :min-value="0" :height="220" />
+      </article>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.monitor__presets {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+.preset-button {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  padding: 6px 14px;
+  font-size: 12px;
+}
+.preset-button:hover {
+  border-color: var(--border-strong);
+}
+.preset-button.active {
+  color: var(--accent-blue);
+  border-color: var(--accent-blue);
+  background: var(--accent-blue-soft);
+}
+.monitor__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 14px;
+}
+.big-chart {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 16px 18px;
+}
+.big-chart__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.big-chart__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.zoom-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid var(--border-soft);
+  background: var(--bg-card-soft);
+  color: var(--text-muted);
+}
+.zoom-button:hover {
+  color: var(--text-primary);
+}
+</style>

--- a/nodelite-server/web/src/components/OverviewCharts.vue
+++ b/nodelite-server/web/src/components/OverviewCharts.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { HistoryPoint, NodeStatus } from '@/api';
 import { buildChartData, averageValue, type ChartPoint } from '@/lib/chart/chartData';
+import { networkSeries } from '@/lib/chart/svgModel';
 import { formatChartValue, type ChartValueKind } from '@/lib/chart/format';
 import { provideChartHoverGroup } from '@/composables/useChartHoverGroup';
 import MetricChart from './MetricChart.vue';
@@ -35,10 +36,9 @@ const nowLatency = computed(() =>
   props.node?.latency_ms == null ? '—' : formatChartValue(props.node.latency_ms, 'latency'),
 );
 
-const networkSeries = computed(() => [
-  { label: t('index.node.download'), color: 'var(--chart-network-down)', points: data.value.dlPts },
-  { label: t('index.node.upload'), color: 'var(--chart-network-up)', points: data.value.upPts },
-]);
+const netSeries = computed(() =>
+  networkSeries(data.value, t('index.node.download'), t('index.node.upload')),
+);
 </script>
 
 <template>
@@ -81,7 +81,7 @@ const networkSeries = computed(() => [
       <header class="chart-card__head">
         <span class="chart-card__title">{{ t('node.network_traffic') }}</span>
       </header>
-      <MetricChart :series="networkSeries" value-kind="rate" :min-value="0" />
+      <MetricChart :series="netSeries" value-kind="rate" :min-value="0" />
     </article>
 
     <article class="panel chart-card chart-card--rtt">

--- a/nodelite-server/web/src/composables/useChartSelection.spec.ts
+++ b/nodelite-server/web/src/composables/useChartSelection.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { effectScope } from 'vue';
+import { useChartSelection, PRESET_WINDOWS } from './useChartSelection';
+
+function run() {
+  const scope = effectScope();
+  const sel = scope.run(() => useChartSelection())!;
+  return { sel, scope };
+}
+
+describe('useChartSelection', () => {
+  it('defaults to the 24h preset', () => {
+    const { sel, scope } = run();
+    expect(sel.activeKey.value).toBe('last_24h');
+    expect(sel.windowHours.value).toBe(24);
+    scope.stop();
+  });
+
+  it('maps each preset to its window hours', () => {
+    const { sel, scope } = run();
+    for (const p of PRESET_WINDOWS) {
+      sel.selectPreset(p.key);
+      expect(sel.windowHours.value).toBe(p.hours);
+    }
+    scope.stop();
+  });
+});

--- a/nodelite-server/web/src/composables/useChartSelection.ts
+++ b/nodelite-server/web/src/composables/useChartSelection.ts
@@ -1,0 +1,37 @@
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
+
+/** Monitor-tab window presets, from node.html:1421-1427. */
+export const PRESET_WINDOWS = [
+  { key: 'last_3h', hours: 3 },
+  { key: 'last_24h', hours: 24 },
+  { key: 'last_3d', hours: 72 },
+  { key: 'last_7d', hours: 168 },
+  { key: 'last_14d', hours: 336 },
+] as const;
+
+export type PresetKey = (typeof PRESET_WINDOWS)[number]['key'];
+
+const DEFAULT_PRESET: PresetKey = 'last_24h';
+
+export interface ChartSelection {
+  presets: typeof PRESET_WINDOWS;
+  activeKey: Ref<PresetKey>;
+  windowHours: ComputedRef<number>;
+  selectPreset: (key: PresetKey) => void;
+}
+
+/**
+ * Monitor window selection. Holds the active preset; windowHours drives the
+ * high-res history fetch. (Freehand brush-drag range selection is a deferred
+ * enhancement; presets cover the primary window UX.)
+ */
+export function useChartSelection(): ChartSelection {
+  const activeKey = ref<PresetKey>(DEFAULT_PRESET);
+  const windowHours = computed(
+    () => PRESET_WINDOWS.find((p) => p.key === activeKey.value)?.hours ?? 24,
+  );
+  function selectPreset(key: PresetKey): void {
+    activeKey.value = key;
+  }
+  return { presets: PRESET_WINDOWS, activeKey, windowHours, selectPreset };
+}

--- a/nodelite-server/web/src/lib/chart/svgModel.ts
+++ b/nodelite-server/web/src/lib/chart/svgModel.ts
@@ -9,6 +9,7 @@ import {
   averageValue,
   chartDisplayBounds,
   type ChartBounds,
+  type ChartData,
   type ChartPoint,
 } from './chartData';
 import { formatChartValue, type ChartValueKind } from './format';
@@ -75,6 +76,18 @@ export interface MultiSeriesInput {
   label: string;
   color: string;
   points: ChartPoint[];
+}
+
+/** Network down/up series for a multi-area chart, with the standard colors. */
+export function networkSeries(
+  data: ChartData,
+  downLabel: string,
+  upLabel: string,
+): MultiSeriesInput[] {
+  return [
+    { label: downLabel, color: 'var(--chart-network-down)', points: data.dlPts },
+    { label: upLabel, color: 'var(--chart-network-up)', points: data.upPts },
+  ];
 }
 
 function isFiniteValue(p: ChartPoint): p is ChartPoint & { value: number } {

--- a/nodelite-server/web/src/stores/monitorHistory.spec.ts
+++ b/nodelite-server/web/src/stores/monitorHistory.spec.ts
@@ -1,0 +1,61 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiClient } from '@/api';
+import { useMonitorHistoryStore, MONITOR_MAX_POINTS, MONITOR_REFRESH_MS } from './monitorHistory';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return { ...actual, apiClient: { ...actual.apiClient, nodeHistory: vi.fn() } };
+});
+
+const mockHistory = vi.mocked(apiClient.nodeHistory);
+
+describe('useMonitorHistoryStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockHistory.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('fetches high-res history for the (node, window) pair', async () => {
+    mockHistory.mockResolvedValueOnce([]);
+    const store = useMonitorHistoryStore();
+    await store.loadIfStale('a', 24);
+    expect(mockHistory).toHaveBeenCalledWith('a', { windowHours: 24, maxPoints: MONITOR_MAX_POINTS });
+  });
+
+  it('refetches when the window changes, clearing stale points', async () => {
+    mockHistory.mockResolvedValue([]);
+    const store = useMonitorHistoryStore();
+    await store.loadIfStale('a', 24);
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+    await store.loadIfStale('a', 72); // window change → new key → fetch
+    expect(mockHistory).toHaveBeenCalledTimes(2);
+    expect(mockHistory).toHaveBeenLastCalledWith('a', { windowHours: 72, maxPoints: MONITOR_MAX_POINTS });
+  });
+
+  it('throttles same-pair re-entry within the window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    mockHistory.mockResolvedValue([]);
+    const store = useMonitorHistoryStore();
+    await store.loadIfStale('a', 24);
+    vi.setSystemTime(1_000_000 + MONITOR_REFRESH_MS - 1);
+    await store.loadIfStale('a', 24);
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+    vi.setSystemTime(1_000_000 + MONITOR_REFRESH_MS + 1);
+    await store.loadIfStale('a', 24);
+    expect(mockHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('refresh loads when the current pair differs', async () => {
+    mockHistory.mockResolvedValue([]);
+    const store = useMonitorHistoryStore();
+    await store.refresh('a', 24);
+    expect(mockHistory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/nodelite-server/web/src/stores/monitorHistory.ts
+++ b/nodelite-server/web/src/stores/monitorHistory.ts
@@ -1,0 +1,85 @@
+import { defineStore } from 'pinia';
+import { ref, shallowRef } from 'vue';
+import { apiClient, type HistoryPoint } from '@/api';
+import { ApiAbortError } from '@/api/client';
+
+/** High-res monitor history (node.html fetchDetailHistory max_points=720). */
+export const MONITOR_MAX_POINTS = 720;
+export const MONITOR_REFRESH_MS = 15 * 1000;
+
+function keyOf(id: string, windowHours: number): string {
+  return `${id}:${windowHours}`;
+}
+
+/**
+ * Monitor-tab history for the active (node, window) pair. The selected
+ * preset changes windowHours, which is part of the cache key — switching
+ * window or node clears stale points and refetches; same key only refetches
+ * once >=15s stale. id/key-aware in-flight guard (the #182 lesson).
+ */
+export const useMonitorHistoryStore = defineStore('monitorHistory', () => {
+  const currentKey = ref<string | null>(null);
+  const points = shallowRef<HistoryPoint[]>([]);
+  const loading = ref(false);
+  const error = ref<Error | null>(null);
+  const fetchedAt = ref(0);
+  const inFlightKey = ref<string | null>(null);
+
+  async function fetchFor(id: string, windowHours: number, key: string): Promise<void> {
+    if (inFlightKey.value === key) return;
+    inFlightKey.value = key;
+    loading.value = true;
+    error.value = null;
+    try {
+      const result = await apiClient.nodeHistory(id, { windowHours, maxPoints: MONITOR_MAX_POINTS });
+      if (currentKey.value === key) {
+        points.value = result;
+        fetchedAt.value = Date.now();
+      }
+    } catch (e) {
+      if (e instanceof ApiAbortError) return;
+      if (currentKey.value === key) {
+        error.value = e instanceof Error ? e : new Error(String(e));
+        fetchedAt.value = Date.now();
+      }
+    } finally {
+      if (inFlightKey.value === key) {
+        inFlightKey.value = null;
+        loading.value = false;
+      }
+    }
+  }
+
+  function switchTo(key: string): boolean {
+    if (currentKey.value === key) return false;
+    currentKey.value = key;
+    points.value = [];
+    error.value = null;
+    fetchedAt.value = 0;
+    return true;
+  }
+
+  /** Load for (node, window); a new pair always fetches, same pair throttles. */
+  async function loadIfStale(id: string, windowHours: number): Promise<void> {
+    const key = keyOf(id, windowHours);
+    if (switchTo(key)) {
+      await fetchFor(id, windowHours, key);
+      return;
+    }
+    if (fetchedAt.value > 0 && Date.now() - fetchedAt.value < MONITOR_REFRESH_MS) return;
+    await fetchFor(id, windowHours, key);
+  }
+
+  /** Poll the current pair, throttled to >=15s. */
+  async function refresh(id: string, windowHours: number): Promise<void> {
+    const key = keyOf(id, windowHours);
+    if (currentKey.value !== key) {
+      await loadIfStale(id, windowHours);
+      return;
+    }
+    if (fetchedAt.value > 0 && Date.now() - fetchedAt.value < MONITOR_REFRESH_MS) return;
+    await fetchFor(id, windowHours, key);
+  }
+
+  return { currentKey, points, loading, error, loadIfStale, refresh };
+});

--- a/nodelite-server/web/src/stores/nodeLogs.spec.ts
+++ b/nodelite-server/web/src/stores/nodeLogs.spec.ts
@@ -1,0 +1,83 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiAbortError, ApiError } from '@/api/client';
+import { apiClient } from '@/api';
+import { makeLogEntry } from '@/api/__fixtures__/nodes';
+import { useNodeLogsStore, NODE_LOGS_LIMIT, NODE_LOGS_REFRESH_MS } from './nodeLogs';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return { ...actual, apiClient: { ...actual.apiClient, nodeLogs: vi.fn() } };
+});
+
+const mockLogs = vi.mocked(apiClient.nodeLogs);
+
+describe('useNodeLogsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockLogs.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('loads logs with limit 200', async () => {
+    mockLogs.mockResolvedValueOnce([makeLogEntry()]);
+    const store = useNodeLogsStore();
+    await store.loadIfStale('a');
+    expect(mockLogs).toHaveBeenCalledWith('a', NODE_LOGS_LIMIT);
+    expect(store.entries.length).toBe(1);
+  });
+
+  it('throttles same-node re-entry but fetches on switch', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    mockLogs.mockResolvedValue([]);
+    const store = useNodeLogsStore();
+
+    await store.loadIfStale('a');
+    expect(mockLogs).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(1_000_000 + NODE_LOGS_REFRESH_MS - 1);
+    await store.loadIfStale('a');
+    expect(mockLogs).toHaveBeenCalledTimes(1);
+
+    await store.loadIfStale('b');
+    expect(mockLogs).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears stale entries when switching nodes', async () => {
+    mockLogs.mockResolvedValueOnce([makeLogEntry()]);
+    const store = useNodeLogsStore();
+    await store.loadIfStale('a');
+    expect(store.entries.length).toBe(1);
+
+    let resolve: (v: never[]) => void = () => {};
+    mockLogs.mockReturnValueOnce(new Promise((r) => (resolve = r)));
+    const pending = store.loadIfStale('b');
+    expect(store.entries).toEqual([]);
+    resolve([]);
+    await pending;
+  });
+
+  it('records non-abort errors and swallows ApiAbortError', async () => {
+    mockLogs.mockRejectedValueOnce(new ApiError(503, 'down'));
+    const store = useNodeLogsStore();
+    await store.loadIfStale('a');
+    expect(store.error).toBeInstanceOf(ApiError);
+
+    setActivePinia(createPinia());
+    const s2 = useNodeLogsStore();
+    mockLogs.mockRejectedValueOnce(new ApiAbortError('redirect'));
+    await s2.loadIfStale('a');
+    expect(s2.error).toBeNull();
+  });
+
+  it('refresh is a no-op with no active node', async () => {
+    const store = useNodeLogsStore();
+    await store.refresh();
+    expect(mockLogs).not.toHaveBeenCalled();
+  });
+});

--- a/nodelite-server/web/src/stores/nodeLogs.ts
+++ b/nodelite-server/web/src/stores/nodeLogs.ts
@@ -1,0 +1,74 @@
+import { defineStore } from 'pinia';
+import { ref, shallowRef } from 'vue';
+import { apiClient, type AgentLogEntry } from '@/api';
+import { ApiAbortError } from '@/api/client';
+
+export const NODE_LOGS_LIMIT = 200;
+export const NODE_LOGS_REFRESH_MS = 10 * 1000;
+
+/**
+ * Active node's agent logs (GET /api/nodes/{id}/logs?limit=200). Same
+ * single-active-node pattern as detailHistory: id-switch clears stale
+ * entries, id-aware in-flight guard, loadIfStale throttles tab re-entry,
+ * refresh() polls at >=10s.
+ */
+export const useNodeLogsStore = defineStore('nodeLogs', () => {
+  const nodeId = ref<string | null>(null);
+  const entries = shallowRef<AgentLogEntry[]>([]);
+  const loading = ref(false);
+  const error = ref<Error | null>(null);
+  const fetchedAt = ref(0);
+  const inFlightId = ref<string | null>(null);
+
+  async function fetchFor(id: string): Promise<void> {
+    if (inFlightId.value === id) return;
+    inFlightId.value = id;
+    loading.value = true;
+    error.value = null;
+    try {
+      const result = await apiClient.nodeLogs(id, NODE_LOGS_LIMIT);
+      if (nodeId.value === id) {
+        entries.value = result;
+        fetchedAt.value = Date.now();
+      }
+    } catch (e) {
+      if (e instanceof ApiAbortError) return;
+      if (nodeId.value === id) {
+        error.value = e instanceof Error ? e : new Error(String(e));
+        fetchedAt.value = Date.now();
+      }
+    } finally {
+      if (inFlightId.value === id) {
+        inFlightId.value = null;
+        loading.value = false;
+      }
+    }
+  }
+
+  function switchTo(id: string): boolean {
+    if (nodeId.value === id) return false;
+    nodeId.value = id;
+    entries.value = [];
+    error.value = null;
+    fetchedAt.value = 0;
+    return true;
+  }
+
+  async function loadIfStale(id: string): Promise<void> {
+    if (switchTo(id)) {
+      await fetchFor(id);
+      return;
+    }
+    if (fetchedAt.value > 0 && Date.now() - fetchedAt.value < NODE_LOGS_REFRESH_MS) return;
+    await fetchFor(id);
+  }
+
+  async function refresh(): Promise<void> {
+    const id = nodeId.value;
+    if (id === null) return;
+    if (fetchedAt.value > 0 && Date.now() - fetchedAt.value < NODE_LOGS_REFRESH_MS) return;
+    await fetchFor(id);
+  }
+
+  return { nodeId, entries, loading, error, loadIfStale, refresh };
+});

--- a/nodelite-server/web/src/views/NodeDetailView.spec.ts
+++ b/nodelite-server/web/src/views/NodeDetailView.spec.ts
@@ -17,12 +17,14 @@ vi.mock('@/api', async () => {
       ...actual.apiClient,
       nodeStatus: vi.fn(),
       nodeHistory: vi.fn().mockResolvedValue([]),
+      nodeLogs: vi.fn().mockResolvedValue([]),
     },
   };
 });
 
 const mockStatus = vi.mocked(apiClient.nodeStatus);
 const mockHistory = vi.mocked(apiClient.nodeHistory);
+const mockLogs = vi.mocked(apiClient.nodeLogs);
 
 const FAKE_DICT = {
   en: {
@@ -60,7 +62,18 @@ const FAKE_DICT = {
     'node.network_traffic': 'Network Traffic',
     'node.latency_history': 'RTT',
     'node.chart.average': 'Avg {value}',
+    'node.chart.zoom': 'Open enlarged chart',
     'node.waiting_history': 'Waiting…',
+    'node.preset.last_3h': '3h',
+    'node.preset.last_24h': '24h',
+    'node.preset.last_3d': '3d',
+    'node.preset.last_7d': '7d',
+    'node.preset.last_14d': '14d',
+    'node.logs.empty': 'No logs.',
+    'node.logs.load_failed': 'Failed: {error}',
+    'node.logs.level_info': 'Info',
+    'node.logs.level_warn': 'Warn',
+    'node.logs.level_error': 'Error',
     'index.node.download': 'Down',
     'index.node.upload': 'Up',
     'common.unknown': 'Unknown',
@@ -188,5 +201,37 @@ describe('NodeDetailView', () => {
     await flushPromises();
     expect(wrapper.find('[data-test="node-disks"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="node-info-panel"]').exists()).toBe(true);
+  });
+
+  it('shows monitor charts and loads high-res history on the monitor tab', async () => {
+    const { wrapper, router } = await mountDetail('srv-1');
+    mockHistory.mockClear();
+    await router.replace({ hash: '#monitor' });
+    await flushPromises();
+    expect(wrapper.find('[data-test="monitor-charts"]').exists()).toBe(true);
+    // default 24h preset, high-res 720 points
+    expect(mockHistory).toHaveBeenCalledWith('srv-1', { windowHours: 24, maxPoints: 720 });
+  });
+
+  it('opens the zoom modal from a monitor chart and closes it', async () => {
+    const { wrapper, router } = await mountDetail('srv-1');
+    await router.replace({ hash: '#monitor' });
+    await flushPromises();
+
+    await wrapper.find('[data-test="zoom-cpu"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="chart-modal"]').exists()).toBe(true);
+
+    await wrapper.find('[data-test="chart-modal-close"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="chart-modal"]').exists()).toBe(false);
+  });
+
+  it('shows the log panel and loads logs on the logs tab', async () => {
+    const { wrapper, router } = await mountDetail('srv-1');
+    await router.replace({ hash: '#logs' });
+    await flushPromises();
+    expect(wrapper.find('[data-test="log-panel"]').exists()).toBe(true);
+    expect(mockLogs).toHaveBeenCalledWith('srv-1', 200);
   });
 });

--- a/nodelite-server/web/src/views/NodeDetailView.vue
+++ b/nodelite-server/web/src/views/NodeDetailView.vue
@@ -16,6 +16,7 @@ import { nodeStatusKey } from '@/lib/map/projection';
 import { ipFromNode, locationFromNode } from '@/lib/nodeMeta';
 import { uptimeParts, fmtBytes, fmtRate } from '@/lib/format';
 import { buildChartData } from '@/lib/chart/chartData';
+import { networkSeries } from '@/lib/chart/svgModel';
 import { formatChartValue } from '@/lib/chart/format';
 import { useI18n } from 'vue-i18n';
 import { useNodeStatusStore } from '@/stores/nodeStatus';
@@ -94,13 +95,9 @@ const net = computed(() => {
     latency: node.value?.latency_ms == null ? '—' : formatChartValue(node.value.latency_ms, 'latency'),
   };
 });
-const networkSeries = computed(() => {
-  const data = buildChartData(historyStore.points);
-  return [
-    { label: t('index.node.download'), color: 'var(--chart-network-down)', points: data.dlPts },
-    { label: t('index.node.upload'), color: 'var(--chart-network-up)', points: data.upPts },
-  ];
-});
+const netSeries = computed(() =>
+  networkSeries(buildChartData(historyStore.points), t('index.node.download'), t('index.node.upload')),
+);
 
 // loadIfStale (not load) so re-entering a tab within the throttle window
 // reuses the cached data, matching legacy fetchOverviewHistory/fetchAgentLogs.
@@ -161,10 +158,7 @@ const modalConfig = computed(() => {
     case 'network':
       return {
         title: t('node.network_traffic'),
-        series: [
-          { label: t('index.node.download'), color: 'var(--chart-network-down)', points: data.dlPts },
-          { label: t('index.node.upload'), color: 'var(--chart-network-up)', points: data.upPts },
-        ],
+        series: networkSeries(data, t('index.node.download'), t('index.node.upload')),
         valueKind: 'rate' as const,
       };
   }
@@ -240,7 +234,7 @@ const modalConfig = computed(() => {
             </div>
           </div>
           <article class="panel">
-            <MetricChart :series="networkSeries" value-kind="rate" :min-value="0" :height="240" />
+            <MetricChart :series="netSeries" value-kind="rate" :min-value="0" :height="240" />
           </article>
         </template>
 
@@ -270,12 +264,7 @@ const modalConfig = computed(() => {
       </section>
     </div>
 
-    <ChartModal
-      v-if="modalConfig"
-      :open="modalMetric !== null"
-      v-bind="modalConfig"
-      @close="closeZoom"
-    />
+    <ChartModal v-if="modalConfig" v-bind="modalConfig" @close="closeZoom" />
   </AppLayout>
 </template>
 

--- a/nodelite-server/web/src/views/NodeDetailView.vue
+++ b/nodelite-server/web/src/views/NodeDetailView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import AppLayout from '@/components/AppLayout.vue';
 import NodeInfoPanel from '@/components/NodeInfoPanel.vue';
@@ -7,7 +7,11 @@ import NodeSummaryCards from '@/components/NodeSummaryCards.vue';
 import OverviewCharts from '@/components/OverviewCharts.vue';
 import NodeDisks from '@/components/NodeDisks.vue';
 import MetricChart from '@/components/MetricChart.vue';
+import MonitorCharts, { type MonitorMetric } from '@/components/MonitorCharts.vue';
+import ChartModal from '@/components/ChartModal.vue';
+import LogPanel from '@/components/LogPanel.vue';
 import { usePolling } from '@/composables/usePolling';
+import { useChartSelection, type PresetKey } from '@/composables/useChartSelection';
 import { nodeStatusKey } from '@/lib/map/projection';
 import { ipFromNode, locationFromNode } from '@/lib/nodeMeta';
 import { uptimeParts, fmtBytes, fmtRate } from '@/lib/format';
@@ -16,6 +20,8 @@ import { formatChartValue } from '@/lib/chart/format';
 import { useI18n } from 'vue-i18n';
 import { useNodeStatusStore } from '@/stores/nodeStatus';
 import { useDetailHistoryStore } from '@/stores/detailHistory';
+import { useMonitorHistoryStore } from '@/stores/monitorHistory';
+import { useNodeLogsStore } from '@/stores/nodeLogs';
 
 const NODE_DETAIL_REFRESH_MS = 5000;
 
@@ -33,6 +39,9 @@ const router = useRouter();
 const { t } = useI18n();
 const store = useNodeStatusStore();
 const historyStore = useDetailHistoryStore();
+const monitorStore = useMonitorHistoryStore();
+const logsStore = useNodeLogsStore();
+const selection = useChartSelection();
 
 const nodeId = computed(() => String(route.params.id ?? ''));
 const node = computed(() => store.data);
@@ -67,11 +76,12 @@ const ip = computed(() => (node.value ? ipFromNode(node.value) : null));
 const location = computed(() => (node.value ? locationFromNode(node.value) : null));
 const uptime = computed(() => uptimeParts(node.value?.snapshot?.uptime_secs));
 
-// Tabs that render history charts; only those trigger the overview-history
-// fetch (mirrors legacy detailHistoryNeedsData; monitor lands in 3d).
+// Tabs that render the overview-history charts (overview/network).
 const historyNeeded = computed(
   () => activeTab.value === 'overview' || activeTab.value === 'network',
 );
+const monitorNeeded = computed(() => activeTab.value === 'monitor');
+const logsNeeded = computed(() => activeTab.value === 'logs');
 
 // Network tab values (legacy renderSummaryCards net block).
 const net = computed(() => {
@@ -92,32 +102,74 @@ const networkSeries = computed(() => {
   ];
 });
 
-function ensureHistory(): void {
-  // loadIfStale (not load) so re-entering a history tab within the throttle
-  // window reuses the cached series, matching legacy fetchOverviewHistory.
-  if (historyNeeded.value && nodeId.value) void historyStore.loadIfStale(nodeId.value);
+// loadIfStale (not load) so re-entering a tab within the throttle window
+// reuses the cached data, matching legacy fetchOverviewHistory/fetchAgentLogs.
+function ensureTabData(): void {
+  const id = nodeId.value;
+  if (!id) return;
+  if (historyNeeded.value) void historyStore.loadIfStale(id);
+  if (monitorNeeded.value) void monitorStore.loadIfStale(id, selection.windowHours.value);
+  if (logsNeeded.value) void logsStore.loadIfStale(id);
 }
 
 onMounted(() => {
   void store.load(nodeId.value);
-  ensureHistory();
+  ensureTabData();
 });
 
-// Navigating between nodes (same component, new :id) reloads both.
+// Navigating between nodes (same component, new :id) reloads.
 watch(nodeId, (id) => {
   if (id) void store.load(id);
-  ensureHistory();
+  ensureTabData();
 });
 
-// Switching into a history tab lazily loads the overview history.
-watch(historyNeeded, (needed) => {
-  if (needed) ensureHistory();
-});
+// Switching tabs / changing the monitor window lazily loads that data.
+watch([activeTab, selection.windowHours], () => ensureTabData());
 
 usePolling(() => {
   void store.refresh();
   if (historyNeeded.value) void historyStore.refresh();
+  if (monitorNeeded.value && nodeId.value) {
+    void monitorStore.refresh(nodeId.value, selection.windowHours.value);
+  }
+  if (logsNeeded.value) void logsStore.refresh();
 }, NODE_DETAIL_REFRESH_MS);
+
+// --- Monitor zoom modal ---
+const modalMetric = ref<MonitorMetric | null>(null);
+function openZoom(metric: MonitorMetric): void {
+  modalMetric.value = metric;
+}
+function closeZoom(): void {
+  modalMetric.value = null;
+}
+function onSelectPreset(key: PresetKey): void {
+  selection.selectPreset(key);
+}
+
+const modalConfig = computed(() => {
+  const metric = modalMetric.value;
+  if (!metric) return null;
+  const data = buildChartData(monitorStore.points);
+  switch (metric) {
+    case 'cpu':
+      return { title: t('node.cpu_usage'), points: data.cpuPts, valueKind: 'percent' as const, color: 'var(--chart-cpu)' };
+    case 'memory':
+      return { title: t('node.memory_usage'), points: data.memPts, valueKind: 'percent' as const, color: 'var(--chart-memory)' };
+    case 'latency':
+      return { title: t('node.latency_history'), points: data.rttPts, valueKind: 'latency' as const, color: 'var(--chart-latency)' };
+    case 'network':
+      return {
+        title: t('node.network_traffic'),
+        series: [
+          { label: t('index.node.download'), color: 'var(--chart-network-down)', points: data.dlPts },
+          { label: t('index.node.upload'), color: 'var(--chart-network-up)', points: data.upPts },
+        ],
+        valueKind: 'rate' as const,
+      };
+  }
+  return null;
+});
 </script>
 
 <template>
@@ -201,11 +253,29 @@ usePolling(() => {
           </article>
         </template>
 
-        <p v-else class="placeholder" data-test="pane-placeholder">
-          {{ activeTab }} — coming in Stage 3d
-        </p>
+        <MonitorCharts
+          v-else-if="activeTab === 'monitor'"
+          :node="node"
+          :history="monitorStore.points"
+          :active-key="selection.activeKey.value"
+          @select-preset="onSelectPreset"
+          @zoom="openZoom"
+        />
+
+        <LogPanel
+          v-else-if="activeTab === 'logs'"
+          :entries="logsStore.entries"
+          :error="logsStore.error"
+        />
       </section>
     </div>
+
+    <ChartModal
+      v-if="modalConfig"
+      :open="modalMetric !== null"
+      v-bind="modalConfig"
+      @close="closeZoom"
+    />
   </AppLayout>
 </template>
 


### PR DESCRIPTION
## Summary

Final Stage 3 PR: the monitor and logs tabs, completing the NodeDetail page. 4 commits, squash on merge.

### What's in

- **Logs** — `useNodeLogsStore` (`GET /logs?limit=200`, ≥10s throttle, same single-active-node pattern) + `LogPanel.vue` (entries newest-first with info/warn/error badges; empty + error states).
- **Monitor window** — `useChartSelection` (presets 3h/24h/3d/7d/14d, `node.html:1421`, default 24h) + `monitorHistory` store (high-res `max_points=720`, keyed by node+window; switching node/window refetches, same pair throttles ≥15s).
- **`MonitorCharts.vue`** — preset selector + four large linked charts (cpu/mem/network/rtt) from the monitor history; emits `selectPreset` + `zoom(metric)`.
- **`ChartModal.vue`** — zoom overlay rendering a single metric's MetricChart at 360px.
- **NodeDetailView wiring** — monitor pane = MonitorCharts (preset → window refetch, zoom → modal); logs pane = LogPanel. Lazy per-tab data (`loadIfStale` on tab/window change, `refresh` on the 5s poll); store throttles bound the real fetches.

### Scope note (deferred)

The legacy monitor also has a **freehand brush-drag** to select an arbitrary start/end sub-range (`node.html` `beginBrushDrag`/`updateSelection`). I shipped the **preset windows** (the primary window-selection UX) and deferred the freehand brush — it's a sizable pointer-drag interaction best added as a focused follow-up. The zoom modal is included. This keeps the PR reviewable; the monitor tab is fully functional via presets.

## Test plan

- [x] `pnpm lint` / `typecheck` / `test` (242 tests, 45 files) / `build` — all clean
- [ ] Manual smoke (`cargo run` + `pnpm dev`): monitor tab shows 4 big charts; switching a preset refetches the high-res window; hover links crosshairs across all four; clicking zoom opens the modal; logs tab streams entries newest-first with level badges

## Stage 3 complete

All six NodeDetail tabs are live: overview / monitor / network / hardware / logs (settings is deferred to **Stage 2.5**, rendered disabled).

Remaining migration work: **Stage 2.5** (Settings/Alerts/Account + the node-settings token-refresh tab), **Stage 3.5** (WS client once a browser endpoint exists), **Stage 4** (build.rs + CSP), plus the deferred monitor brush-drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)