### PR TITLE
Stage 2.5c — Alerts page: shell + channels + inspection + save

### DIFF
--- a/nodelite-server/web/src/api/__fixtures__/nodes.ts
+++ b/nodelite-server/web/src/api/__fixtures__/nodes.ts
@@ -1,5 +1,8 @@
 import type {
   AgentLogEntry,
+  AlertSettingsResponse,
+  AlertSettingsView,
+  AlertPreview,
   BootstrapResponse,
   NodeListItem,
   NodeStatus,
@@ -168,5 +171,89 @@ export function makeOverview(overrides: Partial<OverviewData> = {}): OverviewDat
     current_tx_bytes_per_sec: 20,
     average_latency_ms: 7.5,
     ...overrides,
+  };
+}
+
+export function makeAlertSettingsView(overrides: Partial<AlertSettingsView> = {}): AlertSettingsView {
+  const base: AlertSettingsView = {
+    enabled: true,
+    smtp: {
+      enabled: true,
+      host: 'smtp.example.com',
+      port: 587,
+      username: 'mailer',
+      sender: 'alerts@example.com',
+      recipients: ['ops@example.com'],
+      transport: 'start_tls',
+      send_resolved: true,
+      password_configured: true,
+    },
+    webhook: {
+      enabled: false,
+      url: '',
+      send_resolved: true,
+      secret_configured: false,
+    },
+    rules: [
+      {
+        id: 'cpu-hot',
+        name: 'CPU hot',
+        enabled: true,
+        metric: 'cpu_usage_percent',
+        comparator: 'gt',
+        threshold: 85,
+        window_minutes: 5,
+        severity: 'warning',
+        scope_mode: 'all',
+        node_ids: [],
+        tags: [],
+        delivery: ['smtp'],
+        cooldown_minutes: 30,
+        send_resolved: true,
+      },
+    ],
+    inspection: {
+      enabled: true,
+      local_time: '09:00',
+      lookback_hours: 24,
+      delivery: ['smtp'],
+      offline_grace_minutes: 10,
+      latency_warn_ms: 250,
+      cpu_warn_percent: 85,
+      memory_warn_percent: 90,
+    },
+  };
+  return {
+    ...base,
+    ...overrides,
+    smtp: { ...base.smtp, ...overrides.smtp },
+    webhook: { ...base.webhook, ...overrides.webhook },
+    inspection: { ...base.inspection, ...overrides.inspection },
+    rules: overrides.rules ?? base.rules,
+  };
+}
+
+export function makeAlertPreview(overrides: Partial<AlertPreview> = {}): AlertPreview {
+  return {
+    generated_at: '2026-05-29T00:00:00Z',
+    triggered_rules: [],
+    inspection: {
+      total_nodes: 3,
+      offline_nodes: 0,
+      latency_nodes: 0,
+      cpu_hot_nodes: 0,
+      memory_hot_nodes: 0,
+      highlights: [],
+    },
+    ...overrides,
+  };
+}
+
+export function makeAlertSettings(
+  overrides: Partial<AlertSettingsResponse> = {},
+): AlertSettingsResponse {
+  return {
+    config: makeAlertSettingsView(overrides.config),
+    preview: makeAlertPreview(overrides.preview),
   };
 }

--- a/nodelite-server/web/src/api/__fixtures__/nodes.ts
+++ b/nodelite-server/web/src/api/__fixtures__/nodes.ts
@@ -1,14 +1,27 @@
 import type {
   AgentLogEntry,
+  AlertRuleView,
   AlertSettingsResponse,
   AlertSettingsView,
+  AlertSmtpSettingsView,
+  AlertWebhookSettingsView,
   AlertPreview,
   BootstrapResponse,
+  InspectionSettingsView,
   NodeListItem,
   NodeStatus,
   OverviewData,
   SettingsResponse,
 } from '@/api';
+
+/** Override shape for the alert View fixture: nested channels accept partials. */
+interface AlertSettingsViewOverrides {
+  enabled?: boolean;
+  smtp?: Partial<AlertSmtpSettingsView>;
+  webhook?: Partial<AlertWebhookSettingsView>;
+  rules?: AlertRuleView[];
+  inspection?: Partial<InspectionSettingsView>;
+}
 
 export function makeSettings(overrides: Partial<SettingsResponse> = {}): SettingsResponse {
   const base: SettingsResponse = {
@@ -174,7 +187,7 @@ export function makeOverview(overrides: Partial<OverviewData> = {}): OverviewDat
   };
 }
 
