### PR TITLE
Stage 2.5a — Settings page (server update / ops / token table)

### DIFF
--- a/nodelite-server/web/src/api/__fixtures__/nodes.ts
+++ b/nodelite-server/web/src/api/__fixtures__/nodes.ts
@@ -4,7 +4,56 @@ import type {
   NodeListItem,
   NodeStatus,
   OverviewData,
+  SettingsResponse,
 } from '@/api';
+
+export function makeSettings(overrides: Partial<SettingsResponse> = {}): SettingsResponse {
+  const base: SettingsResponse = {
+    service: 'nodelite-server',
+    server_version: '2.3.0',
+    repository: 'https://github.com/XiNian-dada/NodeLite',
+    public_base_url: 'http://localhost:8080',
+    listen: '127.0.0.1:8080',
+    config_path: '/etc/nodelite/server.toml',
+    registry_path: '/var/lib/nodelite/registry.json',
+    history_db_path: '/var/lib/nodelite/history.db',
+    snapshot_path: '/var/lib/nodelite/snapshot.json',
+    history_retention_hours: 336,
+    refresh_interval_secs: 5,
+    auth: {
+      enabled: true,
+      username: 'admin',
+      two_factor_enabled: false,
+      totp_secret_configured: false,
+      session_ttl_secs: 86_400,
+      pending_ttl_secs: 300,
+    },
+    updates: {
+      latest_release_url: 'https://github.com/XiNian-dada/NodeLite/releases/latest',
+      server_upgrade_command: 'curl -fsSL https://example/install.sh | sh',
+      agent_upgrade_command: 'curl -fsSL https://example/agent.sh | sh',
+    },
+    agents: [
+      {
+        node_id: 'node-a',
+        node_label: 'Node A',
+        online: true,
+        agent_version: '2.3.0',
+        remote_ip: '203.0.113.7',
+        tags: [],
+        token_expires_at: '2026-12-01T00:00:00Z',
+        token_expires_in_secs: 1_000_000,
+      },
+    ],
+  };
+  return {
+    ...base,
+    ...overrides,
+    auth: { ...base.auth, ...overrides.auth },
+    updates: { ...base.updates, ...overrides.updates },
+    agents: overrides.agents ?? base.agents,
+  };
+}
 
 export function makeBootstrap(
   overrides: Partial<BootstrapResponse> = {},

--- a/nodelite-server/web/src/api/index.ts
+++ b/nodelite-server/web/src/api/index.ts
@@ -12,6 +12,9 @@ import type {
   NodeListItem,
   NodeStatus,
   OverviewData,
+  ReauthPayload,
+  SettingsActionResponse,
+  SettingsResponse,
 } from './types';
 
 export type {
@@ -28,6 +31,12 @@ export type {
   NodeSnapshot,
   NodeStatus,
   OverviewData,
+  ReauthPayload,
+  SettingsActionResponse,
+  SettingsAgentToken,
+  SettingsAuth,
+  SettingsResponse,
+  SettingsUpdates,
 } from './types';
 
 export const apiClient = {
@@ -58,4 +67,13 @@ export const apiClient = {
     api<AgentLogEntry[]>(
       `/api/nodes/${encodeURIComponent(id)}/logs?limit=${encodeURIComponent(String(limit))}`,
     ),
+
+  // --- Settings ---
+  settings: () => api<SettingsResponse>('/api/settings'),
+  updateServer: (body: ReauthPayload) =>
+    api<SettingsActionResponse>('/api/settings/update/server', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
 };

--- a/nodelite-server/web/src/api/types.ts
+++ b/nodelite-server/web/src/api/types.ts
@@ -145,3 +145,61 @@ export interface AgentLogEntry {
   level: LogLevel;
   message: string;
 }
+
+// --- Settings (handlers/settings/types.rs) ---
+
+export interface SettingsAuth {
+  enabled: boolean;
+  username: string | null;
+  two_factor_enabled: boolean;
+  totp_secret_configured: boolean;
+  session_ttl_secs: number;
+  pending_ttl_secs: number;
+}
+
+export interface SettingsUpdates {
+  latest_release_url: string;
+  server_upgrade_command: string;
+  agent_upgrade_command: string;
+}
+
+export interface SettingsAgentToken {
+  node_id: string;
+  node_label: string;
+  online: boolean;
+  agent_version: string | null;
+  remote_ip: string | null;
+  tags: string[];
+  token_expires_at: string | null;
+  token_expires_in_secs: number | null;
+}
+
+/** GET /api/settings — SettingsResponse (flat + nested) */
+export interface SettingsResponse {
+  service: string;
+  server_version: string;
+  repository: string;
+  public_base_url: string;
+  listen: string;
+  config_path: string;
+  registry_path: string;
+  history_db_path: string;
+  snapshot_path: string;
+  history_retention_hours: number;
+  refresh_interval_secs: number;
+  auth: SettingsAuth;
+  updates: SettingsUpdates;
+  agents: SettingsAgentToken[];
+}
+
+/** Standard mutation response for the settings endpoints. */
+export interface SettingsActionResponse {
+  ok: boolean;
+  message: string;
+}
+
+/** Reauth carried by every sensitive settings write. */
+export interface ReauthPayload {
+  current_password?: string;
+  code?: string;
+}

--- a/nodelite-server/web/src/components/OpsCard.spec.ts
+++ b/nodelite-server/web/src/components/OpsCard.spec.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { makeSettings } from '@/api/__fixtures__/nodes';
+import OpsCard from './OpsCard.vue';
+
+const FAKE_DICT = {
+  en: {
+    'settings.ops.title': 'Operations',
+    'settings.ops.config': 'Config',
+    'settings.ops.registry': 'Registry',
+    'settings.ops.history': 'History DB',
+    'settings.ops.snapshot': 'Snapshot',
+    'settings.ops.server_upgrade': 'Server upgrade command:',
+    'settings.ops.agent_upgrade': 'Agent upgrade command:',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+describe('OpsCard', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the ops paths and upgrade commands', () => {
+    const settings = makeSettings({
+      config_path: '/etc/x.toml',
+      updates: {
+        latest_release_url: 'u',
+        server_upgrade_command: 'do-server-upgrade',
+        agent_upgrade_command: 'do-agent-upgrade',
+      },
+    });
+    const wrapper = mount(OpsCard, { props: { settings }, global: { plugins: [getI18n()] } });
+    const text = wrapper.text();
+    expect(text).toContain('/etc/x.toml');
+    expect(text).toContain('do-server-upgrade');
+    expect(text).toContain('do-agent-upgrade');
+  });
+});

--- a/nodelite-server/web/src/components/OpsCard.vue
+++ b/nodelite-server/web/src/components/OpsCard.vue
@@ -1,23 +1,24 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { SettingsResponse } from '@/api';
 
 const props = defineProps<{ settings: SettingsResponse }>();
 const { t } = useI18n();
 
-const rows = () => [
+const rows = computed(() => [
   { label: t('settings.ops.config'), value: props.settings.config_path },
   { label: t('settings.ops.registry'), value: props.settings.registry_path },
   { label: t('settings.ops.history'), value: props.settings.history_db_path },
   { label: t('settings.ops.snapshot'), value: props.settings.snapshot_path },
-];
+]);
 </script>
 
 <template>
   <article class="panel" data-test="ops-card">
     <h2 class="card-title">{{ t('settings.ops.title') }}</h2>
     <div class="kv">
-      <template v-for="row in rows()" :key="row.label">
+      <template v-for="row in rows" :key="row.label">
         <span class="kv__label">{{ row.label }}</span>
         <span class="kv__value">{{ row.value }}</span>
       </template>

--- a/nodelite-server/web/src/components/OpsCard.vue
+++ b/nodelite-server/web/src/components/OpsCard.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import type { SettingsResponse } from '@/api';
+
+const props = defineProps<{ settings: SettingsResponse }>();
+const { t } = useI18n();
+
+const rows = () => [
+  { label: t('settings.ops.config'), value: props.settings.config_path },
+  { label: t('settings.ops.registry'), value: props.settings.registry_path },
+  { label: t('settings.ops.history'), value: props.settings.history_db_path },
+  { label: t('settings.ops.snapshot'), value: props.settings.snapshot_path },
+];
+</script>
+
+<template>
+  <article class="panel" data-test="ops-card">
+    <h2 class="card-title">{{ t('settings.ops.title') }}</h2>
+    <div class="kv">
+      <template v-for="row in rows()" :key="row.label">
+        <span class="kv__label">{{ row.label }}</span>
+        <span class="kv__value">{{ row.value }}</span>
+      </template>
+    </div>
+    <p class="note">{{ t('settings.ops.server_upgrade') }}</p>
+    <pre class="code">{{ settings.updates.server_upgrade_command }}</pre>
+    <p class="note">{{ t('settings.ops.agent_upgrade') }}</p>
+    <pre class="code">{{ settings.updates.agent_upgrade_command }}</pre>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.kv {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 16px;
+  font-size: 13px;
+}
+.kv__label {
+  color: var(--text-muted);
+}
+.kv__value {
+  color: var(--text-primary);
+  text-align: right;
+  word-break: break-all;
+  font-variant-numeric: tabular-nums;
+}
+.note {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin: 12px 0 4px;
+}
+.code {
+  margin: 0;
+  background: var(--bg-card-soft);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--text-secondary);
+}
+</style>

--- a/nodelite-server/web/src/components/ReauthFields.spec.ts
+++ b/nodelite-server/web/src/components/ReauthFields.spec.ts
@@ -11,7 +11,10 @@ const FAKE_DICT = {
 
 const Stub = defineComponent({ render: () => h('div') });
 
-function mountFields(props: Record<string, unknown>) {
+function mountFields(props: {
+  twoFactorEnabled: boolean;
+  variant?: 'server-update' | 'standard' | 'both';
+}) {
   return mount(ReauthFields, { props, global: { plugins: [getI18n()] } });
 }
 

--- a/nodelite-server/web/src/components/ReauthFields.spec.ts
+++ b/nodelite-server/web/src/components/ReauthFields.spec.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import ReauthFields from './ReauthFields.vue';
+
+const FAKE_DICT = {
+  en: { 'settings.password.current': 'Current password', 'settings.security.verification_code': '6-digit code' },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountFields(props: Record<string, unknown>) {
+  return mount(ReauthFields, { props, global: { plugins: [getI18n()] } });
+}
+
+describe('ReauthFields', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('server-update variant: code only when 2FA on, password only when off', () => {
+    const on = mountFields({ twoFactorEnabled: true, variant: 'server-update' });
+    expect(on.find('[data-test="reauth-code"]').exists()).toBe(true);
+    expect(on.find('[data-test="reauth-password"]').exists()).toBe(false);
+
+    const off = mountFields({ twoFactorEnabled: false, variant: 'server-update' });
+    expect(off.find('[data-test="reauth-password"]').exists()).toBe(true);
+    expect(off.find('[data-test="reauth-code"]').exists()).toBe(false);
+  });
+
+  it('standard variant: password always, code only when 2FA on', () => {
+    const off = mountFields({ twoFactorEnabled: false });
+    expect(off.find('[data-test="reauth-password"]').exists()).toBe(true);
+    expect(off.find('[data-test="reauth-code"]').exists()).toBe(false);
+
+    const on = mountFields({ twoFactorEnabled: true });
+    expect(on.find('[data-test="reauth-password"]').exists()).toBe(true);
+    expect(on.find('[data-test="reauth-code"]').exists()).toBe(true);
+  });
+
+  it('both variant: password + code always', () => {
+    const w = mountFields({ twoFactorEnabled: false, variant: 'both' });
+    expect(w.find('[data-test="reauth-password"]').exists()).toBe(true);
+    expect(w.find('[data-test="reauth-code"]').exists()).toBe(true);
+  });
+
+  it('updates v-models on input', async () => {
+    const w = mountFields({ twoFactorEnabled: true, variant: 'both' });
+    await w.find('[data-test="reauth-password"]').setValue('pw');
+    await w.find('[data-test="reauth-code"]').setValue('123456');
+    expect(w.emitted('update:currentPassword')?.at(-1)).toEqual(['pw']);
+    expect(w.emitted('update:code')?.at(-1)).toEqual(['123456']);
+  });
+});

--- a/nodelite-server/web/src/components/ReauthFields.vue
+++ b/nodelite-server/web/src/components/ReauthFields.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+/**
+ * Reauth inputs for sensitive settings writes. Which fields show depends on
+ * the variant + whether 2FA is enabled (ports the legacy confirmation-field
+ * logic in index-settings.js):
+ * - 'server-update': 2FA → code only; else current_password only.
+ * - 'standard' (default): current_password always; + code when 2FA enabled.
+ * - 'both': current_password + code always (e.g. enabling/disabling 2FA).
+ */
+const props = withDefaults(
+  defineProps<{
+    twoFactorEnabled: boolean;
+    variant?: 'server-update' | 'standard' | 'both';
+  }>(),
+  { variant: 'standard' },
+);
+
+const currentPassword = defineModel<string>('currentPassword', { default: '' });
+const code = defineModel<string>('code', { default: '' });
+
+const { t } = useI18n();
+
+const showPassword = computed(() =>
+  props.variant === 'server-update' ? !props.twoFactorEnabled : true,
+);
+const showCode = computed(() => {
+  if (props.variant === 'both') return true;
+  return props.twoFactorEnabled;
+});
+</script>
+
+<template>
+  <div class="reauth-fields" data-test="reauth-fields">
+    <label v-if="showPassword" class="reauth-field">
+      <span>{{ t('settings.password.current') }}</span>
+      <input
+        v-model="currentPassword"
+        type="password"
+        autocomplete="current-password"
+        data-test="reauth-password"
+        required
+      />
+    </label>
+    <label v-if="showCode" class="reauth-field">
+      <span>{{ t('settings.security.verification_code') }}</span>
+      <input
+        v-model="code"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9]{6}"
+        maxlength="6"
+        autocomplete="one-time-code"
+        data-test="reauth-code"
+        required
+      />
+    </label>
+  </div>
+</template>
+
+<style scoped>
+.reauth-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.reauth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.reauth-field input {
+  background: var(--bg-card-soft);
+  color: var(--text-primary);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+}
+</style>

--- a/nodelite-server/web/src/components/ServerUpdateCard.spec.ts
+++ b/nodelite-server/web/src/components/ServerUpdateCard.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { apiClient } from '@/api';
+import { ApiError } from '@/api/client';
+import { makeSettings } from '@/api/__fixtures__/nodes';
+import ServerUpdateCard from './ServerUpdateCard.vue';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return { ...actual, apiClient: { ...actual.apiClient, updateServer: vi.fn() } };
+});
+
+const mockUpdate = vi.mocked(apiClient.updateServer);
+
+const FAKE_DICT = {
+  en: {
+    'settings.version.title': 'Version & Updates',
+    'settings.version.current': 'Current version',
+    'settings.version.repository': 'Repository',
+    'settings.version.public_url': 'Public URL',
+    'settings.version.listen': 'Listen',
+    'settings.version.check_updates': 'Check updates',
+    'settings.version.open_release': 'Releases',
+    'settings.version.checking': 'Checking…',
+    'settings.version.update_available': 'New: {version}',
+    'settings.version.up_to_date': 'Up to date: {version}',
+    'settings.version.check_failed': 'Check failed: {error}',
+    'settings.version.manual_update_note_2fa': 'Enter code',
+    'settings.version.manual_update_note_password': 'Enter password',
+    'settings.version.update_now': 'Update now',
+    'settings.version.update_starting': 'Starting…',
+    'settings.version.update_started': 'Started',
+    'settings.version.update_failed': 'Failed: {error}',
+    'settings.password.current': 'Current password',
+    'settings.security.verification_code': '6-digit code',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+// fetch routes: ui-i18n.json → dict; api.github.com → release.
+function routedFetch(release: { tag_name: string } | { fail: true }) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (String(url).includes('ui-i18n.json')) {
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response);
+    }
+    if ('fail' in release) return Promise.resolve({ ok: false, status: 503 } as unknown as Response);
+    return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(release) } as unknown as Response);
+  });
+}
+
+async function mountCard(over = {}, release: { tag_name: string } | { fail: true } = { tag_name: 'v2.3.0' }) {
+  vi.stubGlobal('fetch', routedFetch(release));
+  const dummy = createApp(Stub);
+  await setupI18n(dummy);
+  const settings = makeSettings({ server_version: '2.3.0', repository: 'https://github.com/o/r', ...over });
+  return mount(ServerUpdateCard, { props: { settings }, global: { plugins: [getI18n()] } });
+}
+
+describe('ServerUpdateCard', () => {
+  beforeEach(() => {
+    __resetI18nForTest();
+    mockUpdate.mockReset();
+  });
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('shows the current version', async () => {
+    const wrapper = await mountCard();
+    expect(wrapper.find('[data-test="server-version"]').text()).toBe('2.3.0');
+  });
+
+  it('check-update reports up-to-date for an equal latest tag', async () => {
+    const wrapper = await mountCard({}, { tag_name: 'v2.3.0' });
+    await wrapper.find('[data-test="check-update"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="settings-message"]').text()).toContain('Up to date: 2.3.0');
+  });
+
+  it('check-update reports a newer release', async () => {
+    const wrapper = await mountCard({}, { tag_name: 'v2.4.0' });
+    await wrapper.find('[data-test="check-update"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="settings-message"]').text()).toContain('New: 2.4.0');
+  });
+
+  it('posts a server update with reauth and shows the started message', async () => {
+    mockUpdate.mockResolvedValueOnce({ ok: true, message: '' });
+    const wrapper = await mountCard(); // 2FA off → password field
+    await wrapper.find('[data-test="reauth-password"]').setValue('pw');
+    await wrapper.find('[data-test="server-update-form"]').trigger('submit');
+    await flushPromises();
+    expect(mockUpdate).toHaveBeenCalledWith({ current_password: 'pw' });
+    expect(wrapper.find('[data-test="server-update-form"] [data-test="settings-message"]').text()).toContain('Started');
+  });
+
+  it('surfaces the server error message on failure', async () => {
+    mockUpdate.mockRejectedValueOnce(new ApiError(400, JSON.stringify({ ok: false, message: 'bad password' })));
+    const wrapper = await mountCard();
+    await wrapper.find('[data-test="reauth-password"]').setValue('nope');
+    await wrapper.find('[data-test="server-update-form"]').trigger('submit');
+    await flushPromises();
+    expect(wrapper.find('[data-test="server-update-form"] [data-test="settings-message"]').text()).toContain('bad password');
+  });
+});

