### PR TITLE
Stage 2.5b — Account page (2FA / password / logout)

### DIFF
--- a/nodelite-server/web/src/api/index.ts
+++ b/nodelite-server/web/src/api/index.ts
@@ -7,6 +7,9 @@ import { api } from './client';
 import type {
   AgentLogEntry,
   BootstrapResponse,
+  ChangePasswordRequest,
+  DisableTwoFactorRequest,
+  EnableTwoFactorRequest,
   HistoryPoint,
   HistoryQuery,
   NodeListItem,
@@ -15,12 +18,16 @@ import type {
   ReauthPayload,
   SettingsActionResponse,
   SettingsResponse,
+  TwoFactorSetupResponse,
 } from './types';
 
 export type {
   AgentLogEntry,
   BootstrapResponse,
+  ChangePasswordRequest,
+  DisableTwoFactorRequest,
   DiskUsage,
+  EnableTwoFactorRequest,
   HistoryPoint,
   HistoryQuery,
   LogLevel,
@@ -37,7 +44,16 @@ export type {
   SettingsAuth,
   SettingsResponse,
   SettingsUpdates,
+  TwoFactorSetupResponse,
 } from './types';
+
+function postJson<T>(path: string, body: unknown): Promise<T> {
+  return api<T>(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
 
 export const apiClient = {
   bootstrap: () => api<BootstrapResponse>('/api/bootstrap'),
@@ -71,9 +87,15 @@ export const apiClient = {
   // --- Settings ---
   settings: () => api<SettingsResponse>('/api/settings'),
   updateServer: (body: ReauthPayload) =>
-    api<SettingsActionResponse>('/api/settings/update/server', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-    }),
+    postJson<SettingsActionResponse>('/api/settings/update/server', body),
+
+  // --- Account / security ---
+  twoFactorStart: () =>
+    postJson<TwoFactorSetupResponse>('/api/settings/2fa/start', {}),
+  twoFactorEnable: (body: EnableTwoFactorRequest) =>
+    postJson<SettingsActionResponse>('/api/settings/2fa/enable', body),
+  twoFactorDisable: (body: DisableTwoFactorRequest) =>
+    postJson<SettingsActionResponse>('/api/settings/2fa/disable', body),
+  changePassword: (body: ChangePasswordRequest) =>
+    postJson<SettingsActionResponse>('/api/settings/password', body),
 };

--- a/nodelite-server/web/src/api/types.ts
+++ b/nodelite-server/web/src/api/types.ts
@@ -203,3 +203,29 @@ export interface ReauthPayload {
   current_password?: string;
   code?: string;
 }
+
+/** GET /api/settings/2fa/start — TwoFactorSetupResponse */
+export interface TwoFactorSetupResponse {
+  secret: string;
+  otpauth_uri: string;
+  qr_svg: string;
+}
+
+/** POST /api/settings/2fa/enable */
+export interface EnableTwoFactorRequest {
+  current_password: string;
+  secret: string;
+  code: string;
+}
+
+/** POST /api/settings/2fa/disable */
+export interface DisableTwoFactorRequest {
+  current_password: string;
+  code: string;
+}
+
+/** POST /api/settings/password */
+export interface ChangePasswordRequest {
+  current_password: string;
+  new_password: string;
+}

--- a/nodelite-server/web/src/components/ChangePasswordCard.spec.ts
+++ b/nodelite-server/web/src/components/ChangePasswordCard.spec.ts
@@ -62,11 +62,15 @@ describe('ChangePasswordCard', () => {
     Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
   });
 
-  it('generate fills a strong new password', async () => {
+  it('generate fills a strong new password and reveals it', async () => {
     const wrapper = mountCard();
+    const field = wrapper.find('[data-test="password-new"]');
+    expect(field.attributes('type')).toBe('password');
     await wrapper.find('[data-test="password-generate"]').trigger('click');
-    const value = (wrapper.find('[data-test="password-new"]').element as HTMLInputElement).value;
-    expect(value.length).toBeGreaterThanOrEqual(8);
+    const input = field.element as HTMLInputElement;
+    expect(input.value.length).toBeGreaterThanOrEqual(8);
+    // revealed so the user can read/copy before the post-submit redirect
+    expect(field.attributes('type')).toBe('text');
   });
 
   it('on success: clears the auth timestamp and navigates to logout-and-reauth', async () => {
@@ -81,6 +85,8 @@ describe('ChangePasswordCard', () => {
 
     expect(mockChange).toHaveBeenCalledWith({ current_password: 'old', new_password: 'newpassword1' });
     expect(wrapper.find('[data-test="settings-message"]').text()).toContain('sign in again');
+    // submit stays disabled through the logout window (no stale double-submit)
+    expect(wrapper.find('[data-test="password-submit"]').attributes('disabled')).toBeDefined();
     // navigation happens after the brief delay
     expect(assignSpy).not.toHaveBeenCalled();
     vi.advanceTimersByTime(900);

--- a/nodelite-server/web/src/components/ChangePasswordCard.spec.ts
+++ b/nodelite-server/web/src/components/ChangePasswordCard.spec.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { apiClient } from '@/api';
+import { AUTH_TIMESTAMP_KEY } from '@/auth/expiry';
+import ChangePasswordCard from './ChangePasswordCard.vue';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return { ...actual, apiClient: { ...actual.apiClient, changePassword: vi.fn() } };
+});
+
+const mockChange = vi.mocked(apiClient.changePassword);
+
+const FAKE_DICT = {
+  en: {
+    'settings.password.title': 'Change Password',
+    'settings.password.current': 'Current password',
+    'settings.password.new': 'New password',
+    'settings.password.generate': 'Generate',
+    'settings.password.submit': 'Update password',
+    'settings.password.saving': 'Updating…',
+    'settings.password.saved': 'Password updated. Please sign in again.',
+    'settings.password.failed': 'Failed: {error}',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountCard() {
+  return mount(ChangePasswordCard, { global: { plugins: [getI18n()] } });
+}
+
+describe('ChangePasswordCard', () => {
+  let assignSpy: ReturnType<typeof vi.fn>;
+  let originalLocation: Location;
+
+  beforeEach(async () => {
+    __resetI18nForTest();
+    mockChange.mockReset();
+    window.localStorage.clear();
+    originalLocation = window.location;
+    assignSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, assign: assignSpy },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  });
+
+  it('generate fills a strong new password', async () => {
+    const wrapper = mountCard();
+    await wrapper.find('[data-test="password-generate"]').trigger('click');
+    const value = (wrapper.find('[data-test="password-new"]').element as HTMLInputElement).value;
+    expect(value.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('on success: clears the auth timestamp and navigates to logout-and-reauth', async () => {
+    vi.useFakeTimers();
+    window.localStorage.setItem(AUTH_TIMESTAMP_KEY, '12345');
+    mockChange.mockResolvedValueOnce({ ok: true, message: '' });
+    const wrapper = mountCard();
+    await wrapper.find('[data-test="password-current"]').setValue('old');
+    await wrapper.find('[data-test="password-new"]').setValue('newpassword1');
+    await wrapper.find('[data-test="password-form"]').trigger('submit');
+    await flushPromises();
+
+    expect(mockChange).toHaveBeenCalledWith({ current_password: 'old', new_password: 'newpassword1' });
+    expect(wrapper.find('[data-test="settings-message"]').text()).toContain('sign in again');
+    // navigation happens after the brief delay
+    expect(assignSpy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(900);
+    expect(window.localStorage.getItem(AUTH_TIMESTAMP_KEY)).toBeNull();
+    expect(assignSpy).toHaveBeenCalledWith('/logout-and-reauth');
+  });
+
+  it('surfaces the server error and does not navigate', async () => {
+    const { ApiError } = await import('@/api/client');
+    mockChange.mockRejectedValueOnce(new ApiError(400, JSON.stringify({ ok: false, message: 'wrong password' })));
+    const wrapper = mountCard();
+    await wrapper.find('[data-test="password-current"]').setValue('bad');
+    await wrapper.find('[data-test="password-new"]').setValue('newpassword1');
+    await wrapper.find('[data-test="password-form"]').trigger('submit');
+    await flushPromises();
+    expect(wrapper.find('[data-test="settings-message"]').text()).toContain('wrong password');
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+});

--- a/nodelite-server/web/src/components/ChangePasswordCard.vue
+++ b/nodelite-server/web/src/components/ChangePasswordCard.vue
@@ -15,9 +15,16 @@ const LOGOUT_DELAY_MS = 900;
 const form = reactive({ current_password: '', new_password: '' });
 const message = reactive<{ state: 'ok' | 'error' | null; text: string }>({ state: null, text: '' });
 const busy = ref(false);
+// Reveal the new-password field after generating so the user can read/copy
+// the value before the post-submit redirect to /logout-and-reauth.
+const revealNew = ref(false);
+// On success the page navigates away after a short delay; keep the submit
+// disabled through that window so a double-click can't fire a stale retry.
+const leaving = ref(false);
 
 function suggest(): void {
   form.new_password = generatePassword();
+  revealNew.value = true;
 }
 
 /** Drop the client session and bounce to reauth (same as logout). */
@@ -43,6 +50,7 @@ async function submit(): Promise<void> {
     message.text = t('settings.password.saved');
     // Password changed → session is invalidated; show the message briefly,
     // then drop to reauth (matches legacy 900ms behavior).
+    leaving.value = true;
     window.setTimeout(finishLogout, LOGOUT_DELAY_MS);
   } catch (e) {
     if (e instanceof ApiAbortError) return;
@@ -72,7 +80,7 @@ async function submit(): Promise<void> {
         <span>{{ t('settings.password.new') }}</span>
         <input
           v-model="form.new_password"
-          type="password"
+          :type="revealNew ? 'text' : 'password'"
           autocomplete="new-password"
           minlength="8"
           data-test="password-new"
@@ -83,7 +91,7 @@ async function submit(): Promise<void> {
         <button type="button" class="btn" data-test="password-generate" @click="suggest">
           {{ t('settings.password.generate') }}
         </button>
-        <button type="submit" class="btn btn--primary" :disabled="busy" data-test="password-submit">
+        <button type="submit" class="btn btn--primary" :disabled="busy || leaving" data-test="password-submit">
           {{ t('settings.password.submit') }}
         </button>
       </div>

--- a/nodelite-server/web/src/components/ChangePasswordCard.vue
+++ b/nodelite-server/web/src/components/ChangePasswordCard.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { apiClient } from '@/api';
+import { ApiAbortError } from '@/api/client';
+import { AUTH_TIMESTAMP_KEY } from '@/auth/expiry';
+import { messageFromError } from '@/lib/apiError';
+import { generatePassword } from '@/lib/password';
+import SettingsMessage from './SettingsMessage.vue';
+
+const { t } = useI18n();
+
+const LOGOUT_DELAY_MS = 900;
+
+const form = reactive({ current_password: '', new_password: '' });
+const message = reactive<{ state: 'ok' | 'error' | null; text: string }>({ state: null, text: '' });
+const busy = ref(false);
+
+function suggest(): void {
+  form.new_password = generatePassword();
+}
+
+/** Drop the client session and bounce to reauth (same as logout). */
+function finishLogout(): void {
+  try {
+    window.localStorage.removeItem(AUTH_TIMESTAMP_KEY);
+  } catch {
+    /* localStorage unavailable */
+  }
+  window.location.assign('/logout-and-reauth');
+}
+
+async function submit(): Promise<void> {
+  busy.value = true;
+  message.state = null;
+  message.text = t('settings.password.saving');
+  try {
+    await apiClient.changePassword({
+      current_password: form.current_password,
+      new_password: form.new_password,
+    });
+    message.state = 'ok';
+    message.text = t('settings.password.saved');
+    // Password changed → session is invalidated; show the message briefly,
+    // then drop to reauth (matches legacy 900ms behavior).
+    window.setTimeout(finishLogout, LOGOUT_DELAY_MS);
+  } catch (e) {
+    if (e instanceof ApiAbortError) return;
+    message.state = 'error';
+    message.text = t('settings.password.failed', { error: messageFromError(e, 'unknown') });
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<template>
+  <article class="panel" data-test="change-password-card">
+    <h2 class="card-title">{{ t('settings.password.title') }}</h2>
+    <form class="form" data-test="password-form" @submit.prevent="submit">
+      <label class="field">
+        <span>{{ t('settings.password.current') }}</span>
+        <input
+          v-model="form.current_password"
+          type="password"
+          autocomplete="current-password"
+          data-test="password-current"
+          required
+        />
+      </label>
+      <label class="field">
+        <span>{{ t('settings.password.new') }}</span>
+        <input
+          v-model="form.new_password"
+          type="password"
+          autocomplete="new-password"
+          minlength="8"
+          data-test="password-new"
+          required
+        />
+      </label>
+      <div class="actions">
+        <button type="button" class="btn" data-test="password-generate" @click="suggest">
+          {{ t('settings.password.generate') }}
+        </button>
+        <button type="submit" class="btn btn--primary" :disabled="busy" data-test="password-submit">
+          {{ t('settings.password.submit') }}
+        </button>
+      </div>
+      <SettingsMessage :state="message.state" :text="message.text" />
+    </form>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.field input {
+  background: var(--bg-card-soft);
+  color: var(--text-primary);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+}
+.actions {
+  display: flex;
+  gap: 8px;
+}
+.btn {
+  background: var(--bg-card-soft);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 8px 14px;
+  font: inherit;
+}
+.btn--primary {
+  color: #fff;
+  background: var(--accent-blue);
+  border-color: transparent;
+}
+</style>

--- a/nodelite-server/web/src/components/ReauthFields.vue
+++ b/nodelite-server/web/src/components/ReauthFields.vue
@@ -12,10 +12,12 @@ import { useI18n } from 'vue-i18n';
  */
 const props = withDefaults(
   defineProps<{
-    twoFactorEnabled: boolean;
+    // Only consulted by the 'server-update' and 'standard' variants; 'both'
+    // always shows password + code, so callers using it can omit this.
+    twoFactorEnabled?: boolean;
     variant?: 'server-update' | 'standard' | 'both';
   }>(),
-  { variant: 'standard' },
+  { twoFactorEnabled: false, variant: 'standard' },
 );
 
 const currentPassword = defineModel<string>('currentPassword', { default: '' });

--- a/nodelite-server/web/src/components/SidebarNav.spec.ts
+++ b/nodelite-server/web/src/components/SidebarNav.spec.ts
@@ -29,6 +29,7 @@ function makeRouter(): Router {
       { path: '/', name: 'dashboard', component: Stub },
       { path: '/nodes/:id', name: 'node-detail', component: Stub },
       { path: '/settings', name: 'settings', component: Stub },
+      { path: '/account', name: 'account', component: Stub },
     ],
   });
 }
@@ -85,15 +86,23 @@ describe('SidebarNav', () => {
     expect(settings.classes()).toContain('active');
   });
 
-  it('still disables the not-yet-built buttons (alerts/account)', async () => {
+  it('links Account and marks it active on /account', async () => {
+    const router = makeRouter();
+    await router.push('/account');
+    await router.isReady();
+    const wrapper = mount(SidebarNav, { global: { plugins: [router, getI18n()] } });
+
+    const account = wrapper.find('[data-test="nav-account"]');
+    expect(account.attributes('disabled')).toBeUndefined();
+    expect(account.classes()).toContain('active');
+  });
+
+  it('still disables the not-yet-built button (alerts)', async () => {
     const router = makeRouter();
     await router.push('/');
     await router.isReady();
     const wrapper = mount(SidebarNav, { global: { plugins: [router, getI18n()] } });
 
-    for (const tab of ['nav-alerts', 'nav-account']) {
-      const el = wrapper.find(`[data-test="${tab}"]`);
-      expect(el.attributes('disabled')).toBeDefined();
-    }
+    expect(wrapper.find('[data-test="nav-alerts"]').attributes('disabled')).toBeDefined();
   });
 });

--- a/nodelite-server/web/src/components/SidebarNav.vue
+++ b/nodelite-server/web/src/components/SidebarNav.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useRoute } from 'vue-router';
 
-// Settings / Alerts / Account land in Stage 2.5; they render as disabled
-// icon buttons so the rail matches the legacy layout but don't navigate.
+// Alerts lands later in Stage 2.5; it renders as a disabled icon button so
+// the rail matches the legacy layout but doesn't navigate yet.
 const route = useRoute();
 </script>
 
@@ -78,11 +78,11 @@ const route = useRoute();
     </button>
 
     <div class="sidebar-bottom">
-      <button
-        type="button"
+      <RouterLink
         class="nav-button avatar-button"
-        disabled
-        :title="`${$t('index.nav.account')} (Stage 2.5)`"
+        :class="{ active: route.path === '/account' }"
+        to="/account"
+        :title="$t('index.nav.account')"
         :aria-label="$t('index.nav.account')"
         data-test="nav-account"
       >
@@ -99,7 +99,7 @@ const route = useRoute();
             <circle cx="12" cy="7" r="4" />
           </svg>
         </div>
-      </button>
+      </RouterLink>
     </div>
   </aside>
 </template>

--- a/nodelite-server/web/src/components/TwoFactorPanel.spec.ts
+++ b/nodelite-server/web/src/components/TwoFactorPanel.spec.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { apiClient } from '@/api';
+import type { SettingsAuth } from '@/api';
+import TwoFactorPanel from './TwoFactorPanel.vue';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return {
+    ...actual,
+    apiClient: {
+      ...actual.apiClient,
+      twoFactorStart: vi.fn(),
+      twoFactorEnable: vi.fn(),
+      twoFactorDisable: vi.fn(),
+    },
+  };
+});
+
+const mockStart = vi.mocked(apiClient.twoFactorStart);
+const mockEnable = vi.mocked(apiClient.twoFactorEnable);
+const mockDisable = vi.mocked(apiClient.twoFactorDisable);
+
+const FAKE_DICT = {
+  en: {
+    'settings.security.2fa': '2FA',
+    'settings.security.2fa_note': 'note',
+    'settings.security.start_2fa': 'Set up',
+    'settings.security.starting_2fa': 'Generating…',
+    'settings.security.setup_note': 'setup',
+    'settings.security.enable_2fa': 'Enable',
+    'settings.security.disable_2fa': 'Disable',
+    'settings.security.disable_note': 'disable note',
+    'settings.security.cancel_setup': 'Cancel',
+    'settings.security.enabling_2fa': 'Enabling…',
+    'settings.security.disabling_2fa': 'Disabling…',
+    'settings.security.enabled_saved': '2FA enabled.',
+    'settings.security.disabled_saved': '2FA disabled.',
+    'settings.security.action_failed': 'Failed: {error}',
+    'settings.password.current': 'Current password',
+    'settings.security.verification_code': 'code',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function auth(over: Partial<SettingsAuth> = {}): SettingsAuth {
+  return {
+    enabled: true, username: 'admin', two_factor_enabled: false,
+    totp_secret_configured: false, session_ttl_secs: 86_400, pending_ttl_secs: 300, ...over,
+  };
+}
+
+function mountPanel(a: SettingsAuth) {
+  return mount(TwoFactorPanel, { props: { auth: a }, global: { plugins: [getI18n()] } });
+}
+
+describe('TwoFactorPanel', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    mockStart.mockReset();
+    mockEnable.mockReset();
+    mockDisable.mockReset();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('idle: shows the start button', () => {
+    const wrapper = mountPanel(auth({ two_factor_enabled: false }));
+    expect(wrapper.find('[data-test="start-2fa"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="enable-2fa-form"]').exists()).toBe(false);
+  });
+
+  it('start → pending-setup shows QR + secret + enable form', async () => {
+    mockStart.mockResolvedValueOnce({ secret: 'SECRET123', otpauth_uri: 'otpauth://x', qr_svg: '<svg data-test="svg"></svg>' });
+    const wrapper = mountPanel(auth({ two_factor_enabled: false }));
+    await wrapper.find('[data-test="start-2fa"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="totp-secret"]').text()).toBe('SECRET123');
+    expect(wrapper.find('[data-test="totp-qr"]').html()).toContain('<svg');
+    expect(wrapper.find('[data-test="enable-2fa-form"]').exists()).toBe(true);
+  });
+
+  it('enable posts password+secret+code and emits changed', async () => {
+    mockStart.mockResolvedValueOnce({ secret: 'S1', otpauth_uri: 'x', qr_svg: '<svg/>' });
+    mockEnable.mockResolvedValueOnce({ ok: true, message: '' });
+    const wrapper = mountPanel(auth({ two_factor_enabled: false }));
+    await wrapper.find('[data-test="start-2fa"]').trigger('click');
+    await flushPromises();
+    await wrapper.find('[data-test="enable-2fa-form"] [data-test="reauth-password"]').setValue('pw');
+    await wrapper.find('[data-test="enable-2fa-form"] [data-test="reauth-code"]').setValue('123456');
+    await wrapper.find('[data-test="enable-2fa-form"]').trigger('submit');
+    await flushPromises();
+    expect(mockEnable).toHaveBeenCalledWith({ current_password: 'pw', secret: 'S1', code: '123456' });
+    expect(wrapper.emitted('changed')).toHaveLength(1);
+  });
+
+  it('enabled: shows the disable form and posts password+code', async () => {
+    mockDisable.mockResolvedValueOnce({ ok: true, message: '' });
+    const wrapper = mountPanel(auth({ two_factor_enabled: true }));
+    expect(wrapper.find('[data-test="disable-2fa-form"]').exists()).toBe(true);
+    await wrapper.find('[data-test="disable-2fa-form"] [data-test="reauth-password"]').setValue('pw');
+    await wrapper.find('[data-test="disable-2fa-form"] [data-test="reauth-code"]').setValue('654321');
+    await wrapper.find('[data-test="disable-2fa-form"]').trigger('submit');
+    await flushPromises();
+    expect(mockDisable).toHaveBeenCalledWith({ current_password: 'pw', code: '654321' });
+    expect(wrapper.emitted('changed')).toHaveLength(1);
+  });
+
+  it('surfaces the server error on a failed enable', async () => {
+    const { ApiError } = await import('@/api/client');
+    mockStart.mockResolvedValueOnce({ secret: 'S', otpauth_uri: 'x', qr_svg: '<svg/>' });
+    mockEnable.mockRejectedValueOnce(new ApiError(400, JSON.stringify({ ok: false, message: 'bad code' })));
+    const wrapper = mountPanel(auth({ two_factor_enabled: false }));
+    await wrapper.find('[data-test="start-2fa"]').trigger('click');
+    await flushPromises();
+    await wrapper.find('[data-test="enable-2fa-form"] [data-test="reauth-password"]').setValue('pw');
+    await wrapper.find('[data-test="enable-2fa-form"] [data-test="reauth-code"]').setValue('000000');
+    await wrapper.find('[data-test="enable-2fa-form"]').trigger('submit');
+    await flushPromises();
+    expect(wrapper.find('[data-test="settings-message"]').text()).toContain('bad code');
+    expect(wrapper.emitted('changed')).toBeUndefined();
+  });
+});

--- a/nodelite-server/web/src/components/TwoFactorPanel.vue
+++ b/nodelite-server/web/src/components/TwoFactorPanel.vue
@@ -110,7 +110,6 @@ async function disable(): Promise<void> {
         <ReauthFields
           v-model:current-password="form.currentPassword"
           v-model:code="form.code"
-          :two-factor-enabled="true"
           variant="both"
         />
         <button type="submit" class="btn btn--danger" :disabled="busy" data-test="disable-2fa">
@@ -137,7 +136,6 @@ async function disable(): Promise<void> {
         <ReauthFields
           v-model:current-password="form.currentPassword"
           v-model:code="form.code"
-          :two-factor-enabled="true"
           variant="both"
         />
         <div class="actions">

--- a/nodelite-server/web/src/components/TwoFactorPanel.vue
+++ b/nodelite-server/web/src/components/TwoFactorPanel.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { SettingsAuth, TwoFactorSetupResponse } from '@/api';
+import { apiClient } from '@/api';
+import { ApiAbortError } from '@/api/client';
+import { messageFromError } from '@/lib/apiError';
+import ReauthFields from './ReauthFields.vue';
+import SettingsMessage from './SettingsMessage.vue';
+
+const props = defineProps<{ auth: SettingsAuth }>();
+const emit = defineEmits<{ changed: [] }>();
+
+const { t } = useI18n();
+
+const pending = ref<TwoFactorSetupResponse | null>(null);
+const busy = ref(false);
+const message = reactive<{ state: 'ok' | 'error' | null; text: string }>({ state: null, text: '' });
+const form = reactive({ currentPassword: '', code: '' });
+
+const mode = computed<'enabled' | 'idle' | 'pending-setup'>(() => {
+  if (props.auth.two_factor_enabled) return 'enabled';
+  return pending.value ? 'pending-setup' : 'idle';
+});
+
+function resetForm(): void {
+  form.currentPassword = '';
+  form.code = '';
+}
+
+async function startSetup(): Promise<void> {
+  busy.value = true;
+  message.state = null;
+  message.text = t('settings.security.starting_2fa');
+  try {
+    pending.value = await apiClient.twoFactorStart();
+    message.state = null;
+    message.text = '';
+  } catch (e) {
+    if (e instanceof ApiAbortError) return;
+    message.state = 'error';
+    message.text = t('settings.security.action_failed', { error: messageFromError(e, 'unknown') });
+  } finally {
+    busy.value = false;
+  }
+}
+
+function cancelSetup(): void {
+  pending.value = null;
+  resetForm();
+  message.state = null;
+  message.text = '';
+}
+
+async function enable(): Promise<void> {
+  busy.value = true;
+  message.state = null;
+  message.text = t('settings.security.enabling_2fa');
+  try {
+    await apiClient.twoFactorEnable({
+      current_password: form.currentPassword,
+      secret: pending.value?.secret ?? '',
+      code: form.code,
+    });
+    pending.value = null;
+    resetForm();
+    message.state = 'ok';
+    message.text = t('settings.security.enabled_saved');
+    emit('changed');
+  } catch (e) {
+    if (e instanceof ApiAbortError) return;
+    message.state = 'error';
+    message.text = t('settings.security.action_failed', { error: messageFromError(e, 'unknown') });
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function disable(): Promise<void> {
+  busy.value = true;
+  message.state = null;
+  message.text = t('settings.security.disabling_2fa');
+  try {
+    await apiClient.twoFactorDisable({
+      current_password: form.currentPassword,
+      code: form.code,
+    });
+    resetForm();
+    message.state = 'ok';
+    message.text = t('settings.security.disabled_saved');
+    emit('changed');
+  } catch (e) {
+    if (e instanceof ApiAbortError) return;
+    message.state = 'error';
+    message.text = t('settings.security.action_failed', { error: messageFromError(e, 'unknown') });
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<template>
+  <article class="panel" data-test="two-factor-panel">
+    <h2 class="card-title">{{ t('settings.security.2fa') }}</h2>
+
+    <!-- Already enabled → disable form -->
+    <template v-if="mode === 'enabled'">
+      <p class="note">{{ t('settings.security.disable_note') }}</p>
+      <form data-test="disable-2fa-form" @submit.prevent="disable">
+        <ReauthFields
+          v-model:current-password="form.currentPassword"
+          v-model:code="form.code"
+          :two-factor-enabled="true"
+          variant="both"
+        />
+        <button type="submit" class="btn btn--danger" :disabled="busy" data-test="disable-2fa">
+          {{ t('settings.security.disable_2fa') }}
+        </button>
+      </form>
+    </template>
+
+    <!-- Not enabled, no setup in progress → start -->
+    <template v-else-if="mode === 'idle'">
+      <p class="note">{{ t('settings.security.2fa_note') }}</p>
+      <button type="button" class="btn btn--primary" :disabled="busy" data-test="start-2fa" @click="startSetup">
+        {{ t('settings.security.start_2fa') }}
+      </button>
+    </template>
+
+    <!-- Setup in progress → QR + enable form -->
+    <template v-else>
+      <p class="note">{{ t('settings.security.setup_note') }}</p>
+      <!-- eslint-disable-next-line vue/no-v-html -- qr_svg is a server-generated QR SVG from our own /api/settings/2fa/start, not user input -->
+      <div class="qr" data-test="totp-qr" v-html="pending!.qr_svg" />
+      <code class="secret" data-test="totp-secret">{{ pending!.secret }}</code>
+      <form data-test="enable-2fa-form" @submit.prevent="enable">
+        <ReauthFields
+          v-model:current-password="form.currentPassword"
+          v-model:code="form.code"
+          :two-factor-enabled="true"
+          variant="both"
+        />
+        <div class="actions">
+          <button type="submit" class="btn btn--primary" :disabled="busy" data-test="enable-2fa">
+            {{ t('settings.security.enable_2fa') }}
+          </button>
+          <button type="button" class="btn" :disabled="busy" data-test="cancel-2fa" @click="cancelSetup">
+            {{ t('settings.security.cancel_setup') }}
+          </button>
+        </div>
+      </form>
+    </template>
+
+    <SettingsMessage :state="message.state" :text="message.text" />
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.note {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin: 0 0 12px;
+}
+.qr {
+  width: 180px;
+  height: 180px;
+  background: #fff;
+  border-radius: 12px;
+  padding: 8px;
+  margin-bottom: 10px;
+}
+.qr :deep(svg) {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.secret {
+  display: inline-block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  background: var(--bg-card-soft);
+  border-radius: 6px;
+  padding: 6px 8px;
+  margin-bottom: 12px;
+  word-break: break-all;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.actions {
+  display: flex;
+  gap: 8px;
+}
+.btn {
+  align-self: flex-start;
+  background: var(--bg-card-soft);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 8px 14px;
+  font: inherit;
+}
+.btn--primary {
+  color: #fff;
+  background: var(--accent-blue);
+  border-color: transparent;
+}
+.btn--danger {
+  color: var(--accent-red);
+  border-color: var(--accent-red-soft);
+  background: var(--accent-red-soft);
+}
+</style>

--- a/nodelite-server/web/src/lib/password.spec.ts
+++ b/nodelite-server/web/src/lib/password.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { generatePassword, passwordFromBytes } from './password';
+
+const CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%';
+
+describe('passwordFromBytes', () => {
+  it('maps each byte to charset[byte % len]', () => {
+    const out = passwordFromBytes(new Uint8Array([0, 1, CHARS.length, CHARS.length + 2]));
+    expect(out).toBe(`${CHARS[0]}${CHARS[1]}${CHARS[0]}${CHARS[2]}`);
+  });
+
+  it('produces a string the length of the byte array', () => {
+    expect(passwordFromBytes(new Uint8Array(24))).toHaveLength(24);
+  });
+});
+
+describe('generatePassword', () => {
+  it('returns a string of the requested length from the charset', () => {
+    const pw = generatePassword(20);
+    expect(pw).toHaveLength(20);
+    for (const ch of pw) expect(CHARS).toContain(ch);
+  });
+
+  it('is (practically) non-repeating across calls', () => {
+    expect(generatePassword()).not.toBe(generatePassword());
+  });
+});

--- a/nodelite-server/web/src/lib/password.ts
+++ b/nodelite-server/web/src/lib/password.ts
@@ -1,0 +1,18 @@
+/**
+ * Password generator, ported from assets/index.html:2357. The byte→char
+ * mapping is pure (testable with injected bytes); generatePassword wraps it
+ * with crypto.getRandomValues for the suggest-password helper.
+ */
+
+const CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%';
+
+/** Map random bytes to the legacy charset. Pure. */
+export function passwordFromBytes(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => CHARS[b % CHARS.length]).join('');
+}
+
+export function generatePassword(length = 24): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return passwordFromBytes(bytes);
+}

--- a/nodelite-server/web/src/router/index.ts
+++ b/nodelite-server/web/src/router/index.ts
@@ -16,6 +16,11 @@ const routes: RouteRecordRaw[] = [
     name: 'settings',
     component: () => import('@/views/SettingsView.vue'),
   },
+  {
+    path: '/account',
+    name: 'account',
+    component: () => import('@/views/AccountView.vue'),
+  },
 ];
 
 export const router = createRouter({

--- a/nodelite-server/web/src/views/AccountView.spec.ts
+++ b/nodelite-server/web/src/views/AccountView.spec.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { apiClient } from '@/api';
+import { makeSettings } from '@/api/__fixtures__/nodes';
+import { AUTH_TIMESTAMP_KEY } from '@/auth/expiry';
+import AccountView from './AccountView.vue';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return { ...actual, apiClient: { ...actual.apiClient, settings: vi.fn() } };
+});
+
+const mockSettings = vi.mocked(apiClient.settings);
+
+const FAKE_DICT = {
+  en: {
+    'account.heading': 'Account',
+    'account.subtitle': 'sub',
+    'common.waiting_for_data': 'Waiting…',
+    'common.language': 'Language',
+    'common.theme_toggle': 'Toggle theme',
+    'common.online': 'Online',
+    'common.offline': 'Offline',
+    'common.not_available': 'n/a',
+    'index.nav.overview': 'Overview',
+    'index.nav.settings': 'Settings',
+    'index.nav.alerts': 'Alerts',
+    'index.nav.account': 'Account',
+    'settings.security.title': 'Security',
+    'settings.security.auth': 'Auth',
+    'settings.security.username': 'Username',
+    'settings.security.2fa': '2FA',
+    'settings.security.2fa_note': 'note',
+    'settings.security.session_ttl': 'Session TTL',
+    'settings.security.logout': 'Sign out',
+    'settings.security.start_2fa': 'Set up',
+    'settings.enabled': 'Enabled',
+    'settings.disabled': 'Disabled',
+    'settings.duration.days_hours': '{days}d {hours}h',
+    'settings.duration.minutes': '{minutes}m',
+    'settings.password.title': 'Change Password',
+    'settings.password.current': 'Current password',
+    'settings.password.new': 'New password',
+    'settings.password.generate': 'Generate',
+    'settings.password.submit': 'Update password',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: Stub },
+      { path: '/nodes/:id', component: Stub },
+      { path: '/settings', component: Stub },
+      { path: '/account', name: 'account', component: AccountView },
+    ],
+  });
+}
+
+describe('AccountView', () => {
+  let assignSpy: ReturnType<typeof vi.fn>;
+  let originalLocation: Location;
+
+  beforeEach(async () => {
+    __resetI18nForTest();
+    mockSettings.mockResolvedValue(makeSettings());
+    window.localStorage.clear();
+    originalLocation = window.location;
+    assignSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, assign: assignSpy },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+    vi.clearAllMocks();
+  });
+
+  async function mountView() {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const router = makeRouter();
+    await router.push('/account');
+    await router.isReady();
+    const wrapper = mount(AccountView, { global: { plugins: [pinia, router, getI18n()] } });
+    await flushPromises();
+    return wrapper;
+  }
+
+  it('loads settings on mount and renders security + 2FA + password cards', async () => {
+    const wrapper = await mountView();
+    expect(mockSettings).toHaveBeenCalled();
+    expect(wrapper.find('[data-test="security-card"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="two-factor-panel"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="change-password-card"]').exists()).toBe(true);
+  });
+
+  it('logout clears the auth timestamp and navigates to logout-and-reauth', async () => {
+    window.localStorage.setItem(AUTH_TIMESTAMP_KEY, '12345');
+    const wrapper = await mountView();
+    await wrapper.find('[data-test="account-logout"]').trigger('click');
+    expect(window.localStorage.getItem(AUTH_TIMESTAMP_KEY)).toBeNull();
+    expect(assignSpy).toHaveBeenCalledWith('/logout-and-reauth');
+  });
+
+  it('shows an error message (not an infinite spinner) when the load fails', async () => {
+    const { ApiError } = await import('@/api/client');
+    mockSettings.mockReset();
+    mockSettings.mockRejectedValueOnce(new ApiError(503, 'service unavailable'));
+    const wrapper = await mountView();
+    expect(wrapper.find('[data-test="account-loading"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="security-card"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="account-error"]').exists()).toBe(true);
+  });
+});

--- a/nodelite-server/web/src/views/AccountView.vue
+++ b/nodelite-server/web/src/views/AccountView.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import AppLayout from '@/components/AppLayout.vue';
+import TwoFactorPanel from '@/components/TwoFactorPanel.vue';
+import ChangePasswordCard from '@/components/ChangePasswordCard.vue';
+import SettingsMessage from '@/components/SettingsMessage.vue';
+import { AUTH_TIMESTAMP_KEY, LOGOUT_PATH } from '@/auth/expiry';
+import { tokenRemaining } from '@/lib/format';
+import { useSettingsStore } from '@/stores/settings';
+
+const { t } = useI18n();
+const store = useSettingsStore();
+
+onMounted(() => {
+  void store.load();
+});
+
+const auth = computed(() => store.data?.auth ?? null);
+
+function sessionTtlText(seconds: number): string {
+  const r = tokenRemaining(seconds);
+  switch (r.kind) {
+    case 'days_hours':
+      return t('settings.duration.days_hours', { days: r.days, hours: r.hours });
+    case 'minutes':
+      return t('settings.duration.minutes', { minutes: r.minutes });
+    default:
+      return t('common.not_available');
+  }
+}
+
+/** Drop the client session and bounce to reauth (same as the legacy logout). */
+function logout(): void {
+  try {
+    window.localStorage.removeItem(AUTH_TIMESTAMP_KEY);
+  } catch {
+    /* localStorage unavailable */
+  }
+  window.location.assign(LOGOUT_PATH);
+}
+</script>
+
+<template>
+  <AppLayout>
+    <template #title>
+      <h1 class="page-heading">{{ t('account.heading') }}</h1>
+      <p class="page-subtitle">{{ t('account.subtitle') }}</p>
+    </template>
+
+    <section class="account" data-test="account-view">
+      <template v-if="auth">
+        <article class="panel" data-test="security-card">
+          <h2 class="card-title">{{ t('settings.security.title') }}</h2>
+          <dl class="kv">
+            <div class="kv__row">
+              <dt>{{ t('settings.security.auth') }}</dt>
+              <dd>{{ auth.enabled ? t('common.online') : t('common.offline') }}</dd>
+            </div>
+            <div class="kv__row">
+              <dt>{{ t('settings.security.username') }}</dt>
+              <dd>{{ auth.username || t('common.not_available') }}</dd>
+            </div>
+            <div class="kv__row">
+              <dt>{{ t('settings.security.2fa') }}</dt>
+              <dd>{{ auth.two_factor_enabled ? t('settings.enabled') : t('settings.disabled') }}</dd>
+            </div>
+            <div class="kv__row">
+              <dt>{{ t('settings.security.session_ttl') }}</dt>
+              <dd>{{ sessionTtlText(auth.session_ttl_secs) }}</dd>
+            </div>
+          </dl>
+          <div class="actions">
+            <button type="button" class="btn btn--danger" data-test="account-logout" @click="logout">
+              {{ t('settings.security.logout') }}
+            </button>
+          </div>
+        </article>
+
+        <TwoFactorPanel :auth="auth" @changed="store.load()" />
+        <ChangePasswordCard />
+      </template>
+
+      <SettingsMessage
+        v-else-if="store.error"
+        state="error"
+        :text="store.error.message"
+        data-test="account-error"
+      />
+      <p v-else class="placeholder" data-test="account-loading">
+        {{ t('common.waiting_for_data') }}
+      </p>
+    </section>
+  </AppLayout>
+</template>
+
+<style scoped>
+.account {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 560px;
+}
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.kv {
+  margin: 0 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.kv__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 13px;
+}
+.kv__row dt {
+  color: var(--text-muted);
+}
+.kv__row dd {
+  margin: 0;
+  color: var(--text-primary);
+}
+.actions {
+  display: flex;
+}
+.btn {
+  background: var(--bg-card-soft);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 8px 14px;
+  font: inherit;
+}
+.btn--danger {
+  color: var(--accent-red);
+  border-color: var(--accent-red-soft);
+  background: var(--accent-red-soft);
+}
+.page-heading {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.page-subtitle {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.placeholder {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+</style>


### PR DESCRIPTION
## Summary
Stage 2.5b ports the legacy **Account** tab to the SPA as a top-level `/account` route inside `AppLayout`. No server changes; all i18n keys already exist.

- **API**: `twoFactorStart/Enable/Disable`, `changePassword` wrappers + types (`TwoFactorSetupResponse`, `Enable/DisableTwoFactorRequest`, `ChangePasswordRequest`); `postJson` helper.
- **`TwoFactorPanel.vue`** — 3-state machine (enabled → disable form / idle → start / pending-setup → `v-html` QR + secret + enable form). Reauth via `ReauthFields`; reloads settings on change.
- **`ChangePasswordCard.vue`** — current + new (minlength 8) with a strong-password generator (`lib/password.ts`, CSPRNG). On success shows "sign in again", then after 900ms clears `nodelite.auth.timestamp` and navigates to `/logout-and-reauth` (real session drop, matches legacy).
- **`AccountView.vue`** — security KV (auth/username/2FA/session TTL) + logout button + the two panels; error branch instead of an infinite spinner.
- **Nav**: Settings was already a link; Account is now a `RouterLink` with active state. Only **Alerts** stays disabled (2.5c). `/account` route added.

## Test plan
- [x] `pnpm lint` (max-warnings=0) — clean
- [x] `pnpm typecheck` (vue-tsc) — clean
- [x] `pnpm test` — 284 passed (new: password / TwoFactorPanel / ChangePasswordCard / AccountView + updated SidebarNav)
- [x] `pnpm build` (vue-tsc --build) — clean, emits AccountView chunk
- [ ] Manual: `/account` 2FA enable (scan QR → code → enabled) + disable; password change redirects to logout-and-reauth; logout button drops session

🤖 Generated with [Claude Code](https://claude.com/claude-code)