-export function makeAlertSettingsView(overrides: Partial<AlertSettingsView> = {}): AlertSettingsView {
+export function makeAlertSettingsView(overrides: AlertSettingsViewOverrides = {}): AlertSettingsView {
   const base: AlertSettingsView = {
     enabled: true,
     smtp: {
@@ -249,8 +262,13 @@ export function makeAlertPreview(overrides: Partial<AlertPreview> = {}): AlertPr
   };
 }
 
+interface AlertSettingsResponseOverrides {
+  config?: AlertSettingsViewOverrides;
+  preview?: Partial<AlertPreview>;
+}
+
 export function makeAlertSettings(
-  overrides: Partial<AlertSettingsResponse> = {},
+  overrides: AlertSettingsResponseOverrides = {},
 ): AlertSettingsResponse {
   return {
     config: makeAlertSettingsView(overrides.config),

--- a/nodelite-server/web/src/api/index.ts
+++ b/nodelite-server/web/src/api/index.ts
@@ -6,6 +6,7 @@
 import { api } from './client';
 import type {
   AgentLogEntry,
+  AlertSettingsResponse,
   BootstrapResponse,
   ChangePasswordRequest,
   DisableTwoFactorRequest,
@@ -19,10 +20,23 @@ import type {
   SettingsActionResponse,
   SettingsResponse,
   TwoFactorSetupResponse,
+  UpdateAlertSettingsRequest,
 } from './types';
 
 export type {
   AgentLogEntry,
+  AlertChannel,
+  AlertComparator,
+  AlertMetric,
+  AlertPreview,
+  AlertRuleView,
+  AlertScopeMode,
+  AlertSettingsResponse,
+  AlertSettingsView,
+  AlertSeverity,
+  AlertSmtpSettingsView,
+  AlertSmtpTransport,
+  AlertWebhookSettingsView,
   BootstrapResponse,
   ChangePasswordRequest,
   DisableTwoFactorRequest,
@@ -30,6 +44,9 @@ export type {
   EnableTwoFactorRequest,
   HistoryPoint,
   HistoryQuery,
+  InspectionHighlight,
+  InspectionPreview,
+  InspectionSettingsView,
   LogLevel,
   NodeIdentity,
   NodeListItem,
@@ -44,7 +61,13 @@ export type {
   SettingsAuth,
   SettingsResponse,
   SettingsUpdates,
+  TriggeredRulePreview,
   TwoFactorSetupResponse,
+  UpdateAlertRuleRequest,
+  UpdateAlertSettingsRequest,
+  UpdateAlertSmtpSettingsRequest,
+  UpdateAlertWebhookSettingsRequest,
+  UpdateInspectionSettingsRequest,
 } from './types';
 
 function postJson<T>(path: string, body: unknown): Promise<T> {
@@ -98,4 +121,9 @@ export const apiClient = {
     postJson<SettingsActionResponse>('/api/settings/2fa/disable', body),
   changePassword: (body: ChangePasswordRequest) =>
     postJson<SettingsActionResponse>('/api/settings/password', body),
+
+  // --- Alerts ---
+  alertSettings: () => api<AlertSettingsResponse>('/api/settings/alerts'),
+  updateAlertSettings: (body: UpdateAlertSettingsRequest) =>
+    postJson<AlertSettingsResponse>('/api/settings/alerts', body),
 };

--- a/nodelite-server/web/src/api/types.ts
+++ b/nodelite-server/web/src/api/types.ts
@@ -229,3 +229,172 @@ export interface ChangePasswordRequest {
   current_password: string;
   new_password: string;
 }
+
+// --- Alerts (handlers/settings/types.rs + nodelite-proto/config/alerts.rs) ---
+// All alert enums serialize snake_case (verified in config/alerts.rs).
+
+export type AlertChannel = 'smtp' | 'webhook';
+export type AlertSmtpTransport = 'start_tls' | 'tls' | 'plain';
+export type AlertMetric =
+  | 'cpu_usage_percent'
+  | 'memory_usage_percent'
+  | 'disk_usage_percent'
+  | 'latency_ms'
+  | 'offline_minutes';
+export type AlertComparator = 'gt' | 'lt';
+export type AlertSeverity = 'warning' | 'critical';
+export type AlertScopeMode = 'all' | 'node_ids' | 'tags';
+
+export interface AlertSmtpSettingsView {
+  enabled: boolean;
+  host: string;
+  port: number;
+  username: string;
+  sender: string;
+  recipients: string[];
+  transport: AlertSmtpTransport;
+  send_resolved: boolean;
+  /** Read-only: true if a password is stored. The secret is never echoed. */
+  password_configured: boolean;
+}
+
+export interface AlertWebhookSettingsView {
+  enabled: boolean;
+  url: string;
+  send_resolved: boolean;
+  /** Read-only: true if a secret is stored. The secret is never echoed. */
+  secret_configured: boolean;
+}
+
+export interface AlertRuleView {
+  id: string;
+  name: string;
+  enabled: boolean;
+  metric: AlertMetric;
+  comparator: AlertComparator;
+  threshold: number;
+  window_minutes: number;
+  severity: AlertSeverity;
+  scope_mode: AlertScopeMode;
+  node_ids: string[];
+  tags: string[];
+  delivery: AlertChannel[];
+  cooldown_minutes: number;
+  send_resolved: boolean;
+}
+
+export interface InspectionSettingsView {
+  enabled: boolean;
+  local_time: string;
+  lookback_hours: number;
+  delivery: AlertChannel[];
+  offline_grace_minutes: number;
+  latency_warn_ms: number;
+  cpu_warn_percent: number;
+  memory_warn_percent: number;
+}
+
+export interface AlertSettingsView {
+  enabled: boolean;
+  smtp: AlertSmtpSettingsView;
+  webhook: AlertWebhookSettingsView;
+  rules: AlertRuleView[];
+  inspection: InspectionSettingsView;
+}
+
+export interface TriggeredRulePreview {
+  rule_id: string;
+  rule_name: string;
+  severity: AlertSeverity;
+  node_ids: string[];
+}
+
+export interface InspectionHighlight {
+  node_id: string;
+  node_label: string;
+  reasons: string[];
+}
+
+export interface InspectionPreview {
+  total_nodes: number;
+  offline_nodes: number;
+  latency_nodes: number;
+  cpu_hot_nodes: number;
+  memory_hot_nodes: number;
+  highlights: InspectionHighlight[];
+}
+
+export interface AlertPreview {
+  generated_at: string;
+  triggered_rules: TriggeredRulePreview[];
+  inspection: InspectionPreview;
+}
+
+/** GET /api/settings/alerts — AlertSettingsResponse */
+export interface AlertSettingsResponse {
+  config: AlertSettingsView;
+  preview: AlertPreview;
+}
+
+// Update payloads (POST /api/settings/alerts). Secrets follow the server's
+// merge rule: clear_* wipes; else a non-empty value replaces; else keep.
+
+export interface UpdateAlertSmtpSettingsRequest {
+  enabled: boolean;
+  host: string;
+  port: number;
+  username: string;
+  password?: string;
+  clear_password: boolean;
+  sender: string;
+  recipients: string[];
+  transport: AlertSmtpTransport;
+  send_resolved: boolean;
+}
+
+export interface UpdateAlertWebhookSettingsRequest {
+  enabled: boolean;
+  url: string;
+  secret?: string;
+  clear_secret: boolean;
+  send_resolved: boolean;
+}
+
+export interface UpdateAlertRuleRequest {
+  id: string;
+  name: string;
+  enabled: boolean;
+  metric: AlertMetric;
+  comparator: AlertComparator;
+  threshold: number;
+  window_minutes: number;
+  severity: AlertSeverity;
+  scope_mode: AlertScopeMode;
+  node_ids: string[];
+  tags: string[];
+  delivery: AlertChannel[];
+  cooldown_minutes: number;
+  send_resolved: boolean;
+}
+
+export interface UpdateInspectionSettingsRequest {
+  enabled: boolean;
+  local_time: string;
+  lookback_hours: number;
+  delivery: AlertChannel[];
+  offline_grace_minutes: number;
+  latency_warn_ms: number;
+  cpu_warn_percent: number;
+  memory_warn_percent: number;
+}
+
+/** POST /api/settings/alerts — UpdateAlertSettingsRequest (carries reauth). */
+export interface UpdateAlertSettingsRequest {
+  current_password?: string;
+  code?: string;
+  enabled: boolean;
+  smtp: UpdateAlertSmtpSettingsRequest;
+  webhook: UpdateAlertWebhookSettingsRequest;
+  rules: UpdateAlertRuleRequest[];
+  inspection: UpdateInspectionSettingsRequest;
+}

--- a/nodelite-server/web/src/components/AlertOverviewCard.spec.ts
+++ b/nodelite-server/web/src/components/AlertOverviewCard.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h, reactive } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { viewToDraft, type AlertsDraft } from '@/lib/alertsDraft';
+import { makeAlertSettingsView } from '@/api/__fixtures__/nodes';
+import AlertOverviewCard from './AlertOverviewCard.vue';
+
+const FAKE_DICT = {
+  en: {
+    'alerts.channel.smtp': 'Email',
+    'alerts.channel.webhook': 'Webhook',
+    'settings.disabled': 'Disabled',
+    'alerts.rules.empty_short': 'None',
+    'alerts.summary.channels': 'Channels',
+    'alerts.summary.rules': 'Rules',
+    'alerts.summary.inspection': 'Inspection',
+  },
+  'zh-CN': {},
+};
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountCard(draft: AlertsDraft) {
+  return mount(AlertOverviewCard, {
+    props: { modelValue: draft, 'onUpdate:modelValue': () => {} },
+    global: { plugins: [getI18n()] },
+  });
+}
+
+describe('AlertOverviewCard', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    await setupI18n(createApp(Stub));
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('summarizes enabled channels and rule counts', () => {
+    const draft = reactive(
+      viewToDraft(
+        makeAlertSettingsView({
+          smtp: { enabled: true },
+          webhook: { enabled: true },
+        }),
+      ),
+    );
+    const text = mountCard(draft).text();
+    expect(text).toContain('Email + Webhook');
+    // one rule in the fixture, enabled
+    expect(text).toContain('1/1');
+  });
+
+  it('binds the global enable toggle', async () => {
+    const draft = reactive(viewToDraft(makeAlertSettingsView({ enabled: false })));
+    const wrapper = mountCard(draft);
+    await wrapper.find('[data-test="alerts-enabled"]').setValue(true);
+    expect(draft.enabled).toBe(true);
+  });
+});

--- a/nodelite-server/web/src/components/AlertOverviewCard.vue
+++ b/nodelite-server/web/src/components/AlertOverviewCard.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { AlertsDraft } from '@/lib/alertsDraft';
+
+/** Top card: global alert enable toggle + a read-only summary of the draft. */
+const draft = defineModel<AlertsDraft>({ required: true });
+
+const { t } = useI18n();
+
+const channelSummary = computed(() => {
+  const enabled = [
+    draft.value.smtp.enabled ? t('alerts.channel.smtp') : '',
+    draft.value.webhook.enabled ? t('alerts.channel.webhook') : '',
+  ].filter(Boolean);
+  return enabled.length ? enabled.join(' + ') : t('settings.disabled');
+});
+
+const ruleSummary = computed(() => {
+  const total = draft.value.rules.length;
+  if (!total) return t('alerts.rules.empty_short');
+  const enabled = draft.value.rules.filter((rule) => rule.enabled).length;
+  return `${enabled}/${total}`;
+});
+
+const inspectionSummary = computed(() => {
+  const insp = draft.value.inspection;
+  if (!insp.enabled) return t('settings.disabled');
+  const delivery = insp.delivery.length
+    ? insp.delivery.map((c) => t(`alerts.channel.${c}`)).join(' + ')
+    : t('common.not_available');
+  return `${insp.local_time || '09:00'} · ${insp.lookback_hours || 24}h · ${delivery}`;
+});
+
+const tiles = computed(() => [
+  { label: t('alerts.summary.channels'), value: channelSummary.value },
+  { label: t('alerts.summary.rules'), value: ruleSummary.value },
+  { label: t('alerts.summary.inspection'), value: inspectionSummary.value },
+]);
+</script>
+
+<template>
+  <article class="panel" data-test="alert-overview-card">
+    <header class="card-head">
+      <h2 class="card-title">{{ t('alerts.overview.title') }}</h2>
+      <label class="toggle">
+        <input v-model="draft.enabled" type="checkbox" data-test="alerts-enabled" />
+        <span>{{ t('alerts.overview.enabled') }}</span>
+      </label>
+    </header>
+    <p class="note">{{ t('alerts.overview.note') }}</p>
+    <div class="tiles">
+      <div v-for="tile in tiles" :key="tile.label" class="tile">
+        <span class="tile__label">{{ tile.label }}</span>
+        <strong class="tile__value">{{ tile.value }}</strong>
+      </div>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.card-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+.note {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin: 0 0 14px;
+}
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--bg-card-soft);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+.tile__label {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.tile__value {
+  color: var(--text-primary);
+  font-size: 14px;
+  word-break: break-word;
+}
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+</style>

--- a/nodelite-server/web/src/components/CsvField.spec.ts
+++ b/nodelite-server/web/src/components/CsvField.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CsvField from './CsvField.vue';
+
+function mountField(modelValue: string[]) {
+  return mount(CsvField, { props: { modelValue, 'onUpdate:modelValue': () => {} } });
+}
+
+describe('CsvField', () => {
+  it('renders the array joined as comma-separated text', () => {
+    const wrapper = mountField(['a', 'b', 'c']);
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('a, b, c');
+  });
+
+  it('emits a trimmed, blank-filtered array on input', async () => {
+    const wrapper = mountField([]);
+    await wrapper.find('input').setValue(' x , , y ,z ');
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted?.at(-1)?.[0]).toEqual(['x', 'y', 'z']);
+  });
+
+  it('keeps the raw text while typing a trailing comma (not clobbered)', async () => {
+    const wrapper = mountField(['a']);
+    const input = wrapper.find('input');
+    await input.setValue('a, ');
+    // model normalizes to ['a'], but the visible text must keep the trailing comma
+    expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toEqual(['a']);
+    expect((input.element as HTMLInputElement).value).toBe('a, ');
+  });
+
+  it('resyncs the text when the model changes externally', async () => {
+    const wrapper = mountField(['a']);
+    await wrapper.setProps({ modelValue: ['p', 'q'] });
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('p, q');
+  });
+});

--- a/nodelite-server/web/src/components/CsvField.vue
+++ b/nodelite-server/web/src/components/CsvField.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+/**
+ * Text input that v-models a string[] — the array stays the canonical form in
+ * the draft, while the user edits a comma-separated string. A local `text` ref
+ * holds the raw input so typing (trailing commas, spaces) isn't clobbered; we
+ * only resync from the model when the incoming array genuinely diverges from
+ * what the text currently parses to (e.g. an external load/reset).
+ */
+const model = defineModel<string[]>({ default: () => [] });
+
+withDefaults(defineProps<{ placeholder?: string }>(), { placeholder: '' });
+
+function parse(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+// Parsed values never contain a comma, so a comma join is a safe equality key.
+function key(items: string[]): string {
+  return items.join(',');
+}
+
+const text = ref(model.value.join(', '));
+
+watch(model, (next) => {
+  if (key(parse(text.value)) !== key(next)) {
+    text.value = next.join(', ');
+  }
+});
+
+function onInput(event: Event): void {
+  text.value = (event.target as HTMLInputElement).value;
+  model.value = parse(text.value);
+}
+</script>
+
+<template>
+  <input
+    class="csv-field"
+    type="text"
+    :value="text"
+    :placeholder="placeholder"
+    data-test="csv-field"
+    @input="onInput"
+  />
+</template>
+
+<style scoped>
+.csv-field {
+  width: 100%;
+  background: var(--bg-card-soft);
+  color: var(--text-primary);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+}
+</style>

--- a/nodelite-server/web/src/components/DeliveryCheckboxes.spec.ts
+++ b/nodelite-server/web/src/components/DeliveryCheckboxes.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import type { AlertChannel } from '@/api';
+import DeliveryCheckboxes from './DeliveryCheckboxes.vue';
+
+const FAKE_DICT = {
+  en: { 'alerts.channel.smtp': 'Email', 'alerts.channel.webhook': 'Webhook' },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountBoxes(modelValue: AlertChannel[]) {
+  return mount(DeliveryCheckboxes, {
+    props: { modelValue, 'onUpdate:modelValue': () => {} },
+    global: { plugins: [getI18n()] },
+  });
+}
+
+describe('DeliveryCheckboxes', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    const dummy = createApp(Stub);
+    await setupI18n(dummy);
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('reflects the selected channels as checked', () => {
+    const wrapper = mountBoxes(['webhook']);
+    expect((wrapper.find('[data-test="delivery-smtp"]').element as HTMLInputElement).checked).toBe(false);
+    expect((wrapper.find('[data-test="delivery-webhook"]').element as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('adds a channel in canonical order when checked', async () => {
+    const wrapper = mountBoxes(['webhook']);
+    await wrapper.find('[data-test="delivery-smtp"]').setValue(true);
+    // smtp added but order stays smtp, webhook regardless of click order
+    expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toEqual(['smtp', 'webhook']);
+  });
+
+  it('removes a channel when unchecked', async () => {
+    const wrapper = mountBoxes(['smtp', 'webhook']);
+    await wrapper.find('[data-test="delivery-smtp"]').setValue(false);
+    expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toEqual(['webhook']);
+  });
+});

--- a/nodelite-server/web/src/components/DeliveryCheckboxes.vue
+++ b/nodelite-server/web/src/components/DeliveryCheckboxes.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import type { AlertChannel } from '@/api';
+
+/**
+ * Checkbox group that v-models an AlertChannel[] (smtp / webhook). Toggling
+ * rebuilds the array in canonical channel order so the saved payload is stable
+ * regardless of click order.
+ */
+const model = defineModel<AlertChannel[]>({ default: () => [] });
+
+const { t } = useI18n();
+
+const channels: AlertChannel[] = ['smtp', 'webhook'];
+
+function isOn(channel: AlertChannel): boolean {
+  return model.value.includes(channel);
+}
+
+function toggle(channel: AlertChannel, checked: boolean): void {
+  const set = new Set(model.value);
+  if (checked) set.add(channel);
+  else set.delete(channel);
+  model.value = channels.filter((c) => set.has(c));
+}
+</script>
+
+<template>
+  <div class="delivery-checkboxes" data-test="delivery-checkboxes">
+    <label v-for="channel in channels" :key="channel" class="delivery-option">
+      <input
+        type="checkbox"
+        :checked="isOn(channel)"
+        :data-test="`delivery-${channel}`"
+        @change="toggle(channel, ($event.target as HTMLInputElement).checked)"
+      />
+      <span>{{ t(`alerts.channel.${channel}`) }}</span>
+    </label>
+  </div>
+</template>
+
+<style scoped>
+.delivery-checkboxes {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.delivery-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+</style>

--- a/nodelite-server/web/src/components/InspectionCard.spec.ts
+++ b/nodelite-server/web/src/components/InspectionCard.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h, reactive } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import type { InspectionSettingsView } from '@/api';
+import { viewToDraft } from '@/lib/alertsDraft';
+import { makeAlertSettingsView } from '@/api/__fixtures__/nodes';
+import InspectionCard from './InspectionCard.vue';
+
+const FAKE_DICT = {
+  en: { 'alerts.channel.smtp': 'Email', 'alerts.channel.webhook': 'Webhook' },
+  'zh-CN': {},
+};
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountCard(inspection: InspectionSettingsView) {
+  return mount(InspectionCard, {
+    props: { modelValue: inspection, 'onUpdate:modelValue': () => {} },
+    global: { plugins: [getI18n()] },
+  });
+}
+
+describe('InspectionCard', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    await setupI18n(createApp(Stub));
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('binds numeric fields back as numbers, not strings', async () => {
+    const inspection = reactive(viewToDraft(makeAlertSettingsView()).inspection);
+    const wrapper = mountCard(inspection);
+    await wrapper.find('[data-test="inspection-lookback"]').setValue('48');
+    expect(inspection.lookback_hours).toBe(48);
+    expect(typeof inspection.lookback_hours).toBe('number');
+    await wrapper.find('[data-test="inspection-cpu-warn"]').setValue('70');
+    expect(inspection.cpu_warn_percent).toBe(70);
+  });
+
+  it('toggles delivery channels through DeliveryCheckboxes', async () => {
+    const inspection = reactive(
+      viewToDraft(makeAlertSettingsView({ inspection: { delivery: ['smtp'] } })).inspection,
+    );
+    const wrapper = mountCard(inspection);
+    await wrapper.find('[data-test="delivery-webhook"]').setValue(true);
+    expect(inspection.delivery).toEqual(['smtp', 'webhook']);
+  });
+});

--- a/nodelite-server/web/src/components/InspectionCard.vue
+++ b/nodelite-server/web/src/components/InspectionCard.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import type { InspectionSettingsView } from '@/api';
+import DeliveryCheckboxes from './DeliveryCheckboxes.vue';
+
+/** Daily inspection editor — binds the parent's reactive inspection slice. */
+const inspection = defineModel<InspectionSettingsView>({ required: true });
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <article class="panel" data-test="inspection-card">
+    <header class="card-head">
+      <h2 class="card-title">{{ t('alerts.inspection.title') }}</h2>
+      <label class="toggle">
+        <input v-model="inspection.enabled" type="checkbox" data-test="inspection-enabled" />
+        <span>{{ t('alerts.inspection.enabled') }}</span>
+      </label>
+    </header>
+
+    <div class="form">
+      <div class="split">
+        <label class="field">
+          <span>{{ t('alerts.inspection.local_time') }}</span>
+          <input v-model="inspection.local_time" type="text" placeholder="09:00" data-test="inspection-local-time" />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.inspection.lookback_hours') }}</span>
+          <input
+            v-model.number="inspection.lookback_hours"
+            type="number"
+            min="1"
+            max="720"
+            data-test="inspection-lookback"
+          />
+        </label>
+      </div>
+      <div class="field">
+        <span>{{ t('alerts.inspection.delivery') }}</span>
+        <DeliveryCheckboxes v-model="inspection.delivery" />
+      </div>
+      <div class="split">
+        <label class="field">
+          <span>{{ t('alerts.inspection.offline_grace_minutes') }}</span>
+          <input
+            v-model.number="inspection.offline_grace_minutes"
+            type="number"
+            min="1"
+            data-test="inspection-offline-grace"
+          />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.inspection.latency_warn_ms') }}</span>
+          <input
+            v-model.number="inspection.latency_warn_ms"
+            type="number"
+            min="1"
+            data-test="inspection-latency-warn"
+          />
+        </label>
+      </div>
+      <div class="split">
+        <label class="field">
+          <span>{{ t('alerts.inspection.cpu_warn_percent') }}</span>
+          <input
+            v-model.number="inspection.cpu_warn_percent"
+            type="number"
+            min="1"
+            max="100"
+            data-test="inspection-cpu-warn"
+          />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.inspection.memory_warn_percent') }}</span>
+          <input
+            v-model.number="inspection.memory_warn_percent"
+            type="number"
+            min="1"
+            max="100"
+            data-test="inspection-memory-warn"
+          />
+        </label>
+      </div>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  gap: 12px;
+}
+.card-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.field input {
+  width: 100%;
+  background: var(--bg-card-soft);
+  color: var(--text-primary);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+}
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+</style>

--- a/nodelite-server/web/src/components/SidebarNav.spec.ts
+++ b/nodelite-server/web/src/components/SidebarNav.spec.ts
@@ -30,6 +30,7 @@ function makeRouter(): Router {
       { path: '/nodes/:id', name: 'node-detail', component: Stub },
       { path: '/settings', name: 'settings', component: Stub },
       { path: '/account', name: 'account', component: Stub },
+      { path: '/alerts', name: 'alerts', component: Stub },
     ],
   });
 }
@@ -97,12 +98,14 @@ describe('SidebarNav', () => {
     expect(account.classes()).toContain('active');
   });
 
-  it('still disables the not-yet-built button (alerts)', async () => {
+  it('links Alerts and marks it active on /alerts', async () => {
     const router = makeRouter();
-    await router.push('/');
+    await router.push('/alerts');
     await router.isReady();
     const wrapper = mount(SidebarNav, { global: { plugins: [router, getI18n()] } });
 
-    expect(wrapper.find('[data-test="nav-alerts"]').attributes('disabled')).toBeDefined();
+    const alerts = wrapper.find('[data-test="nav-alerts"]');
+    expect(alerts.attributes('disabled')).toBeUndefined();
+    expect(alerts.classes()).toContain('active');
   });
 });

--- a/nodelite-server/web/src/components/SidebarNav.vue
+++ b/nodelite-server/web/src/components/SidebarNav.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { useRoute } from 'vue-router';
 
-// Alerts lands later in Stage 2.5; it renders as a disabled icon button so
-// the rail matches the legacy layout but doesn't navigate yet.
 const route = useRoute();
 </script>
 
@@ -56,11 +54,11 @@ const route = useRoute();
       </svg>
     </RouterLink>
 
-    <button
-      type="button"
+    <RouterLink
       class="nav-button"
-      disabled
-      :title="`${$t('index.nav.alerts')} (Stage 2.5)`"
+      :class="{ active: route.path === '/alerts' }"
+      to="/alerts"
+      :title="$t('index.nav.alerts')"
       :aria-label="$t('index.nav.alerts')"
       data-test="nav-alerts"
     >
@@ -75,7 +73,7 @@ const route = useRoute();
         <path d="M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2a2 2 0 0 1-.6 1.4L4 17h5" />
         <path d="M9 17a3 3 0 0 0 6 0" />
       </svg>
-    </button>
+    </RouterLink>
 
     <div class="sidebar-bottom">
       <RouterLink

--- a/nodelite-server/web/src/components/SmtpChannelCard.spec.ts
+++ b/nodelite-server/web/src/components/SmtpChannelCard.spec.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h, reactive } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { viewToDraft, type SmtpDraft } from '@/lib/alertsDraft';
+import { makeAlertSettingsView } from '@/api/__fixtures__/nodes';
+import SmtpChannelCard from './SmtpChannelCard.vue';
+
+const FAKE_DICT = { en: { 'alerts.secret.keep': 'leave blank to keep' }, 'zh-CN': {} };
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountCard(smtp: SmtpDraft) {
+  return mount(SmtpChannelCard, {
+    props: { modelValue: smtp, 'onUpdate:modelValue': () => {} },
+    global: { plugins: [getI18n()] },
+  });
+}
+
+describe('SmtpChannelCard', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    await setupI18n(createApp(Stub));
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders draft values and the keep-secret placeholder when configured', () => {
+    const smtp = reactive(viewToDraft(makeAlertSettingsView()).smtp);
+    const wrapper = mountCard(smtp);
+    expect((wrapper.find('[data-test="smtp-host"]').element as HTMLInputElement).value).toBe('smtp.example.com');
+    expect(wrapper.find('[data-test="smtp-password"]').attributes('placeholder')).toBe('leave blank to keep');
+  });
+
+  it('binds enabled + password edits back into the draft slice', async () => {
+    const smtp = reactive(viewToDraft(makeAlertSettingsView({ smtp: { enabled: false } })).smtp);
+    const wrapper = mountCard(smtp);
+    await wrapper.find('[data-test="smtp-enabled"]').setValue(true);
+    expect(smtp.enabled).toBe(true);
+    await wrapper.find('[data-test="smtp-password"]').setValue('new-secret');
+    expect(smtp.password).toBe('new-secret');
+  });
+
+  it('clear-password disables the password input and sets the flag', async () => {
+    const smtp = reactive(viewToDraft(makeAlertSettingsView()).smtp);
+    const wrapper = mountCard(smtp);
+    await wrapper.find('[data-test="smtp-clear-password"]').setValue(true);
+    expect(smtp.clear_password).toBe(true);
+    expect(wrapper.find('[data-test="smtp-password"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('edits recipients through CsvField', async () => {
+    const smtp = reactive(viewToDraft(makeAlertSettingsView()).smtp);
+    const wrapper = mountCard(smtp);
+    await wrapper.find('[data-test="smtp-recipients"]').setValue('a@x.com, b@x.com');
+    expect(smtp.recipients).toEqual(['a@x.com', 'b@x.com']);
+  });
+});

--- a/nodelite-server/web/src/components/SmtpChannelCard.vue
+++ b/nodelite-server/web/src/components/SmtpChannelCard.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import type { AlertSmtpTransport } from '@/api';
+import type { SmtpDraft } from '@/lib/alertsDraft';
+import CsvField from './CsvField.vue';
+
+/**
+ * SMTP channel editor. Binds directly against the parent's reactive draft slice
+ * (single source of truth). The stored password is never echoed: when one is on
+ * file (`password_configured`), the input shows a "leave blank to keep"
+ * placeholder; typing replaces it, the clear checkbox wipes it.
+ */
+const smtp = defineModel<SmtpDraft>({ required: true });
+
+const { t } = useI18n();
+
+const transports: AlertSmtpTransport[] = ['start_tls', 'tls', 'plain'];
+</script>
+
+<template>
+  <article class="panel" data-test="smtp-card">
+    <header class="card-head">
+      <h2 class="card-title">{{ t('alerts.smtp.title') }}</h2>
+      <label class="toggle">
+        <input v-model="smtp.enabled" type="checkbox" data-test="smtp-enabled" />
+        <span>{{ t('alerts.smtp.enabled') }}</span>
+      </label>
+    </header>
+
+    <div class="form">
+      <div class="split">
+        <label class="field">
+          <span>{{ t('alerts.smtp.host') }}</span>
+          <input v-model="smtp.host" type="text" data-test="smtp-host" />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.smtp.port') }}</span>
+          <input v-model.number="smtp.port" type="number" min="1" max="65535" data-test="smtp-port" />
+        </label>
+      </div>
+      <label class="field">
+        <span>{{ t('alerts.smtp.sender') }}</span>
+        <input v-model="smtp.sender" type="text" data-test="smtp-sender" />
+      </label>
+      <label class="field">
+        <span>{{ t('alerts.smtp.recipients') }}</span>
+        <CsvField v-model="smtp.recipients" data-test="smtp-recipients" />
+      </label>
+      <div class="split">
+        <label class="field">
+          <span>{{ t('alerts.smtp.username') }}</span>
+          <input v-model="smtp.username" type="text" data-test="smtp-username" />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.smtp.transport') }}</span>
+          <select v-model="smtp.transport" data-test="smtp-transport">
+            <option v-for="value in transports" :key="value" :value="value">
+              {{ t(`alerts.smtp.transport.${value}`) }}
+            </option>
+          </select>
+        </label>
+      </div>
+      <label class="field">
+        <span>{{ t('alerts.smtp.password') }}</span>
+        <input
+          v-model="smtp.password"
+          type="password"
+          autocomplete="new-password"
+          :placeholder="smtp.password_configured ? t('alerts.secret.keep') : ''"
+          :disabled="smtp.clear_password"
+          data-test="smtp-password"
+        />
+      </label>
+      <label class="toggle">
+        <input v-model="smtp.clear_password" type="checkbox" data-test="smtp-clear-password" />
+        <span>{{ t('alerts.secret.clear') }}</span>
+      </label>
+      <label class="toggle">
+        <input v-model="smtp.send_resolved" type="checkbox" data-test="smtp-send-resolved" />
+        <span>{{ t('alerts.smtp.send_resolved') }}</span>
+      </label>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  gap: 12px;
+}
+.card-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.field input,
+.field select {
+  width: 100%;
+  background: var(--bg-card-soft);
+  color: var(--text-primary);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+}
+.field input:disabled {
+  opacity: 0.5;
+}
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+</style>

--- a/nodelite-server/web/src/components/WebhookChannelCard.spec.ts
+++ b/nodelite-server/web/src/components/WebhookChannelCard.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h, reactive } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { viewToDraft, type WebhookDraft } from '@/lib/alertsDraft';
+import { makeAlertSettingsView } from '@/api/__fixtures__/nodes';
+import WebhookChannelCard from './WebhookChannelCard.vue';
+
+const FAKE_DICT = { en: { 'alerts.secret.keep': 'leave blank to keep' }, 'zh-CN': {} };
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountCard(webhook: WebhookDraft) {
+  return mount(WebhookChannelCard, {
+    props: { modelValue: webhook, 'onUpdate:modelValue': () => {} },
+    global: { plugins: [getI18n()] },
+  });
+}
+
+describe('WebhookChannelCard', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    await setupI18n(createApp(Stub));
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the keep-secret placeholder only when a secret is configured', () => {
+    const configured = reactive(
+      viewToDraft(makeAlertSettingsView({ webhook: { secret_configured: true } })).webhook,
+    );
+    expect(mountCard(configured).find('[data-test="webhook-secret"]').attributes('placeholder')).toBe(
+      'leave blank to keep',
+    );
+    const blank = reactive(
+      viewToDraft(makeAlertSettingsView({ webhook: { secret_configured: false } })).webhook,
+    );
+    expect(mountCard(blank).find('[data-test="webhook-secret"]').attributes('placeholder')).toBe('');
+  });
+
+  it('binds url + secret edits and the clear flag', async () => {
+    const webhook = reactive(viewToDraft(makeAlertSettingsView()).webhook);
+    const wrapper = mountCard(webhook);
+    await wrapper.find('[data-test="webhook-url"]').setValue('https://hooks.example.com/y');
+    expect(webhook.url).toBe('https://hooks.example.com/y');
+    await wrapper.find('[data-test="webhook-clear-secret"]').setValue(true);
+    expect(webhook.clear_secret).toBe(true);
+    expect(wrapper.find('[data-test="webhook-secret"]').attributes('disabled')).toBeDefined();
+  });
+});