--- a/nodelite-server/web/src/components/ServerUpdateCard.vue
+++ b/nodelite-server/web/src/components/ServerUpdateCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue';
+import { computed, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { SettingsResponse } from '@/api';
 import { apiClient } from '@/api';
@@ -12,14 +12,14 @@ import SettingsMessage from './SettingsMessage.vue';
 const props = defineProps<{ settings: SettingsResponse }>();
 const { t } = useI18n();
 
-const twoFactor = () => props.settings.auth.two_factor_enabled;
+const twoFactor = computed(() => props.settings.auth.two_factor_enabled);
 
 // --- Check for update (direct GitHub call) ---
 const checkMsg = reactive<{ state: 'ok' | 'error' | null; text: string }>({ state: null, text: '' });
 const checking = ref(false);
 
 function githubLatestUrl(): string | null {
-  const repo = props.settings.repository;
+  const repo = props.settings.repository.replace(/\/+$/, '');
   if (!repo.startsWith('https://github.com/')) return null;
   return `${repo.replace('https://github.com/', 'https://api.github.com/repos/')}/releases/latest`;
 }
@@ -60,7 +60,9 @@ async function submitUpdate(): Promise<void> {
   updateMsg.state = null;
   updateMsg.text = t('settings.version.update_starting');
   // server-update reauth: 2FA → code only; else current_password only.
-  const payload = twoFactor() ? { code: reauth.code } : { current_password: reauth.currentPassword };
+  const payload = twoFactor.value
+    ? { code: reauth.code }
+    : { current_password: reauth.currentPassword };
   try {
     const res = await apiClient.updateServer(payload);
     updateMsg.state = res.ok ? 'ok' : 'error';
@@ -105,12 +107,12 @@ async function submitUpdate(): Promise<void> {
 
     <form class="update-form" data-test="server-update-form" @submit.prevent="submitUpdate">
       <p class="note">
-        {{ twoFactor() ? t('settings.version.manual_update_note_2fa') : t('settings.version.manual_update_note_password') }}
+        {{ twoFactor ? t('settings.version.manual_update_note_2fa') : t('settings.version.manual_update_note_password') }}
       </p>
       <ReauthFields
         v-model:current-password="reauth.currentPassword"
         v-model:code="reauth.code"
-        :two-factor-enabled="twoFactor()"
+        :two-factor-enabled="twoFactor"
         variant="server-update"
       />
       <button type="submit" class="btn btn--primary" :disabled="updating" data-test="server-update-submit">

--- a/nodelite-server/web/src/components/ServerUpdateCard.vue
+++ b/nodelite-server/web/src/components/ServerUpdateCard.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { SettingsResponse } from '@/api';
+import { apiClient } from '@/api';
+import { ApiAbortError } from '@/api/client';
+import { isNewerVersion, normalizeVersionTag } from '@/lib/version';
+import { messageFromError } from '@/lib/apiError';
+import ReauthFields from './ReauthFields.vue';
+import SettingsMessage from './SettingsMessage.vue';
+
+const props = defineProps<{ settings: SettingsResponse }>();
+const { t } = useI18n();
+
+const twoFactor = () => props.settings.auth.two_factor_enabled;
+
+// --- Check for update (direct GitHub call) ---
+const checkMsg = reactive<{ state: 'ok' | 'error' | null; text: string }>({ state: null, text: '' });
+const checking = ref(false);
+
+function githubLatestUrl(): string | null {
+  const repo = props.settings.repository;
+  if (!repo.startsWith('https://github.com/')) return null;
+  return `${repo.replace('https://github.com/', 'https://api.github.com/repos/')}/releases/latest`;
+}
+
+async function checkForUpdate(): Promise<void> {
+  const url = githubLatestUrl();
+  if (!url) return;
+  checking.value = true;
+  checkMsg.state = null;
+  checkMsg.text = t('settings.version.checking');
+  try {
+    const res = await fetch(url, { headers: { accept: 'application/vnd.github+json' } });
+    if (!res.ok) throw new Error(`GitHub ${res.status}`);
+    const body = (await res.json()) as { tag_name?: string };
+    const latest = normalizeVersionTag(body.tag_name ?? '');
+    if (latest && isNewerVersion(latest, props.settings.server_version)) {
+      checkMsg.state = 'ok';
+      checkMsg.text = t('settings.version.update_available', { version: latest });
+    } else {
+      checkMsg.state = 'ok';
+      checkMsg.text = t('settings.version.up_to_date', { version: props.settings.server_version });
+    }
+  } catch (e) {
+    checkMsg.state = 'error';
+    checkMsg.text = t('settings.version.check_failed', { error: messageFromError(e, 'unknown') });
+  } finally {
+    checking.value = false;
+  }
+}
+
+// --- Manual server update (POST with reauth) ---
+const reauth = reactive({ currentPassword: '', code: '' });
+const updateMsg = reactive<{ state: 'ok' | 'error' | null; text: string }>({ state: null, text: '' });
+const updating = ref(false);
+
+async function submitUpdate(): Promise<void> {
+  updating.value = true;
+  updateMsg.state = null;
+  updateMsg.text = t('settings.version.update_starting');
+  // server-update reauth: 2FA → code only; else current_password only.
+  const payload = twoFactor() ? { code: reauth.code } : { current_password: reauth.currentPassword };
+  try {
+    const res = await apiClient.updateServer(payload);
+    updateMsg.state = res.ok ? 'ok' : 'error';
+    updateMsg.text = res.ok ? t('settings.version.update_started') : res.message;
+    if (res.ok) {
+      reauth.currentPassword = '';
+      reauth.code = '';
+    }
+  } catch (e) {
+    if (e instanceof ApiAbortError) return;
+    updateMsg.state = 'error';
+    updateMsg.text = t('settings.version.update_failed', { error: messageFromError(e, 'unknown') });
+  } finally {
+    updating.value = false;
+  }
+}
+</script>
+
+<template>
+  <article class="panel" data-test="server-update-card">
+    <h2 class="card-title">{{ t('settings.version.title') }}</h2>
+    <div class="kv">
+      <span class="kv__label">{{ t('settings.version.current') }}</span>
+      <span class="kv__value" data-test="server-version">{{ settings.server_version }}</span>
+      <span class="kv__label">{{ t('settings.version.repository') }}</span>
+      <span class="kv__value">{{ settings.repository }}</span>
+      <span class="kv__label">{{ t('settings.version.public_url') }}</span>
+      <span class="kv__value">{{ settings.public_base_url }}</span>
+      <span class="kv__label">{{ t('settings.version.listen') }}</span>
+      <span class="kv__value">{{ settings.listen }}</span>
+    </div>
+
+    <div class="actions">
+      <button type="button" class="btn" :disabled="checking" data-test="check-update" @click="checkForUpdate">
+        {{ t('settings.version.check_updates') }}
+      </button>
+      <a class="btn btn--link" :href="settings.updates.latest_release_url" target="_blank" rel="noopener">
+        {{ t('settings.version.open_release') }}
+      </a>
+    </div>
+    <SettingsMessage :state="checkMsg.state" :text="checkMsg.text" />
+
+    <form class="update-form" data-test="server-update-form" @submit.prevent="submitUpdate">
+      <p class="note">
+        {{ twoFactor() ? t('settings.version.manual_update_note_2fa') : t('settings.version.manual_update_note_password') }}
+      </p>
+      <ReauthFields
+        v-model:current-password="reauth.currentPassword"
+        v-model:code="reauth.code"
+        :two-factor-enabled="twoFactor()"
+        variant="server-update"
+      />
+      <button type="submit" class="btn btn--primary" :disabled="updating" data-test="server-update-submit">
+        {{ t('settings.version.update_now') }}
+      </button>
+      <SettingsMessage :state="updateMsg.state" :text="updateMsg.text" />
+    </form>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.kv {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 16px;
+  font-size: 13px;
+}
+.kv__label {
+  color: var(--text-muted);
+}
+.kv__value {
+  color: var(--text-primary);
+  text-align: right;
+  word-break: break-all;
+}
+.actions {
+  display: flex;
+  gap: 8px;
+  margin: 14px 0 4px;
+}
+.note {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin: 14px 0 10px;
+}
+.update-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-top: 1px solid var(--border-soft);
+  margin-top: 14px;
+  padding-top: 14px;
+}
+.btn {
+  align-self: flex-start;
+  background: var(--bg-card-soft);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 8px 14px;
+  font: inherit;
+}
+.btn:hover:not([disabled]) {
+  color: var(--text-primary);
+}
+.btn--link {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+.btn--primary {
+  color: #fff;
+  background: var(--accent-blue);
+  border-color: transparent;
+}
+</style>

--- a/nodelite-server/web/src/components/SettingsMessage.vue
+++ b/nodelite-server/web/src/components/SettingsMessage.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+defineProps<{ state: 'ok' | 'error' | null; text: string }>();
+</script>
+
+<template>
+  <p
+    v-if="state && text"
+    class="settings-message"
+    :class="state"
+    data-test="settings-message"
+    role="status"
+  >
+    {{ text }}
+  </p>
+</template>
+
+<style scoped>
+.settings-message {
+  margin: 8px 0 0;
+  font-size: 13px;
+}
+.settings-message.ok {
+  color: var(--accent-green);
+}
+.settings-message.error {
+  color: var(--accent-red);
+}
+</style>

--- a/nodelite-server/web/src/components/SidebarNav.spec.ts
+++ b/nodelite-server/web/src/components/SidebarNav.spec.ts
@@ -28,6 +28,7 @@ function makeRouter(): Router {
     routes: [
       { path: '/', name: 'dashboard', component: Stub },
       { path: '/nodes/:id', name: 'node-detail', component: Stub },
+      { path: '/settings', name: 'settings', component: Stub },
     ],
   });
 }
@@ -73,13 +74,24 @@ describe('SidebarNav', () => {
     expect(wrapper.find('[data-test="nav-overview"]').classes()).toContain('active');
   });
 
-  it('disables the Stage 2.5 buttons', async () => {
+  it('links Settings and marks it active on /settings', async () => {
+    const router = makeRouter();
+    await router.push('/settings');
+    await router.isReady();
+    const wrapper = mount(SidebarNav, { global: { plugins: [router, getI18n()] } });
+
+    const settings = wrapper.find('[data-test="nav-settings"]');
+    expect(settings.attributes('disabled')).toBeUndefined();
+    expect(settings.classes()).toContain('active');
+  });
+
+  it('still disables the not-yet-built buttons (alerts/account)', async () => {
     const router = makeRouter();
     await router.push('/');
     await router.isReady();
     const wrapper = mount(SidebarNav, { global: { plugins: [router, getI18n()] } });
 
-    for (const tab of ['nav-settings', 'nav-alerts', 'nav-account']) {
+    for (const tab of ['nav-alerts', 'nav-account']) {
       const el = wrapper.find(`[data-test="${tab}"]`);
       expect(el.attributes('disabled')).toBeDefined();
     }

--- a/nodelite-server/web/src/components/SidebarNav.vue
+++ b/nodelite-server/web/src/components/SidebarNav.vue
@@ -33,11 +33,11 @@ const route = useRoute();
       </svg>
     </RouterLink>
 
-    <button
-      type="button"
+    <RouterLink
       class="nav-button"
-      disabled
-      :title="`${$t('index.nav.settings')} (Stage 2.5)`"
+      :class="{ active: route.path === '/settings' }"
+      to="/settings"
+      :title="$t('index.nav.settings')"
       :aria-label="$t('index.nav.settings')"
       data-test="nav-settings"
     >
@@ -54,7 +54,7 @@ const route = useRoute();
           d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"
         />
       </svg>
-    </button>
+    </RouterLink>
 
     <button
       type="button"

--- a/nodelite-server/web/src/components/TokenTable.spec.ts
+++ b/nodelite-server/web/src/components/TokenTable.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import type { SettingsAgentToken } from '@/api';
+import TokenTable from './TokenTable.vue';
+
+const FAKE_DICT = {
+  en: {
+    'settings.tokens.title': 'Agent Token Expiry',
+    'settings.tokens.empty': 'No enrolled agents yet.',
+    'settings.tokens.node': 'Node',
+    'settings.tokens.status': 'Status',
+    'settings.tokens.agent': 'Agent',
+    'settings.tokens.ip': 'Remote IP',
+    'settings.tokens.expires_at': 'Expires at',
+    'settings.tokens.remaining': 'Remaining',
+    'settings.token.no_expiry': 'No expiry',
+    'settings.token.expired': 'Expired',
+    'settings.duration.days_hours': '{days}d {hours}h',
+    'settings.duration.minutes': '{minutes}m',
+    'common.online': 'Online',
+    'common.offline': 'Offline',
+    'common.not_available': 'n/a',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function agent(over: Partial<SettingsAgentToken>): SettingsAgentToken {
+  return {
+    node_id: 'n', node_label: 'N', online: true, agent_version: '1.0',
+    remote_ip: '10.0.0.1', tags: [], token_expires_at: '2026-12-01T00:00:00Z',
+    token_expires_in_secs: 1_000_000, ...over,
+  };
+}
+
+function mountTable(agents: SettingsAgentToken[]) {
+  return mount(TokenTable, { props: { agents }, global: { plugins: [getI18n()] } });
+}
+
+describe('TokenTable', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the empty state with no agents', () => {
+    expect(mountTable([]).find('[data-test="token-table-empty"]').exists()).toBe(true);
+  });
+
+  it('renders a row per agent with severity classes', () => {
+    const wrapper = mountTable([
+      agent({ node_id: 'a', token_expires_in_secs: 30 * 86400 }), // ok
+      agent({ node_id: 'b', token_expires_in_secs: 3 * 86400 }), // expiring
+      agent({ node_id: 'c', token_expires_in_secs: -1 }), // expired
+    ]);
+    const rows = wrapper.findAll('[data-test="token-row"]');
+    expect(rows).toHaveLength(3);
+    expect(wrapper.find('.tokens .ok').exists()).toBe(true);
+    expect(wrapper.find('.tokens .expiring').exists()).toBe(true);
+    expect(wrapper.find('.tokens .expired').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Expired');
+  });
+});

--- a/nodelite-server/web/src/components/TokenTable.vue
+++ b/nodelite-server/web/src/components/TokenTable.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { SettingsAgentToken } from '@/api';
+import { tokenRemaining, tokenSeverity } from '@/lib/format';
+
+const props = defineProps<{ agents: SettingsAgentToken[] }>();
+const { t, locale } = useI18n();
+
+function fmtDateTime(value: string | null): string {
+  if (!value) return t('settings.token.no_expiry');
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? new Date(ms).toLocaleString(locale.value) : value;
+}
+
+function remainingText(seconds: number | null): string {
+  const r = tokenRemaining(seconds);
+  switch (r.kind) {
+    case 'none':
+      return t('settings.token.no_expiry');
+    case 'expired':
+      return t('settings.token.expired');
+    case 'days_hours':
+      return t('settings.duration.days_hours', { days: r.days, hours: r.hours });
+    case 'minutes':
+      return t('settings.duration.minutes', { minutes: r.minutes });
+  }
+}
+
+const rows = computed(() =>
+  props.agents.map((a) => ({
+    id: a.node_id,
+    label: a.node_label || a.node_id,
+    nodeId: a.node_id,
+    status: a.online ? t('common.online') : t('common.offline'),
+    online: a.online,
+    agent: a.agent_version ?? t('common.not_available'),
+    ip: a.remote_ip ?? t('common.not_available'),
+    expiresAt: fmtDateTime(a.token_expires_at),
+    remaining: remainingText(a.token_expires_in_secs),
+    severity: tokenSeverity(a.token_expires_in_secs),
+  })),
+);
+</script>
+
+<template>
+  <article class="panel" data-test="token-table">
+    <h2 class="card-title">{{ t('settings.tokens.title') }}</h2>
+    <p v-if="rows.length === 0" class="empty" data-test="token-table-empty">
+      {{ t('settings.tokens.empty') }}
+    </p>
+    <table v-else class="tokens">
+      <thead>
+        <tr>
+          <th>{{ t('settings.tokens.node') }}</th>
+          <th>{{ t('settings.tokens.status') }}</th>
+          <th>{{ t('settings.tokens.agent') }}</th>
+          <th>{{ t('settings.tokens.ip') }}</th>
+          <th>{{ t('settings.tokens.expires_at') }}</th>
+          <th class="numeric">{{ t('settings.tokens.remaining') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in rows" :key="row.id" data-test="token-row">
+          <td>
+            {{ row.label }}<div class="subnote">{{ row.nodeId }}</div>
+          </td>
+          <td>{{ row.status }}</td>
+          <td>{{ row.agent }}</td>
+          <td>{{ row.ip }}</td>
+          <td>{{ row.expiresAt }}</td>
+          <td class="numeric" :class="row.severity">{{ row.remaining }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.empty {
+  color: var(--text-muted);
+  font-size: 13px;
+  margin: 0;
+}
+.tokens {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.tokens th,
+.tokens td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-soft);
+  vertical-align: top;
+}
+.tokens th {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+.tokens .numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.subnote {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.expired {
+  color: var(--accent-red);
+}
+.expiring {
+  color: var(--accent-yellow);
+}
+.ok {
+  color: var(--accent-green);
+}
+</style>

--- a/nodelite-server/web/src/lib/apiError.ts
+++ b/nodelite-server/web/src/lib/apiError.ts
@@ -1,0 +1,20 @@
+import { ApiError } from '@/api/client';
+
+/**
+ * Extract a human message from a settings/alerts mutation failure. The
+ * server returns `{ ok:false, message }` JSON on non-2xx, which api() wraps
+ * as ApiError(status, body). Prefer that message; fall back otherwise.
+ */
+export function messageFromError(error: unknown, fallback: string): string {
+  if (error instanceof ApiError) {
+    try {
+      const parsed = JSON.parse(error.body) as { message?: unknown };
+      if (typeof parsed.message === 'string' && parsed.message) return parsed.message;
+    } catch {
+      // body wasn't JSON — fall through
+    }
+    if (error.body) return error.body;
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}

--- a/nodelite-server/web/src/lib/format.spec.ts
+++ b/nodelite-server/web/src/lib/format.spec.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { fmtBytes, fmtLatency, fmtPercent, fmtRate, uptimeParts } from './format';
+import {
+  fmtBytes,
+  fmtLatency,
+  fmtPercent,
+  fmtRate,
+  tokenRemaining,
+  tokenSeverity,
+  uptimeParts,
+} from './format';
 
 describe('fmtBytes', () => {
   it('scales by 1024 with legacy decimal rules', () => {
@@ -61,5 +69,29 @@ describe('uptimeParts', () => {
   it('returns null for null/NaN', () => {
     expect(uptimeParts(null)).toBeNull();
     expect(uptimeParts(Number.NaN)).toBeNull();
+  });
+});
+
+describe('tokenRemaining', () => {
+  it('maps null/NaN to none, <=0 to expired', () => {
+    expect(tokenRemaining(null)).toEqual({ kind: 'none' });
+    expect(tokenRemaining(Number.NaN)).toEqual({ kind: 'none' });
+    expect(tokenRemaining(0)).toEqual({ kind: 'expired' });
+    expect(tokenRemaining(-5)).toEqual({ kind: 'expired' });
+  });
+
+  it('uses days_hours when >=1 day, minutes (min 1) otherwise', () => {
+    expect(tokenRemaining((25 * 3600 + 5))).toEqual({ kind: 'days_hours', days: 1, hours: 1 });
+    expect(tokenRemaining(90 * 60)).toEqual({ kind: 'minutes', minutes: 90 });
+    expect(tokenRemaining(10)).toEqual({ kind: 'minutes', minutes: 1 }); // floor → 0, clamped to 1
+  });
+});
+
+describe('tokenSeverity', () => {
+  it('classifies by remaining seconds', () => {
+    expect(tokenSeverity(null)).toBe('');
+    expect(tokenSeverity(0)).toBe('expired');
+    expect(tokenSeverity(3 * 86400)).toBe('expiring'); // < 7 days
+    expect(tokenSeverity(30 * 86400)).toBe('ok');
   });
 });

--- a/nodelite-server/web/src/lib/format.ts
+++ b/nodelite-server/web/src/lib/format.ts
@@ -84,7 +84,7 @@ export function tokenRemaining(seconds: number | null | undefined): DurationResu
 
 /** Token-row severity class from remaining seconds (expired / <7d / ok). */
 export function tokenSeverity(seconds: number | null | undefined): '' | 'expired' | 'expiring' | 'ok' {
-  if (seconds == null) return '';
+  if (seconds == null || !Number.isFinite(Number(seconds))) return '';
   if (seconds <= 0) return 'expired';
   return seconds < 7 * 86400 ? 'expiring' : 'ok';
 }

--- a/nodelite-server/web/src/lib/format.ts
+++ b/nodelite-server/web/src/lib/format.ts
@@ -59,3 +59,32 @@ export function uptimeParts(seconds: number | null | undefined): UptimeParts | n
   const minutes = totalMinutes % 60;
   return { days, hours, minutes };
 }
+
+export type DurationResult =
+  | { kind: 'none' }
+  | { kind: 'expired' }
+  | { kind: 'days_hours'; days: number; hours: number }
+  | { kind: 'minutes'; minutes: number };
+
+/**
+ * Token-expiry "remaining" duration, ported from legacy fmtDurationSeconds.
+ * The caller maps the result to i18n: none → settings.token.no_expiry,
+ * expired → settings.token.expired, days_hours → settings.duration.days_hours,
+ * minutes → settings.duration.minutes. Returns structured (i18n-free).
+ */
+export function tokenRemaining(seconds: number | null | undefined): DurationResult {
+  if (seconds == null || !Number.isFinite(Number(seconds))) return { kind: 'none' };
+  const value = Number(seconds);
+  if (value <= 0) return { kind: 'expired' };
+  const days = Math.floor(value / 86400);
+  const hours = Math.floor((value % 86400) / 3600);
+  if (days > 0) return { kind: 'days_hours', days, hours };
+  return { kind: 'minutes', minutes: Math.max(1, Math.floor(value / 60)) };
+}
+
+/** Token-row severity class from remaining seconds (expired / <7d / ok). */
+export function tokenSeverity(seconds: number | null | undefined): '' | 'expired' | 'expiring' | 'ok' {
+  if (seconds == null) return '';
+  if (seconds <= 0) return 'expired';
+  return seconds < 7 * 86400 ? 'expiring' : 'ok';
+}

--- a/nodelite-server/web/src/lib/version.spec.ts
+++ b/nodelite-server/web/src/lib/version.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { compareVersions, isNewerVersion, normalizeVersionTag } from './version';
+
+describe('compareVersions', () => {
+  it('orders by numeric segments', () => {
+    expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
+    expect(compareVersions('1.2.4', '1.2.3')).toBeGreaterThan(0);
+    expect(compareVersions('1.2.3', '1.3.0')).toBeLessThan(0);
+    expect(compareVersions('2.0.0', '1.9.9')).toBeGreaterThan(0);
+  });
+
+  it('treats missing segments as 0', () => {
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+    expect(compareVersions('1.2.1', '1.2')).toBeGreaterThan(0);
+  });
+
+  it('treats non-numeric segments as 0', () => {
+    expect(compareVersions('1.x.0', '1.0.0')).toBe(0);
+  });
+});
+
+describe('normalizeVersionTag', () => {
+  it('strips a leading v', () => {
+    expect(normalizeVersionTag('v2.3.0')).toBe('2.3.0');
+    expect(normalizeVersionTag('2.3.0')).toBe('2.3.0');
+  });
+});
+
+describe('isNewerVersion', () => {
+  it('detects a newer release tag vs the current version', () => {
+    expect(isNewerVersion('v2.3.1', '2.3.0')).toBe(true);
+    expect(isNewerVersion('v2.3.0', '2.3.0')).toBe(false);
+    expect(isNewerVersion('v2.2.9', '2.3.0')).toBe(false);
+  });
+});

--- a/nodelite-server/web/src/lib/version.ts
+++ b/nodelite-server/web/src/lib/version.ts
@@ -1,0 +1,27 @@
+/**
+ * Dotted-version comparison, ported from assets/index.html:2348. Pure.
+ * Returns <0 if left < right, 0 if equal, >0 if left > right. Non-numeric
+ * segments count as 0 (matching the legacy `parseInt(v,10) || 0`).
+ */
+export function compareVersions(left: string, right: string): number {
+  const a = String(left)
+    .split('.')
+    .map((v) => parseInt(v, 10) || 0);
+  const b = String(right)
+    .split('.')
+    .map((v) => parseInt(v, 10) || 0);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    if ((a[i] || 0) !== (b[i] || 0)) return (a[i] || 0) - (b[i] || 0);
+  }
+  return 0;
+}
+
+/** Strip a leading `v`/`V` from a release tag (e.g. "v2.3.0" → "2.3.0"). */
+export function normalizeVersionTag(tag: string): string {
+  return String(tag).replace(/^v/i, '').trim();
+}
+
+/** True when `latest` is strictly newer than `current` (tags `v`-tolerant). */
+export function isNewerVersion(latest: string, current: string): boolean {
+  return compareVersions(normalizeVersionTag(latest), normalizeVersionTag(current)) > 0;
+}

--- a/nodelite-server/web/src/router/index.ts
+++ b/nodelite-server/web/src/router/index.ts
@@ -11,6 +11,11 @@ const routes: RouteRecordRaw[] = [
     name: 'node-detail',
     component: () => import('@/views/NodeDetailView.vue'),
   },
+  {
+    path: '/settings',
+    name: 'settings',
+    component: () => import('@/views/SettingsView.vue'),
+  },
 ];
 
 export const router = createRouter({

--- a/nodelite-server/web/src/stores/settings.spec.ts
+++ b/nodelite-server/web/src/stores/settings.spec.ts
@@ -1,0 +1,60 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiAbortError, ApiError } from '@/api/client';
+import { apiClient } from '@/api';
+import { makeSettings } from '@/api/__fixtures__/nodes';
+import { useSettingsStore } from './settings';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return { ...actual, apiClient: { ...actual.apiClient, settings: vi.fn() } };
+});
+
+const mockSettings = vi.mocked(apiClient.settings);
+
+describe('useSettingsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockSettings.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads settings on success', async () => {
+    const settings = makeSettings({ server_version: '9.9.9' });
+    mockSettings.mockResolvedValueOnce(settings);
+    const store = useSettingsStore();
+    await store.load();
+    expect(store.data).toEqual(settings);
+    expect(store.error).toBeNull();
+  });
+
+  it('captures non-abort errors', async () => {
+    mockSettings.mockRejectedValueOnce(new ApiError(503, 'down'));
+    const store = useSettingsStore();
+    await store.load();
+    expect(store.data).toBeNull();
+    expect(store.error).toBeInstanceOf(ApiError);
+  });
+
+  it('swallows ApiAbortError', async () => {
+    mockSettings.mockRejectedValueOnce(new ApiAbortError('redirect'));
+    const store = useSettingsStore();
+    await store.load();
+    expect(store.error).toBeNull();
+  });
+
+  it('skips concurrent loads', async () => {
+    let resolve: (v: ReturnType<typeof makeSettings>) => void = () => {};
+    mockSettings.mockReturnValueOnce(new Promise((r) => (resolve = r)));
+    const store = useSettingsStore();
+    const first = store.load();
+    void store.load();
+    expect(mockSettings).toHaveBeenCalledTimes(1);
+    resolve(makeSettings());
+    await first;
+    expect(mockSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/nodelite-server/web/src/stores/settings.ts
+++ b/nodelite-server/web/src/stores/settings.ts
@@ -27,7 +27,7 @@ export const useSettingsStore = defineStore('settings', () => {
     }
   }
 
-  /** Load once; pages call this on mount. Re-fetches even if data exists. */
+  /** Alias for refresh(); pages call this on mount for readability. */
   async function load(): Promise<void> {
     await refresh();
   }

--- a/nodelite-server/web/src/stores/settings.ts
+++ b/nodelite-server/web/src/stores/settings.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia';
+import { ref, shallowRef } from 'vue';
+import { apiClient, type SettingsResponse } from '@/api';
+import { ApiAbortError } from '@/api/client';
+
+/**
+ * Global server settings (GET /api/settings) — shared by the Settings and
+ * Account pages and the NodeDetail per-node settings tab. Single global
+ * resource (no id), so a simple concurrent-load guard suffices.
+ */
+export const useSettingsStore = defineStore('settings', () => {
+  const data = shallowRef<SettingsResponse | null>(null);
+  const loading = ref(false);
+  const error = ref<Error | null>(null);
+
+  async function refresh(): Promise<void> {
+    if (loading.value) return;
+    loading.value = true;
+    error.value = null;
+    try {
+      data.value = await apiClient.settings();
+    } catch (e) {
+      if (e instanceof ApiAbortError) return;
+      error.value = e instanceof Error ? e : new Error(String(e));
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /** Load once; pages call this on mount. Re-fetches even if data exists. */
+  async function load(): Promise<void> {
+    await refresh();
+  }
+
+  return { data, loading, error, load, refresh };
+});

--- a/nodelite-server/web/src/views/SettingsView.spec.ts
+++ b/nodelite-server/web/src/views/SettingsView.spec.ts
@@ -101,7 +101,7 @@ describe('SettingsView', () => {
     vi.clearAllMocks();
   });
 
-  it('loads settings on mount and renders the three cards', async () => {
+  async function mountView() {
     const pinia = createPinia();
     setActivePinia(pinia);
     const router = makeRouter();
@@ -109,11 +109,25 @@ describe('SettingsView', () => {
     await router.isReady();
     const wrapper = mount(SettingsView, { global: { plugins: [pinia, router, getI18n()] } });
     await flushPromises();
+    return wrapper;
+  }
 
+  it('loads settings on mount and renders the three cards', async () => {
+    const wrapper = await mountView();
     expect(mockSettings).toHaveBeenCalled();
     expect(wrapper.find('[data-test="settings-view"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="server-update-card"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="ops-card"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="token-table"]').exists()).toBe(true);
+  });
+
+  it('shows an error message (not an infinite spinner) when the load fails', async () => {
+    const { ApiError } = await import('@/api/client');
+    mockSettings.mockReset();
+    mockSettings.mockRejectedValueOnce(new ApiError(503, 'service unavailable'));
+    const wrapper = await mountView();
+    expect(wrapper.find('[data-test="settings-loading"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="server-update-card"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="settings-error"]').exists()).toBe(true);
   });
 });

--- a/nodelite-server/web/src/views/SettingsView.spec.ts
+++ b/nodelite-server/web/src/views/SettingsView.spec.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { apiClient } from '@/api';
+import { makeSettings } from '@/api/__fixtures__/nodes';
+import SettingsView from './SettingsView.vue';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return { ...actual, apiClient: { ...actual.apiClient, settings: vi.fn() } };
+});
+
+const mockSettings = vi.mocked(apiClient.settings);
+
+const FAKE_DICT = {
+  en: {
+    'settings.heading': 'Settings',
+    'settings.subtitle': 'sub',
+    'common.waiting_for_data': 'Waiting…',
+    'common.language': 'Language',
+    'common.theme_toggle': 'Toggle theme',
+    'index.nav.overview': 'Overview',
+    'index.nav.settings': 'Settings',
+    'index.nav.alerts': 'Alerts',
+    'index.nav.account': 'Account',
+    'settings.version.title': 'Version',
+    'settings.version.current': 'Current',
+    'settings.version.repository': 'Repo',
+    'settings.version.public_url': 'URL',
+    'settings.version.listen': 'Listen',
+    'settings.version.check_updates': 'Check',
+    'settings.version.open_release': 'Releases',
+    'settings.version.manual_update_note_password': 'note',
+    'settings.version.manual_update_note_2fa': 'note',
+    'settings.version.update_now': 'Update',
+    'settings.password.current': 'Current password',
+    'settings.security.verification_code': 'code',
+    'settings.ops.title': 'Operations',
+    'settings.ops.config': 'Config',
+    'settings.ops.registry': 'Registry',
+    'settings.ops.history': 'History',
+    'settings.ops.snapshot': 'Snapshot',
+    'settings.ops.server_upgrade': 'srv',
+    'settings.ops.agent_upgrade': 'agent',
+    'settings.tokens.title': 'Tokens',
+    'settings.tokens.empty': 'none',
+    'settings.tokens.node': 'Node',
+    'settings.tokens.status': 'Status',
+    'settings.tokens.agent': 'Agent',
+    'settings.tokens.ip': 'IP',
+    'settings.tokens.expires_at': 'Expires',
+    'settings.tokens.remaining': 'Remaining',
+    'settings.token.no_expiry': 'No expiry',
+    'settings.token.expired': 'Expired',
+    'settings.duration.days_hours': '{days}d {hours}h',
+    'settings.duration.minutes': '{minutes}m',
+    'common.online': 'Online',
+    'common.offline': 'Offline',
+    'common.not_available': 'n/a',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: Stub },
+      { path: '/nodes/:id', component: Stub },
+      { path: '/settings', name: 'settings', component: SettingsView },
+    ],
+  });
+}
+
+describe('SettingsView', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    mockSettings.mockResolvedValue(makeSettings());
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(String(url).includes('ui-i18n') ? FAKE_DICT : { tag_name: 'v2.3.0' }),
+        } as unknown as Response),
+      ),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('loads settings on mount and renders the three cards', async () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const router = makeRouter();
+    await router.push('/settings');
+    await router.isReady();
+    const wrapper = mount(SettingsView, { global: { plugins: [pinia, router, getI18n()] } });
+    await flushPromises();
+
+    expect(mockSettings).toHaveBeenCalled();
+    expect(wrapper.find('[data-test="settings-view"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="server-update-card"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="ops-card"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="token-table"]').exists()).toBe(true);
+  });
+});

--- a/nodelite-server/web/src/views/SettingsView.vue
+++ b/nodelite-server/web/src/views/SettingsView.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import AppLayout from '@/components/AppLayout.vue';
+import ServerUpdateCard from '@/components/ServerUpdateCard.vue';
+import OpsCard from '@/components/OpsCard.vue';
+import TokenTable from '@/components/TokenTable.vue';
+import { useSettingsStore } from '@/stores/settings';
+
+const { t } = useI18n();
+const store = useSettingsStore();
+
+onMounted(() => {
+  void store.load();
+});
+</script>
+
+<template>
+  <AppLayout>
+    <template #title>
+      <h1 class="page-heading">{{ t('settings.heading') }}</h1>
+      <p class="page-subtitle">{{ t('settings.subtitle') }}</p>
+    </template>
+
+    <section class="settings" data-test="settings-view">
+      <p v-if="!store.data" class="placeholder" data-test="settings-loading">
+        {{ t('common.waiting_for_data') }}
+      </p>
+      <template v-else>
+        <div class="settings__grid">
+          <ServerUpdateCard :settings="store.data" />
+          <OpsCard :settings="store.data" />
+        </div>
+        <TokenTable :agents="store.data.agents" />
+      </template>
+    </section>
+  </AppLayout>
+</template>
+
+<style scoped>
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.settings__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+.page-heading {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.page-subtitle {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.placeholder {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+</style>

--- a/nodelite-server/web/src/views/SettingsView.vue
+++ b/nodelite-server/web/src/views/SettingsView.vue
@@ -5,6 +5,7 @@ import AppLayout from '@/components/AppLayout.vue';
 import ServerUpdateCard from '@/components/ServerUpdateCard.vue';
 import OpsCard from '@/components/OpsCard.vue';
 import TokenTable from '@/components/TokenTable.vue';
+import SettingsMessage from '@/components/SettingsMessage.vue';
 import { useSettingsStore } from '@/stores/settings';
 
 const { t } = useI18n();
@@ -23,16 +24,22 @@ onMounted(() => {
     </template>
 
     <section class="settings" data-test="settings-view">
-      <p v-if="!store.data" class="placeholder" data-test="settings-loading">
-        {{ t('common.waiting_for_data') }}
-      </p>
-      <template v-else>
+      <template v-if="store.data">
         <div class="settings__grid">
           <ServerUpdateCard :settings="store.data" />
           <OpsCard :settings="store.data" />
         </div>
         <TokenTable :agents="store.data.agents" />
       </template>
+      <SettingsMessage
+        v-else-if="store.error"
+        state="error"
+        :text="store.error.message"
+        data-test="settings-error"
+      />
+      <p v-else class="placeholder" data-test="settings-loading">
+        {{ t('common.waiting_for_data') }}
+      </p>
     </section>
   </AppLayout>
 </template>


### PR DESCRIPTION
## Summary

First of the Stage 2.5 admin PRs (Settings / Account / Alerts). This ports the legacy dashboard **Settings** tab (`index-settings.js` system half) to a standalone `/settings` route. 5 commits, squash on merge. **No server changes**; all i18n keys already exist.

### Routing decision
The legacy dashboard used hash-tabs; the SPA already routes `/` and `/nodes/:id`, so the admin sections become **top-level routes**. This PR adds `/settings`; Account (`/account`) and Alerts (`/alerts`) follow in 2.5b/2.5c. The sidebar Settings button is now a `<RouterLink>`; Alerts/Account stay disabled until their PRs.

### What's in
- **API**: `SettingsResponse` (+auth/updates/agent-token) + `SettingsActionResponse` + `ReauthPayload` types; `settings()` / `updateServer()` wrappers.
- **`useSettingsStore`** — `GET /api/settings`, shared by Settings/Account/(node) tabs.
- **Shared `ReauthFields`** — reauth inputs for sensitive writes; variants port the legacy confirmation logic (server-update = code|password by 2FA; standard = password + code-if-2FA; both). **Shared `SettingsMessage`** (ok/error). **`lib/apiError.ts`** `messageFromError` pulls the server `{ok,message}` out of an `ApiError` body.
- **Cards**: `ServerUpdateCard` (version KV + check-for-update via GitHub `releases/latest` + `isNewerVersion`; manual update `POST` with reauth + status), `OpsCard` (read-only paths + upgrade commands), `TokenTable` (agent token expiry with remaining duration + severity).
- **`lib/version.ts`** (`compareVersions`/`isNewerVersion`) + `lib/format.ts` `tokenRemaining`/`tokenSeverity`, all pure + unit-tested.

### Deferred (noted)
The legacy server-update **live log streaming console** is not ported here — this PR ships the trigger + status. The live console is a sizable streaming feature best added as a follow-up; the manual-update flow is functional without it.

## Test plan
- [x] `pnpm lint` / `typecheck` / `test` (267 tests) / `build` — clean
- [ ] Manual: `/settings` shows server info + token table; "check updates" hits GitHub; manual update posts with reauth and surfaces the server message on bad password/code

## Next
- **2.5b** — Account page (2FA + password)
- **2.5c/d** — Alerts page (the big form)
- **2.5e** — NodeDetail per-node settings (token refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)