--- a/nodelite-server/web/src/components/WebhookChannelCard.vue
+++ b/nodelite-server/web/src/components/WebhookChannelCard.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import type { WebhookDraft } from '@/lib/alertsDraft';
+
+/**
+ * Webhook channel editor. Same secret keep/clear contract as SMTP: the stored
+ * secret is never echoed; placeholder when one is on file, type to replace,
+ * clear checkbox to wipe.
+ */
+const webhook = defineModel<WebhookDraft>({ required: true });
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <article class="panel" data-test="webhook-card">
+    <header class="card-head">
+      <h2 class="card-title">{{ t('alerts.webhook.title') }}</h2>
+      <label class="toggle">
+        <input v-model="webhook.enabled" type="checkbox" data-test="webhook-enabled" />
+        <span>{{ t('alerts.webhook.enabled') }}</span>
+      </label>
+    </header>
+
+    <div class="form">
+      <label class="field">
+        <span>{{ t('alerts.webhook.url') }}</span>
+        <input v-model="webhook.url" type="text" data-test="webhook-url" />
+      </label>
+      <label class="field">
+        <span>{{ t('alerts.webhook.secret') }}</span>
+        <input
+          v-model="webhook.secret"
+          type="password"
+          autocomplete="new-password"
+          :placeholder="webhook.secret_configured ? t('alerts.secret.keep') : ''"
+          :disabled="webhook.clear_secret"
+          data-test="webhook-secret"
+        />
+      </label>
+      <label class="toggle">
+        <input v-model="webhook.clear_secret" type="checkbox" data-test="webhook-clear-secret" />
+        <span>{{ t('alerts.secret.clear') }}</span>
+      </label>
+      <label class="toggle">
+        <input v-model="webhook.send_resolved" type="checkbox" data-test="webhook-send-resolved" />
+        <span>{{ t('alerts.webhook.send_resolved') }}</span>
+      </label>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  gap: 12px;
+}
+.card-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.field input {
+  width: 100%;
+  background: var(--bg-card-soft);
+  color: var(--text-primary);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+}
+.field input:disabled {
+  opacity: 0.5;
+}
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+</style>

--- a/nodelite-server/web/src/lib/alertsDraft.spec.ts
+++ b/nodelite-server/web/src/lib/alertsDraft.spec.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import type { AlertSettingsView } from '@/api';
+import {
+  blankRule,
+  draftToPayload,
+  emptyAlertsConfig,
+  viewToDraft,
+  type ReauthInput,
+} from './alertsDraft';
+
+const NO_REAUTH: ReauthInput = { current_password: '', code: '' };
+
+function sampleView(): AlertSettingsView {
+  return {
+    enabled: true,
+    smtp: {
+      enabled: true,
+      host: 'smtp.example.com',
+      port: 465,
+      username: 'mailer',
+      sender: 'alerts@example.com',
+      recipients: ['ops@example.com', 'sre@example.com'],
+      transport: 'tls',
+      send_resolved: false,
+      password_configured: true,
+    },
+    webhook: {
+      enabled: true,
+      url: 'https://hooks.example.com/x',
+      send_resolved: true,
+      secret_configured: true,
+    },
+    rules: [
+      {
+        id: 'cpu-hot',
+        name: 'CPU hot',
+        enabled: true,
+        metric: 'cpu_usage_percent',
+        comparator: 'gt',
+        threshold: 90,
+        window_minutes: 10,
+        severity: 'critical',
+        scope_mode: 'tags',
+        node_ids: [],
+        tags: ['prod'],
+        delivery: ['smtp', 'webhook'],
+        cooldown_minutes: 15,
+        send_resolved: true,
+      },
+    ],
+    inspection: {
+      enabled: true,
+      local_time: '08:30',
+      lookback_hours: 12,
+      delivery: ['webhook'],
+      offline_grace_minutes: 5,
+      latency_warn_ms: 300,
+      cpu_warn_percent: 80,
+      memory_warn_percent: 85,
+    },
+  };
+}
+
+describe('emptyAlertsConfig / blankRule', () => {
+  it('emptyAlertsConfig has legacy defaults and blank transient secrets', () => {
+    const cfg = emptyAlertsConfig();
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.smtp.port).toBe(587);
+    expect(cfg.smtp.transport).toBe('start_tls');
+    expect(cfg.smtp.password).toBe('');
+    expect(cfg.smtp.clear_password).toBe(false);
+    expect(cfg.webhook.secret).toBe('');
+    expect(cfg.inspection.delivery).toEqual(['smtp']);
+    expect(cfg.rules).toEqual([]);
+  });
+
+  it('blankRule gives unique uid + id each call', () => {
+    const a = blankRule();
+    const b = blankRule();
+    expect(a.uid).not.toBe(b.uid);
+    expect(a.id).not.toBe(b.id);
+    expect(a.metric).toBe('cpu_usage_percent');
+    expect(a.delivery).toEqual(['smtp']);
+  });
+});
+
+describe('viewToDraft', () => {
+  it('copies fields, seeds blank secrets, and assigns rule uids', () => {
+    const view = sampleView();
+    const draft = viewToDraft(view);
+    expect(draft.enabled).toBe(true);
+    expect(draft.smtp.host).toBe('smtp.example.com');
+    expect(draft.smtp.password_configured).toBe(true);
+    // stored secret never echoed
+    expect(draft.smtp.password).toBe('');
+    expect(draft.smtp.clear_password).toBe(false);
+    expect(draft.webhook.secret_configured).toBe(true);
+    expect(draft.webhook.secret).toBe('');
+    expect(draft.rules).toHaveLength(1);
+    expect(draft.rules[0]?.uid).toMatch(/^rule-uid-/);
+    expect(draft.rules[0]?.id).toBe('cpu-hot');
+  });
+
+  it('clones arrays so editing the draft never mutates the source view', () => {
+    const view = sampleView();
+    const draft = viewToDraft(view);
+    draft.smtp.recipients.push('extra@example.com');
+    draft.rules[0]?.tags.push('staging');
+    draft.inspection.delivery.push('smtp');
+    expect(view.smtp.recipients).toEqual(['ops@example.com', 'sre@example.com']);
+    expect(view.rules[0]?.tags).toEqual(['prod']);
+    expect(view.inspection.delivery).toEqual(['webhook']);
+  });
+});
+
+describe('draftToPayload — secret keep/clear', () => {
+  it('keep: blank password (configured) omits the key, clear flag false', () => {
+    const draft = viewToDraft(sampleView()); // password '', clear false
+    const payload = draftToPayload(draft, NO_REAUTH);
+    expect('password' in payload.smtp).toBe(false);
+    expect(payload.smtp.clear_password).toBe(false);
+    expect('secret' in payload.webhook).toBe(false);
+    expect(payload.webhook.clear_secret).toBe(false);
+  });
+
+  it('set: a typed password is sent verbatim with clear flag false', () => {
+    const draft = viewToDraft(sampleView());
+    draft.smtp.password = 's3cr3t ';
+    draft.webhook.secret = 'hook-key';
+    const payload = draftToPayload(draft, NO_REAUTH);
+    // sent untrimmed so passwords with spaces survive
+    expect(payload.smtp.password).toBe('s3cr3t ');
+    expect(payload.smtp.clear_password).toBe(false);
+    expect(payload.webhook.secret).toBe('hook-key');
+  });
+
+  it('clear: clear flag wins even when a value was typed (key omitted)', () => {
+    const draft = viewToDraft(sampleView());
+    draft.smtp.password = 'ignored';
+    draft.smtp.clear_password = true;
+    draft.webhook.secret = 'ignored';
+    draft.webhook.clear_secret = true;
+    const payload = draftToPayload(draft, NO_REAUTH);
+    expect('password' in payload.smtp).toBe(false);
+    expect(payload.smtp.clear_password).toBe(true);
+    expect('secret' in payload.webhook).toBe(false);
+    expect(payload.webhook.clear_secret).toBe(true);
+  });
+
+  it('whitespace-only secret counts as keep (omitted), matching the server filter', () => {
+    const draft = viewToDraft(sampleView());
+    draft.smtp.password = '   ';
+    const payload = draftToPayload(draft, NO_REAUTH);
+    expect('password' in payload.smtp).toBe(false);
+  });
+});
+
+describe('draftToPayload — reauth + rules + scalars', () => {
+  it('includes current_password / code only when non-blank', () => {
+    const draft = emptyAlertsConfig();
+    expect('current_password' in draftToPayload(draft, NO_REAUTH)).toBe(false);
+    expect('code' in draftToPayload(draft, NO_REAUTH)).toBe(false);
+    const withPw = draftToPayload(draft, { current_password: 'pw', code: '' });
+    expect(withPw.current_password).toBe('pw');
+    expect('code' in withPw).toBe(false);
+    const withCode = draftToPayload(draft, { current_password: '', code: '123456' });
+    expect(withCode.code).toBe('123456');
+    expect('current_password' in withCode).toBe(false);
+  });
+
+  it('strips uid from rules and preserves every rule field', () => {
+    const draft = viewToDraft(sampleView());
+    const payload = draftToPayload(draft, NO_REAUTH);
+    expect(payload.rules).toHaveLength(1);
+    const rule = payload.rules[0];
+    expect(rule).not.toHaveProperty('uid');
+    expect(rule?.id).toBe('cpu-hot');
+    expect(rule?.scope_mode).toBe('tags');
+    expect(rule?.tags).toEqual(['prod']);
+    expect(rule?.delivery).toEqual(['smtp', 'webhook']);
+    expect(rule?.threshold).toBe(90);
+  });
+
+  it('passes through enabled + numeric scalars and trims text fields', () => {
+    const draft = viewToDraft(sampleView());
+    draft.smtp.host = '  smtp.trim.me  ';
+    const payload = draftToPayload(draft, NO_REAUTH);
+    expect(payload.enabled).toBe(true);
+    expect(payload.smtp.host).toBe('smtp.trim.me');
+    expect(payload.smtp.port).toBe(465);
+    expect(payload.inspection.local_time).toBe('08:30');
+    expect(payload.inspection.lookback_hours).toBe(12);
+  });
+});

--- a/nodelite-server/web/src/lib/alertsDraft.ts
+++ b/nodelite-server/web/src/lib/alertsDraft.ts
@@ -1,0 +1,236 @@
+/**
+ * Pure bridge between the server's alert View shapes and the editable draft the
+ * AlertsView binds with v-model. Replaces the legacy DOM-as-state model
+ * (assets/index-alert-settings.js `syncAlertDraftFromDom`): here the reactive
+ * draft is the single source of truth, and these helpers only translate at the
+ * two boundaries — load (View → draft) and save (draft → request payload).
+ *
+ * Secret handling mirrors the server merge rule (handlers/settings/alerts.rs):
+ * `clear_*` wipes; else a non-blank typed value replaces; else the stored secret
+ * is kept. Stored secrets are never echoed into the draft — `*_configured` is the
+ * only signal the UI gets, and it drives a "leave blank to keep" placeholder.
+ */
+
+import type {
+  AlertRuleView,
+  AlertSettingsView,
+  UpdateAlertRuleRequest,
+  UpdateAlertSettingsRequest,
+  UpdateAlertSmtpSettingsRequest,
+  UpdateAlertWebhookSettingsRequest,
+} from '@/api';
+
+export interface SmtpDraft {
+  enabled: boolean;
+  host: string;
+  port: number;
+  username: string;
+  sender: string;
+  recipients: string[];
+  transport: AlertSettingsView['smtp']['transport'];
+  send_resolved: boolean;
+  /** Read-only from the server: a secret is on file. The secret itself is never sent down. */
+  password_configured: boolean;
+  /** Transient input: empty = nothing typed (keep stored secret unless cleared). */
+  password: string;
+  /** Transient input: wipe the stored secret. */
+  clear_password: boolean;
+}
+
+export interface WebhookDraft {
+  enabled: boolean;
+  url: string;
+  send_resolved: boolean;
+  secret_configured: boolean;
+  secret: string;
+  clear_secret: boolean;
+}
+
+/** A rule plus a stable client-side key for v-for (the server `id` is user-editable). */
+export interface RuleDraft extends AlertRuleView {
+  uid: string;
+}
+
+export interface AlertsDraft {
+  enabled: boolean;
+  smtp: SmtpDraft;
+  webhook: WebhookDraft;
+  rules: RuleDraft[];
+  inspection: AlertSettingsView['inspection'];
+}
+
+/** Reauth carried by the save; matches the server's per-handler confirmation check. */
+export interface ReauthInput {
+  current_password: string;
+  code: string;
+}
+
+let ruleSeq = 0;
+function nextSeq(): number {
+  ruleSeq += 1;
+  return ruleSeq;
+}
+
+/** Defaults matching the legacy `emptyAlertsConfig` (used before the first load). */
+export function emptyAlertsConfig(): AlertsDraft {
+  return {
+    enabled: false,
+    smtp: {
+      enabled: false,
+      host: '',
+      port: 587,
+      username: '',
+      sender: '',
+      recipients: [],
+      transport: 'start_tls',
+      send_resolved: true,
+      password_configured: false,
+      password: '',
+      clear_password: false,
+    },
+    webhook: {
+      enabled: false,
+      url: '',
+      send_resolved: true,
+      secret_configured: false,
+      secret: '',
+      clear_secret: false,
+    },
+    rules: [],
+    inspection: {
+      enabled: false,
+      local_time: '09:00',
+      lookback_hours: 24,
+      delivery: ['smtp'],
+      offline_grace_minutes: 10,
+      latency_warn_ms: 250,
+      cpu_warn_percent: 85,
+      memory_warn_percent: 90,
+    },
+  };
+}
+
+/** A fresh rule with sensible defaults and a unique uid/id (for "add rule"). */
+export function blankRule(): RuleDraft {
+  const seq = nextSeq();
+  return {
+    uid: `rule-uid-${seq}`,
+    id: `rule-${seq}`,
+    name: '',
+    enabled: true,
+    metric: 'cpu_usage_percent',
+    comparator: 'gt',
+    threshold: 85,
+    window_minutes: 5,
+    severity: 'warning',
+    scope_mode: 'all',
+    node_ids: [],
+    tags: [],
+    delivery: ['smtp'],
+    cooldown_minutes: 30,
+    send_resolved: true,
+  };
+}
+
+function ruleViewToDraft(rule: AlertRuleView): RuleDraft {
+  return {
+    ...rule,
+    uid: `rule-uid-${nextSeq()}`,
+    node_ids: [...rule.node_ids],
+    tags: [...rule.tags],
+    delivery: [...rule.delivery],
+  };
+}
+
+/** Server View → editable draft. Copies arrays (no shared refs) and seeds the
+ * transient secret fields blank; stored secrets are never echoed. */
+export function viewToDraft(view: AlertSettingsView): AlertsDraft {
+  return {
+    enabled: view.enabled,
+    smtp: {
+      enabled: view.smtp.enabled,
+      host: view.smtp.host,
+      port: view.smtp.port,
+      username: view.smtp.username,
+      sender: view.smtp.sender,
+      recipients: [...view.smtp.recipients],
+      transport: view.smtp.transport,
+      send_resolved: view.smtp.send_resolved,
+      password_configured: view.smtp.password_configured,
+      password: '',
+      clear_password: false,
+    },
+    webhook: {
+      enabled: view.webhook.enabled,
+      url: view.webhook.url,
+      send_resolved: view.webhook.send_resolved,
+      secret_configured: view.webhook.secret_configured,
+      secret: '',
+      clear_secret: false,
+    },
+    rules: view.rules.map(ruleViewToDraft),
+    inspection: { ...view.inspection, delivery: [...view.inspection.delivery] },
+  };
+}
+
+function ruleToPayload(rule: RuleDraft): UpdateAlertRuleRequest {
+  return {
+    id: rule.id,
+    name: rule.name,
+    enabled: rule.enabled,
+    metric: rule.metric,
+    comparator: rule.comparator,
+    threshold: rule.threshold,
+    window_minutes: rule.window_minutes,
+    severity: rule.severity,
+    scope_mode: rule.scope_mode,
+    node_ids: [...rule.node_ids],
+    tags: [...rule.tags],
+    delivery: [...rule.delivery],
+    cooldown_minutes: rule.cooldown_minutes,
+    send_resolved: rule.send_resolved,
+  };
+}
+
+/**
+ * Draft + reauth → POST payload. The `password`/`secret` keys are included
+ * ONLY when a non-blank value was typed and the field isn't being cleared —
+ * omitting the key (rather than sending null/undefined) lets the server keep the
+ * stored secret. `current_password`/`code` are likewise omitted when blank.
+ */
+export function draftToPayload(draft: AlertsDraft, reauth: ReauthInput): UpdateAlertSettingsRequest {
+  const sendPassword = !draft.smtp.clear_password && draft.smtp.password.trim() !== '';
+  const smtp: UpdateAlertSmtpSettingsRequest = {
+    enabled: draft.smtp.enabled,
+    host: draft.smtp.host.trim(),
+    port: draft.smtp.port,
+    username: draft.smtp.username.trim(),
+    sender: draft.smtp.sender.trim(),
+    recipients: [...draft.smtp.recipients],
+    transport: draft.smtp.transport,
+    send_resolved: draft.smtp.send_resolved,
+    clear_password: draft.smtp.clear_password,
+    ...(sendPassword ? { password: draft.smtp.password } : {}),
+  };
+
+  const sendSecret = !draft.webhook.clear_secret && draft.webhook.secret.trim() !== '';
+  const webhook: UpdateAlertWebhookSettingsRequest = {
+    enabled: draft.webhook.enabled,
+    url: draft.webhook.url.trim(),
+    send_resolved: draft.webhook.send_resolved,
+    clear_secret: draft.webhook.clear_secret,
+    ...(sendSecret ? { secret: draft.webhook.secret } : {}),
+  };
+
+  const currentPassword = reauth.current_password;
+  const code = reauth.code.trim();
+  return {
+    ...(currentPassword.trim() !== '' ? { current_password: currentPassword } : {}),
+    ...(code !== '' ? { code } : {}),
+    enabled: draft.enabled,
+    smtp,
+    webhook,
+    rules: draft.rules.map(ruleToPayload),
+    inspection: { ...draft.inspection, delivery: [...draft.inspection.delivery] },
+  };
+}

--- a/nodelite-server/web/src/router/index.ts
+++ b/nodelite-server/web/src/router/index.ts
@@ -21,6 +21,11 @@ const routes: RouteRecordRaw[] = [
     name: 'account',
     component: () => import('@/views/AccountView.vue'),
   },
+  {
+    path: '/alerts',
+    name: 'alerts',
+    component: () => import('@/views/AlertsView.vue'),
+  },
 ];
 
 export const router = createRouter({

--- a/nodelite-server/web/src/stores/alerts.spec.ts
+++ b/nodelite-server/web/src/stores/alerts.spec.ts
@@ -1,0 +1,85 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiAbortError, ApiError } from '@/api/client';
+import { apiClient, type UpdateAlertSettingsRequest } from '@/api';
+import { makeAlertSettings } from '@/api/__fixtures__/nodes';
+import { useAlertsStore } from './alerts';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, alertSettings: vi.fn(), updateAlertSettings: vi.fn() },
+  };
+});
+
+const mockGet = vi.mocked(apiClient.alertSettings);
+const mockPost = vi.mocked(apiClient.updateAlertSettings);
+
+const EMPTY_PAYLOAD = {} as UpdateAlertSettingsRequest;
+
+describe('useAlertsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockGet.mockReset();
+    mockPost.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads config + preview on success', async () => {
+    const res = makeAlertSettings({ config: { enabled: false } });
+    mockGet.mockResolvedValueOnce(res);
+    const store = useAlertsStore();
+    await store.load();
+    expect(store.config).toEqual(res.config);
+    expect(store.preview).toEqual(res.preview);
+    expect(store.error).toBeNull();
+  });
+
+  it('captures non-abort load errors', async () => {
+    mockGet.mockRejectedValueOnce(new ApiError(503, 'down'));
+    const store = useAlertsStore();
+    await store.load();
+    expect(store.config).toBeNull();
+    expect(store.error).toBeInstanceOf(ApiError);
+  });
+
+  it('swallows ApiAbortError on load', async () => {
+    mockGet.mockRejectedValueOnce(new ApiAbortError('redirect'));
+    const store = useAlertsStore();
+    await store.load();
+    expect(store.error).toBeNull();
+  });
+
+  it('skips concurrent loads', async () => {
+    let resolve: (v: ReturnType<typeof makeAlertSettings>) => void = () => {};
+    mockGet.mockReturnValueOnce(new Promise((r) => (resolve = r)));
+    const store = useAlertsStore();
+    const first = store.load();
+    void store.load();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    resolve(makeAlertSettings());
+    await first;
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('save refreshes config + preview from the POST response', async () => {
+    const updated = makeAlertSettings({ config: { enabled: true } });
+    mockPost.mockResolvedValueOnce(updated);
+    const store = useAlertsStore();
+    await store.save(EMPTY_PAYLOAD);
+    expect(mockPost).toHaveBeenCalledWith(EMPTY_PAYLOAD);
+    expect(store.config).toEqual(updated.config);
+    expect(store.saving).toBe(false);
+  });
+
+  it('save propagates the error and clears the saving flag', async () => {
+    mockPost.mockRejectedValueOnce(new ApiError(401, JSON.stringify({ ok: false, message: 'bad code' })));
+    const store = useAlertsStore();
+    await expect(store.save(EMPTY_PAYLOAD)).rejects.toBeInstanceOf(ApiError);
+    expect(store.saving).toBe(false);
+  });
+});

--- a/nodelite-server/web/src/stores/alerts.ts
+++ b/nodelite-server/web/src/stores/alerts.ts
@@ -1,0 +1,53 @@
+import { defineStore } from 'pinia';
+import { ref, shallowRef } from 'vue';
+import {
+  apiClient,
+  type AlertPreview,
+  type AlertSettingsView,
+  type UpdateAlertSettingsRequest,
+} from '@/api';
+import { ApiAbortError } from '@/api/client';
+
+/**
+ * Alert settings (GET/POST /api/settings/alerts). Holds the server's canonical
+ * config + preview; the editable draft lives in AlertsView (viewToDraft). Single
+ * global resource, so a simple concurrent-load guard suffices. `save` lets its
+ * error propagate so the view can surface the server's reauth/validation message.
+ */
+export const useAlertsStore = defineStore('alerts', () => {
+  const config = shallowRef<AlertSettingsView | null>(null);
+  const preview = shallowRef<AlertPreview | null>(null);
+  const loading = ref(false);
+  const saving = ref(false);
+  const error = ref<Error | null>(null);
+
+  async function load(): Promise<void> {
+    if (loading.value) return;
+    loading.value = true;
+    error.value = null;
+    try {
+      const res = await apiClient.alertSettings();
+      config.value = res.config;
+      preview.value = res.preview;
+    } catch (e) {
+      if (e instanceof ApiAbortError) return;
+      error.value = e instanceof Error ? e : new Error(String(e));
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /** POST the payload; on success refresh config + preview from the response. */
+  async function save(payload: UpdateAlertSettingsRequest): Promise<void> {
+    saving.value = true;
+    try {
+      const res = await apiClient.updateAlertSettings(payload);
+      config.value = res.config;
+      preview.value = res.preview;
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  return { config, preview, loading, saving, error, load, save };
+});

--- a/nodelite-server/web/src/views/AlertsView.spec.ts
+++ b/nodelite-server/web/src/views/AlertsView.spec.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { apiClient } from '@/api';
+import { makeAlertSettings } from '@/api/__fixtures__/nodes';
+import AlertsView from './AlertsView.vue';
+
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<typeof import('@/api')>('@/api');
+  return {
+    ...actual,
+    apiClient: { ...actual.apiClient, alertSettings: vi.fn(), updateAlertSettings: vi.fn() },
+  };
+});
+
+const mockLoad = vi.mocked(apiClient.alertSettings);
+const mockSave = vi.mocked(apiClient.updateAlertSettings);
+
+const FAKE_DICT = {
+  en: {
+    'alerts.heading': 'Alerts',
+    'alerts.subtitle': 'sub',
+    'alerts.save': 'Save',
+    'alerts.saving': 'Saving…',
+    'alerts.saved': 'Saved',
+    'alerts.save_failed': 'Save failed: {error}',
+    'alerts.secret.keep': 'leave blank to keep',
+    'settings.password.current': 'Current password',
+    'settings.security.verification_code': 'Code',
+    'common.waiting_for_data': 'Waiting…',
+    'common.language': 'Language',
+    'common.theme_toggle': 'Toggle theme',
+    'index.nav.overview': 'Overview',
+    'index.nav.settings': 'Settings',
+    'index.nav.alerts': 'Alerts',
+    'index.nav.account': 'Account',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: Stub },
+      { path: '/nodes/:id', component: Stub },
+      { path: '/alerts', name: 'alerts', component: AlertsView },
+    ],
+  });
+}
+
+describe('AlertsView', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    mockLoad.mockResolvedValue(makeAlertSettings());
+    mockSave.mockResolvedValue(makeAlertSettings());
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FAKE_DICT),
+      } as unknown as Response),
+    );
+    await setupI18n(createApp(Stub));
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  async function mountView() {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const router = makeRouter();
+    await router.push('/alerts');
+    await router.isReady();
+    const wrapper = mount(AlertsView, { global: { plugins: [pinia, router, getI18n()] } });
+    await flushPromises();
+    return wrapper;
+  }
+
+  it('loads on mount and renders the editor cards', async () => {
+    const wrapper = await mountView();
+    expect(mockLoad).toHaveBeenCalled();
+    expect(wrapper.find('[data-test="alerts-view"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="alert-overview-card"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="alerts-save-bar"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="smtp-host"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="webhook-url"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="inspection-lookback"]').exists()).toBe(true);
+  });
+
+  it('shows an error message (not an infinite spinner) when the load fails', async () => {
+    const { ApiError } = await import('@/api/client');
+    mockLoad.mockReset();
+    mockLoad.mockRejectedValueOnce(new ApiError(503, 'service unavailable'));
+    const wrapper = await mountView();
+    expect(wrapper.find('[data-test="alerts-loading"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="alert-overview-card"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="alerts-error"]').exists()).toBe(true);
+  });
+
+  it('saves the draft with typed reauth and shows the saved message', async () => {
+    const wrapper = await mountView();
+    await wrapper.find('[data-test="reauth-password"]').setValue('hunter2');
+    await wrapper.find('[data-test="alerts-save"]').trigger('click');
+    await flushPromises();
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockSave.mock.calls[0]?.[0]).toMatchObject({ current_password: 'hunter2' });
+    expect(wrapper.find('[data-test="settings-message"]').text()).toBe('Saved');
+  });
+
+  it('surfaces the server message when a save is rejected', async () => {
+    const { ApiError } = await import('@/api/client');
+    mockSave.mockReset();
+    mockSave.mockRejectedValueOnce(new ApiError(400, JSON.stringify({ ok: false, message: 'bad code' })));
+    const wrapper = await mountView();
+    await wrapper.find('[data-test="alerts-save"]').trigger('click');
+    await flushPromises();
+
+    const msg = wrapper.find('[data-test="settings-message"]');
+    expect(msg.classes()).toContain('error');
+    expect(msg.text()).toBe('Save failed: bad code');
+  });
+});

--- a/nodelite-server/web/src/views/AlertsView.vue
+++ b/nodelite-server/web/src/views/AlertsView.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import { onMounted, reactive } from 'vue';
+import { useI18n } from 'vue-i18n';
+import AppLayout from '@/components/AppLayout.vue';
+import AlertOverviewCard from '@/components/AlertOverviewCard.vue';
+import SmtpChannelCard from '@/components/SmtpChannelCard.vue';
+import WebhookChannelCard from '@/components/WebhookChannelCard.vue';
+import InspectionCard from '@/components/InspectionCard.vue';
+import ReauthFields from '@/components/ReauthFields.vue';
+import SettingsMessage from '@/components/SettingsMessage.vue';
+import { ApiAbortError } from '@/api/client';
+import { messageFromError } from '@/lib/apiError';
+import { draftToPayload, emptyAlertsConfig, viewToDraft } from '@/lib/alertsDraft';
+import { useAlertsStore } from '@/stores/alerts';
+
+const { t } = useI18n();
+const store = useAlertsStore();
+
+// The reactive draft is the single source of truth (no DOM-as-state). Seeded
+// from the server config on load and re-seeded after each successful save.
+const draft = reactive(emptyAlertsConfig());
+// Both reauth fields always show (matches legacy); the server validates whichever
+// applies given the account's 2FA state. draftToPayload omits blanks.
+const reauth = reactive({ current_password: '', code: '' });
+const message = reactive<{ state: 'ok' | 'error' | null; text: string }>({ state: null, text: '' });
+
+function seedDraft(): void {
+  if (store.config) Object.assign(draft, viewToDraft(store.config));
+}
+
+onMounted(async () => {
+  await store.load();
+  seedDraft();
+});
+
+async function save(): Promise<void> {
+  message.state = null;
+  message.text = t('alerts.saving');
+  try {
+    await store.save(draftToPayload(draft, reauth));
+    seedDraft();
+    reauth.current_password = '';
+    reauth.code = '';
+    message.state = 'ok';
+    message.text = t('alerts.saved');
+  } catch (e) {
+    if (e instanceof ApiAbortError) return;
+    message.state = 'error';
+    message.text = t('alerts.save_failed', { error: messageFromError(e, 'unknown') });
+  }
+}
+</script>
+
+<template>
+  <AppLayout>
+    <template #title>
+      <h1 class="page-heading">{{ t('alerts.heading') }}</h1>
+      <p class="page-subtitle">{{ t('alerts.subtitle') }}</p>
+    </template>
+
+    <section class="alerts" data-test="alerts-view">
+      <template v-if="store.config">
+        <AlertOverviewCard v-model="draft" />
+
+        <article class="save-bar panel" data-test="alerts-save-bar">
+          <ReauthFields
+            v-model:current-password="reauth.current_password"
+            v-model:code="reauth.code"
+            variant="both"
+          />
+          <button
+            type="button"
+            class="btn btn--primary"
+            :disabled="store.saving"
+            data-test="alerts-save"
+            @click="save"
+          >
+            {{ t('alerts.save') }}
+          </button>
+          <SettingsMessage :state="message.state" :text="message.text" />
+        </article>
+
+        <div class="alerts__grid">
+          <SmtpChannelCard v-model="draft.smtp" />
+          <WebhookChannelCard v-model="draft.webhook" />
+          <InspectionCard v-model="draft.inspection" />
+        </div>
+      </template>
+
+      <SettingsMessage
+        v-else-if="store.error"
+        state="error"
+        :text="store.error.message"
+        data-test="alerts-error"
+      />
+      <p v-else class="placeholder" data-test="alerts-loading">
+        {{ t('common.waiting_for_data') }}
+      </p>
+    </section>
+  </AppLayout>
+</template>
+
+<style scoped>
+.alerts {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.alerts__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.save-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.btn {
+  align-self: flex-start;
+  background: var(--bg-card-soft);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 8px 14px;
+  font: inherit;
+}
+.btn--primary {
+  color: #fff;
+  background: var(--accent-blue);
+  border-color: transparent;
+}
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.page-heading {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.page-subtitle {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.placeholder {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+</style>


### PR DESCRIPTION
## Summary
Ports the legacy `index-alert-settings.js` alert config form (the channels/inspection half) to a Vue/Vite page at `/alerts`, replacing the legacy DOM-as-state model with a single reactive draft.

- **API + store**: alert View/Update types + `alertSettings()`/`updateAlertSettings()` wrappers; `useAlertsStore` (load → config + preview, save → POST + refresh, error propagates so the view can surface the server's reauth/validation message).
- **Pure draft bridge** (`lib/alertsDraft.ts`): `viewToDraft` (load) / `draftToPayload` (save) encode the server's secret keep/clear rule — `clear_*` wipes; a non-blank typed value replaces; otherwise the stored secret is kept (never echoed). Exhaustively unit-tested.
- **Cards** (all `v-model` against the draft): `AlertOverviewCard` (enable + summary), `SmtpChannelCard`, `WebhookChannelCard`, `InspectionCard`, plus shared `CsvField` (string↔array bridge) and `DeliveryCheckboxes`.
- **`AlertsView`**: owns the reactive draft (seeded via `viewToDraft`, re-seeded after save) + a save bar with both reauth fields (server validates whichever applies given 2FA state). Existing rules carry through unchanged — the rule editor + preview land in 2.5d.
- **Routing/nav**: lazy `/alerts` route; the disabled Alerts sidebar button becomes an active-aware `RouterLink`.

No server changes; all i18n keys already existed.

## Test plan
- [ ] `pnpm lint` (max-warnings=0), `pnpm typecheck`, `pnpm test` (322 passing), `pnpm build` — all clean.
- [ ] `/alerts` loads server config; toggle enable; edit SMTP/webhook (secret keep vs clear placeholder); edit inspection numerics.
- [ ] Save with reauth persists and re-seeds the draft; bad reauth shows the server message.
- [ ] Alerts sidebar link is enabled and marks active on `/alerts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)