### PR TITLE
Stage 2.5d — Alerts: rule list/editor + preview

### DIFF
--- a/nodelite-server/web/src/components/PreviewCard.spec.ts
+++ b/nodelite-server/web/src/components/PreviewCard.spec.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { makeAlertPreview } from '@/api/__fixtures__/nodes';
+import type { AlertPreview } from '@/api';
+import PreviewCard from './PreviewCard.vue';
+
+const FAKE_DICT = {
+  en: {
+    'alerts.preview.title': 'Preview',
+    'alerts.preview.empty': 'Save once to preview.',
+    'alerts.preview.total_nodes': 'Total nodes',
+    'alerts.preview.offline_nodes': 'Offline nodes',
+    'alerts.preview.latency_nodes': 'High latency nodes',
+    'alerts.preview.cpu_hot_nodes': 'High CPU nodes',
+    'alerts.preview.memory_hot_nodes': 'High memory nodes',
+    'alerts.preview.triggered_rules': 'Triggered rules',
+    'alerts.preview.no_triggered_rules': 'No rules would currently fire.',
+    'alerts.preview.highlights': 'Inspection highlights',
+    'alerts.preview.no_highlights': 'No daily inspection highlights yet.',
+    'alerts.severity.warning': 'Warning',
+    'alerts.severity.critical': 'Critical',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountCard(preview: AlertPreview | null) {
+  return mount(PreviewCard, { props: { preview }, global: { plugins: [getI18n()] } });
+}
+
+describe('PreviewCard', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    await setupI18n(createApp(Stub));
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the empty state when there is no preview', () => {
+    const wrapper = mountCard(null);
+    expect(wrapper.find('[data-test="preview-empty"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="preview-summary"]').exists()).toBe(false);
+  });
+
+  it('renders the inspection summary counts', () => {
+    const wrapper = mountCard(
+      makeAlertPreview({
+        inspection: {
+          total_nodes: 9,
+          offline_nodes: 2,
+          latency_nodes: 1,
+          cpu_hot_nodes: 3,
+          memory_hot_nodes: 0,
+          highlights: [],
+        },
+      }),
+    );
+    const values = wrapper.findAll('[data-test="preview-summary"] .summary-value').map((n) => n.text());
+    expect(values).toEqual(['9', '2', '1', '3', '0']);
+  });
+
+  it('renders triggered rules with a severity badge and the empty highlight state', () => {
+    const wrapper = mountCard(
+      makeAlertPreview({
+        triggered_rules: [
+          { rule_id: 'r1', rule_name: 'CPU hot', severity: 'critical', node_ids: ['node-a', 'node-b'] },
+        ],
+      }),
+    );
+    const item = wrapper.find('[data-test="preview-triggered"] .preview-item');
+    expect(item.text()).toContain('Critical');
+    expect(item.text()).toContain('CPU hot');
+    expect(item.text()).toContain('node-a, node-b');
+    expect(wrapper.find('[data-test="preview-no-triggered"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="preview-no-highlights"]').exists()).toBe(true);
+  });
+
+  it('renders highlights using node_label, falling back to node_id', () => {
+    const wrapper = mountCard(
+      makeAlertPreview({
+        inspection: {
+          total_nodes: 1,
+          offline_nodes: 0,
+          latency_nodes: 0,
+          cpu_hot_nodes: 0,
+          memory_hot_nodes: 0,
+          highlights: [
+            { node_id: 'node-a', node_label: 'Node A', reasons: ['offline', 'high cpu'] },
+            { node_id: 'node-b', node_label: '', reasons: ['high latency'] },
+          ],
+        },
+      }),
+    );
+    const items = wrapper.findAll('[data-test="preview-highlights"] .preview-item');
+    expect(items).toHaveLength(2);
+    expect(items[0]?.text()).toContain('Node A');
+    expect(items[0]?.text()).toContain('offline, high cpu');
+    expect(items[1]?.text()).toContain('node-b');
+  });
+});

--- a/nodelite-server/web/src/components/PreviewCard.vue
+++ b/nodelite-server/web/src/components/PreviewCard.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { AlertPreview, InspectionPreview } from '@/api';
+
+/**
+ * Read-only render of the server-computed alert preview (triggered rules +
+ * daily-inspection summary). The server recomputes it on every GET/save, so
+ * there's no client logic here — the card just reflects `store.preview`. Null
+ * before the first successful load → the "save once to preview" empty state.
+ */
+const props = defineProps<{ preview: AlertPreview | null }>();
+
+const { t } = useI18n();
+
+type CountField = Exclude<keyof InspectionPreview, 'highlights'>;
+const summaryFields: { key: string; field: CountField }[] = [
+  { key: 'alerts.preview.total_nodes', field: 'total_nodes' },
+  { key: 'alerts.preview.offline_nodes', field: 'offline_nodes' },
+  { key: 'alerts.preview.latency_nodes', field: 'latency_nodes' },
+  { key: 'alerts.preview.cpu_hot_nodes', field: 'cpu_hot_nodes' },
+  { key: 'alerts.preview.memory_hot_nodes', field: 'memory_hot_nodes' },
+];
+
+const summary = computed(() => {
+  const ins = props.preview?.inspection;
+  if (!ins) return [];
+  return summaryFields.map(({ key, field }) => ({ key, label: t(key), value: ins[field] }));
+});
+
+const triggered = computed(() => props.preview?.triggered_rules ?? []);
+const highlights = computed(() => props.preview?.inspection.highlights ?? []);
+</script>
+
+<template>
+  <article class="panel preview" data-test="preview-card">
+    <header class="card-head">
+      <h2 class="card-title">{{ t('alerts.preview.title') }}</h2>
+    </header>
+
+    <p v-if="!preview" class="preview-muted" data-test="preview-empty">
+      {{ t('alerts.preview.empty') }}
+    </p>
+
+    <template v-else>
+      <div class="summary" data-test="preview-summary">
+        <div v-for="row in summary" :key="row.key" class="summary-cell">
+          <span class="summary-value">{{ row.value }}</span>
+          <span class="summary-label">{{ row.label }}</span>
+        </div>
+      </div>
+
+      <section class="preview-section">
+        <h3 class="preview-subtitle">{{ t('alerts.preview.triggered_rules') }}</h3>
+        <p v-if="!triggered.length" class="preview-muted" data-test="preview-no-triggered">
+          {{ t('alerts.preview.no_triggered_rules') }}
+        </p>
+        <ul v-else class="preview-list" data-test="preview-triggered">
+          <li v-for="rule in triggered" :key="rule.rule_id" class="preview-item">
+            <span class="badge" :class="`badge--${rule.severity}`">
+              {{ t(`alerts.severity.${rule.severity}`) }}
+            </span>
+            <span class="preview-name">{{ rule.rule_name }}</span>
+            <span class="preview-nodes">{{ rule.node_ids.join(', ') }}</span>
+          </li>
+        </ul>
+      </section>
+
+      <section class="preview-section">
+        <h3 class="preview-subtitle">{{ t('alerts.preview.highlights') }}</h3>
+        <p v-if="!highlights.length" class="preview-muted" data-test="preview-no-highlights">
+          {{ t('alerts.preview.no_highlights') }}
+        </p>
+        <ul v-else class="preview-list" data-test="preview-highlights">
+          <li v-for="h in highlights" :key="h.node_id" class="preview-item">
+            <span class="preview-name">{{ h.node_label || h.node_id }}</span>
+            <span class="preview-nodes">{{ h.reasons.join(', ') }}</span>
+          </li>
+        </ul>
+      </section>
+    </template>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.card-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: 10px;
+  margin: 14px 0;
+}
+.summary-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  background: var(--bg-card-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+}
+.summary-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.summary-label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.preview-section {
+  margin-top: 14px;
+}
+.preview-subtitle {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.preview-muted {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.preview-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.preview-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+.preview-name {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+.preview-nodes {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  color: var(--text-secondary);
+}
+.badge--warning {
+  color: var(--accent-amber, #d29922);
+  border-color: var(--accent-amber, #d29922);
+}
+.badge--critical {
+  color: var(--accent-red);
+  border-color: var(--accent-red-soft);
+  background: var(--accent-red-soft);
+}
+</style>

--- a/nodelite-server/web/src/components/RuleEditorCard.spec.ts
+++ b/nodelite-server/web/src/components/RuleEditorCard.spec.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h, reactive } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { blankRule, type RuleDraft } from '@/lib/alertsDraft';
+import RuleEditorCard from './RuleEditorCard.vue';
+
+const FAKE_DICT = {
+  en: {
+    'alerts.rules.name': 'Rule name',
+    'alerts.rules.enabled': 'Enabled',
+    'alerts.rules.remove': 'Remove',
+    'alerts.rules.details': 'Details',
+    'alerts.rules.id': 'ID',
+    'alerts.rules.metric': 'Metric',
+    'alerts.rules.comparator': 'Comparator',
+    'alerts.rules.threshold': 'Threshold',
+    'alerts.rules.window_minutes': 'Window (min)',
+    'alerts.rules.cooldown_minutes': 'Cooldown (min)',
+    'alerts.rules.severity': 'Severity',
+    'alerts.rules.scope_mode': 'Scope',
+    'alerts.rules.node_ids': 'Node IDs',
+    'alerts.rules.tags': 'Tags',
+    'alerts.rules.send_resolved': 'Send resolved',
+    'alerts.inspection.delivery': 'Delivery',
+    'alerts.metric.cpu': 'CPU',
+    'alerts.metric.memory': 'Memory',
+    'alerts.metric.disk': 'Disk',
+    'alerts.metric.latency': 'Latency',
+    'alerts.metric.offline': 'Offline',
+    'alerts.comparator.gt': '>',
+    'alerts.comparator.lt': '<',
+    'alerts.severity.warning': 'Warning',
+    'alerts.severity.critical': 'Critical',
+    'alerts.scope.all': 'All nodes',
+    'alerts.scope.node_ids': 'Node IDs',
+    'alerts.scope.tags': 'Tags',
+    'alerts.channel.smtp': 'Email',
+    'alerts.channel.webhook': 'Webhook',
+    'common.not_available': 'N/A',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountCard(rule: RuleDraft) {
+  return mount(RuleEditorCard, {
+    props: { modelValue: rule, 'onUpdate:modelValue': () => {} },
+    global: { plugins: [getI18n()] },
+  });
+}
+
+describe('RuleEditorCard', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    await setupI18n(createApp(Stub));
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the title and a human-readable expression', () => {
+    const rule = reactive({ ...blankRule(), name: 'CPU hot' });
+    const wrapper = mountCard(rule);
+    expect(wrapper.find('[data-test="rule-title"]').text()).toBe('CPU hot');
+    // metric > threshold · window m · scope · delivery
+    expect(wrapper.find('[data-test="rule-expression"]').text()).toBe('CPU > 85 · 5m · All nodes · Email');
+  });
+
+  it('falls back to id then label when name is blank', () => {
+    const rule = reactive({ ...blankRule(), name: '', id: 'rule-7' });
+    const wrapper = mountCard(rule);
+    expect(wrapper.find('[data-test="rule-title"]').text()).toBe('rule-7');
+  });
+
+  it('binds field edits back into the bound rule, coercing numbers', async () => {
+    const rule = reactive(blankRule());
+    const wrapper = mountCard(rule);
+    await wrapper.find('[data-test="rule-name"]').setValue('Memory hot');
+    expect(rule.name).toBe('Memory hot');
+    await wrapper.find('[data-test="rule-threshold"]').setValue('90');
+    expect(rule.threshold).toBe(90);
+    expect(typeof rule.threshold).toBe('number');
+    await wrapper.find('[data-test="rule-metric"]').setValue('memory_usage_percent');
+    expect(rule.metric).toBe('memory_usage_percent');
+  });
+
+  it('gates the scope target field on scope_mode', async () => {
+    const rule = reactive(blankRule());
+    const wrapper = mountCard(rule);
+    expect(wrapper.find('[data-test="rule-node-ids"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="rule-tags"]').exists()).toBe(false);
+
+    rule.scope_mode = 'node_ids';
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="rule-node-ids"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="rule-tags"]').exists()).toBe(false);
+
+    rule.scope_mode = 'tags';
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="rule-node-ids"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="rule-tags"]').exists()).toBe(true);
+  });
+
+  it('edits node_ids through CsvField when scoped to node_ids', async () => {
+    const rule = reactive({ ...blankRule(), scope_mode: 'node_ids' as const });
+    const wrapper = mountCard(rule);
+    await wrapper.find('[data-test="rule-node-ids"]').setValue('node-a, node-b');
+    expect(rule.node_ids).toEqual(['node-a', 'node-b']);
+  });
+
+  it('toggles delivery channels', async () => {
+    const rule = reactive(blankRule());
+    const wrapper = mountCard(rule);
+    expect(rule.delivery).toEqual(['smtp']);
+    await wrapper.find('[data-test="delivery-webhook"]').setValue(true);
+    expect(rule.delivery).toEqual(['smtp', 'webhook']);
+  });
+
+  it('emits remove when the remove button is clicked', async () => {
+    const rule = reactive(blankRule());
+    const wrapper = mountCard(rule);
+    await wrapper.find('[data-test="rule-remove"]').trigger('click');
+    expect(wrapper.emitted('remove')).toHaveLength(1);
+  });
+});

--- a/nodelite-server/web/src/components/RuleEditorCard.vue
+++ b/nodelite-server/web/src/components/RuleEditorCard.vue
@@ -1,0 +1,239 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type {
+  AlertComparator,
+  AlertMetric,
+  AlertScopeMode,
+  AlertSeverity,
+} from '@/api';
+import type { RuleDraft } from '@/lib/alertsDraft';
+import CsvField from './CsvField.vue';
+import DeliveryCheckboxes from './DeliveryCheckboxes.vue';
+
+/**
+ * Editor for one alert rule, bound directly against the parent's reactive draft
+ * slice (single source of truth). The scope selector gates which target field
+ * shows (node IDs vs tags). Numeric inputs are integer/step=1/non-negative
+ * because the server stores them as u64 — a decimal would 4xx on save.
+ * Removal is an array-level concern, so it's emitted to the parent (RuleList).
+ */
+const rule = defineModel<RuleDraft>({ required: true });
+const emit = defineEmits<{ remove: [] }>();
+
+const { t } = useI18n();
+
+const metrics: AlertMetric[] = [
+  'cpu_usage_percent',
+  'memory_usage_percent',
+  'disk_usage_percent',
+  'latency_ms',
+  'offline_minutes',
+];
+const comparators: AlertComparator[] = ['gt', 'lt'];
+const severities: AlertSeverity[] = ['warning', 'critical'];
+const scopes: AlertScopeMode[] = ['all', 'node_ids', 'tags'];
+
+// The i18n keys use short metric aliases, not the full snake_case enum value.
+const METRIC_LABEL_KEY: Record<AlertMetric, string> = {
+  cpu_usage_percent: 'alerts.metric.cpu',
+  memory_usage_percent: 'alerts.metric.memory',
+  disk_usage_percent: 'alerts.metric.disk',
+  latency_ms: 'alerts.metric.latency',
+  offline_minutes: 'alerts.metric.offline',
+};
+
+function scopeLabel(): string {
+  const r = rule.value;
+  if (r.scope_mode === 'node_ids' && r.node_ids.length) return r.node_ids.join(', ');
+  if (r.scope_mode === 'tags' && r.tags.length) return r.tags.join(', ');
+  return t(`alerts.scope.${r.scope_mode}`);
+}
+
+const title = computed(() => rule.value.name || rule.value.id || t('alerts.rules.name'));
+
+const expression = computed(() => {
+  const r = rule.value;
+  const metric = t(METRIC_LABEL_KEY[r.metric]);
+  const comparator = t(`alerts.comparator.${r.comparator}`);
+  const delivery = r.delivery.length
+    ? r.delivery.map((c) => t(`alerts.channel.${c}`)).join(' + ')
+    : t('common.not_available');
+  return `${metric} ${comparator} ${r.threshold} · ${r.window_minutes}m · ${scopeLabel()} · ${delivery}`;
+});
+</script>
+
+<template>
+  <section class="rule-card" data-test="rule-card">
+    <header class="rule-head">
+      <div class="rule-id">
+        <strong class="rule-title" data-test="rule-title">{{ title }}</strong>
+        <span class="rule-expression" data-test="rule-expression">{{ expression }}</span>
+      </div>
+      <div class="rule-actions">
+        <label class="toggle">
+          <input v-model="rule.enabled" type="checkbox" data-test="rule-enabled" />
+          <span>{{ t('alerts.rules.enabled') }}</span>
+        </label>
+        <button type="button" class="btn btn--danger" data-test="rule-remove" @click="emit('remove')">
+          {{ t('alerts.rules.remove') }}
+        </button>
+      </div>
+    </header>
+
+    <details class="rule-details">
+      <summary>{{ t('alerts.rules.details') }}</summary>
+      <div class="grid">
+        <label class="field">
+          <span>{{ t('alerts.rules.id') }}</span>
+          <input v-model="rule.id" type="text" data-test="rule-id" />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.rules.name') }}</span>
+          <input v-model="rule.name" type="text" data-test="rule-name" />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.rules.metric') }}</span>
+          <select v-model="rule.metric" data-test="rule-metric">
+            <option v-for="m in metrics" :key="m" :value="m">{{ t(METRIC_LABEL_KEY[m]) }}</option>
+          </select>
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.rules.comparator') }}</span>
+          <select v-model="rule.comparator" data-test="rule-comparator">
+            <option v-for="c in comparators" :key="c" :value="c">{{ t(`alerts.comparator.${c}`) }}</option>
+          </select>
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.rules.threshold') }}</span>
+          <input v-model.number="rule.threshold" type="number" min="0" step="1" data-test="rule-threshold" />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.rules.window_minutes') }}</span>
+          <input v-model.number="rule.window_minutes" type="number" min="1" step="1" data-test="rule-window" />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.rules.cooldown_minutes') }}</span>
+          <input v-model.number="rule.cooldown_minutes" type="number" min="1" step="1" data-test="rule-cooldown" />
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.rules.severity') }}</span>
+          <select v-model="rule.severity" data-test="rule-severity">
+            <option v-for="s in severities" :key="s" :value="s">{{ t(`alerts.severity.${s}`) }}</option>
+          </select>
+        </label>
+        <label class="field">
+          <span>{{ t('alerts.rules.scope_mode') }}</span>
+          <select v-model="rule.scope_mode" data-test="rule-scope">
+            <option v-for="s in scopes" :key="s" :value="s">{{ t(`alerts.scope.${s}`) }}</option>
+          </select>
+        </label>
+        <label v-if="rule.scope_mode === 'node_ids'" class="field">
+          <span>{{ t('alerts.rules.node_ids') }}</span>
+          <CsvField v-model="rule.node_ids" data-test="rule-node-ids" />
+        </label>
+        <label v-else-if="rule.scope_mode === 'tags'" class="field">
+          <span>{{ t('alerts.rules.tags') }}</span>
+          <CsvField v-model="rule.tags" data-test="rule-tags" />
+        </label>
+      </div>
+
+      <div class="field">
+        <span>{{ t('alerts.inspection.delivery') }}</span>
+        <DeliveryCheckboxes v-model="rule.delivery" data-test="rule-delivery" />
+      </div>
+
+      <label class="toggle">
+        <input v-model="rule.send_resolved" type="checkbox" data-test="rule-send-resolved" />
+        <span>{{ t('alerts.rules.send_resolved') }}</span>
+      </label>
+    </details>
+  </section>
+</template>
+
+<style scoped>
+.rule-card {
+  background: var(--bg-card-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+.rule-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.rule-id {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.rule-title {
+  font-size: 14px;
+  color: var(--text-primary);
+}
+.rule-expression {
+  font-size: 12px;
+  color: var(--text-muted);
+  word-break: break-word;
+}
+.rule-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.rule-details {
+  margin-top: 12px;
+}
+.rule-details summary {
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin: 12px 0;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.field input,
+.field select {
+  width: 100%;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+}
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.btn {
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font: inherit;
+}
+.btn--danger {
+  color: var(--accent-red);
+  border-color: var(--accent-red-soft);
+  background: var(--accent-red-soft);
+}
+</style>

--- a/nodelite-server/web/src/components/RuleList.spec.ts
+++ b/nodelite-server/web/src/components/RuleList.spec.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createApp, defineComponent, h, reactive } from 'vue';
+import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { viewToDraft, type RuleDraft } from '@/lib/alertsDraft';
+import { makeAlertSettingsView } from '@/api/__fixtures__/nodes';
+import RuleList from './RuleList.vue';
+
+const FAKE_DICT = {
+  en: {
+    'alerts.rules.title': 'Alert Rules',
+    'alerts.rules.note': 'note',
+    'alerts.rules.add': 'Add rule',
+    'alerts.rules.empty': 'No alert rules yet.',
+    // keys the nested RuleEditorCard renders
+    'alerts.rules.name': 'Rule name',
+    'alerts.rules.enabled': 'Enabled',
+    'alerts.rules.remove': 'Remove',
+    'alerts.rules.details': 'Details',
+    'alerts.rules.id': 'ID',
+    'alerts.rules.metric': 'Metric',
+    'alerts.rules.comparator': 'Comparator',
+    'alerts.rules.threshold': 'Threshold',
+    'alerts.rules.window_minutes': 'Window',
+    'alerts.rules.cooldown_minutes': 'Cooldown',
+    'alerts.rules.severity': 'Severity',
+    'alerts.rules.scope_mode': 'Scope',
+    'alerts.rules.node_ids': 'Node IDs',
+    'alerts.rules.tags': 'Tags',
+    'alerts.rules.send_resolved': 'Send resolved',
+    'alerts.inspection.delivery': 'Delivery',
+    'alerts.metric.cpu': 'CPU',
+    'alerts.metric.memory': 'Memory',
+    'alerts.metric.disk': 'Disk',
+    'alerts.metric.latency': 'Latency',
+    'alerts.metric.offline': 'Offline',
+    'alerts.comparator.gt': '>',
+    'alerts.comparator.lt': '<',
+    'alerts.severity.warning': 'Warning',
+    'alerts.severity.critical': 'Critical',
+    'alerts.scope.all': 'All nodes',
+    'alerts.scope.node_ids': 'Node IDs',
+    'alerts.scope.tags': 'Tags',
+    'alerts.channel.smtp': 'Email',
+    'alerts.channel.webhook': 'Webhook',
+    'common.not_available': 'N/A',
+  },
+  'zh-CN': {},
+};
+
+const Stub = defineComponent({ render: () => h('div') });
+
+function mountList(rules: RuleDraft[]) {
+  return mount(RuleList, {
+    props: { modelValue: rules, 'onUpdate:modelValue': () => {} },
+    global: { plugins: [getI18n()] },
+  });
+}
+
+describe('RuleList', () => {
+  beforeEach(async () => {
+    __resetI18nForTest();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve(FAKE_DICT) } as unknown as Response),
+    );
+    await setupI18n(createApp(Stub));
+  });
+
+  afterEach(() => {
+    __resetI18nForTest();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders one editor card per rule', () => {
+    const rules = reactive(viewToDraft(makeAlertSettingsView()).rules);
+    const wrapper = mountList(rules);
+    expect(wrapper.findAll('[data-test="rule-card"]')).toHaveLength(1);
+    expect(wrapper.find('[data-test="rule-list-empty"]').exists()).toBe(false);
+  });
+
+  it('shows the empty state when there are no rules', () => {
+    const rules = reactive<RuleDraft[]>([]);
+    const wrapper = mountList(rules);
+    expect(wrapper.find('[data-test="rule-list-empty"]').exists()).toBe(true);
+    expect(wrapper.findAll('[data-test="rule-card"]')).toHaveLength(0);
+  });
+
+  it('appends a blank rule on add', async () => {
+    const rules = reactive<RuleDraft[]>([]);
+    const wrapper = mountList(rules);
+    await wrapper.find('[data-test="rule-add"]').trigger('click');
+    expect(rules).toHaveLength(1);
+    expect(wrapper.findAll('[data-test="rule-card"]')).toHaveLength(1);
+  });
+
+  it('removes the rule whose card emitted remove', async () => {
+    const rules = reactive(viewToDraft(makeAlertSettingsView({ rules: makeAlertSettingsView().rules })).rules);
+    // Seed a second rule with a distinct uid by adding through the UI.
+    const wrapper = mountList(rules);
+    await wrapper.find('[data-test="rule-add"]').trigger('click');
+    expect(rules).toHaveLength(2);
+    const firstUid = rules[0]?.uid;
+    await wrapper.findAll('[data-test="rule-remove"]')[0]?.trigger('click');
+    expect(rules).toHaveLength(1);
+    expect(rules.some((r) => r.uid === firstUid)).toBe(false);
+  });
+});

--- a/nodelite-server/web/src/components/RuleList.vue
+++ b/nodelite-server/web/src/components/RuleList.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { blankRule, type RuleDraft } from '@/lib/alertsDraft';
+import RuleEditorCard from './RuleEditorCard.vue';
+
+/**
+ * The rule collection editor. Binds the parent's reactive `draft.rules` array
+ * and mutates it in place (push/splice) — the reactive draft is the single
+ * source of truth, so add/remove never loses sibling edits. Each card is keyed
+ * by the stable `uid` (not the array index, and not the user-editable `id`) so
+ * Vue keeps each editor's local DOM state when rules are added or removed.
+ */
+const rules = defineModel<RuleDraft[]>({ required: true });
+
+const { t } = useI18n();
+
+function add(): void {
+  rules.value.push(blankRule());
+}
+
+function remove(index: number): void {
+  rules.value.splice(index, 1);
+}
+
+// Fired only if a card reassigns its whole model; field edits mutate in place.
+function update(index: number, next: RuleDraft): void {
+  rules.value[index] = next;
+}
+</script>
+
+<template>
+  <article class="panel rules" data-test="rule-list">
+    <header class="rules-head">
+      <div class="rules-intro">
+        <h2 class="card-title">{{ t('alerts.rules.title') }}</h2>
+        <p class="rules-note">{{ t('alerts.rules.note') }}</p>
+      </div>
+      <button type="button" class="btn" data-test="rule-add" @click="add">
+        {{ t('alerts.rules.add') }}
+      </button>
+    </header>
+
+    <p v-if="!rules.length" class="rules-empty" data-test="rule-list-empty">
+      {{ t('alerts.rules.empty') }}
+    </p>
+    <div v-else class="rules-items">
+      <RuleEditorCard
+        v-for="(rule, index) in rules"
+        :key="rule.uid"
+        :model-value="rule"
+        @update:model-value="(next) => update(index, next)"
+        @remove="remove(index)"
+      />
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+}
+.rules-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.rules-intro {
+  min-width: 0;
+}
+.card-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+.rules-note {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.rules-empty {
+  margin: 14px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.rules-items {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 14px;
+}
+.btn {
+  flex-shrink: 0;
+  background: var(--bg-card-soft);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 8px 14px;
+  font: inherit;
+}
+</style>

--- a/nodelite-server/web/src/views/AlertsView.spec.ts
+++ b/nodelite-server/web/src/views/AlertsView.spec.ts
@@ -28,6 +28,9 @@ const FAKE_DICT = {
     'alerts.saved': 'Saved',
     'alerts.save_failed': 'Save failed: {error}',
     'alerts.secret.keep': 'leave blank to keep',
+    'alerts.rules.title': 'Alert Rules',
+    'alerts.rules.add': 'Add rule',
+    'alerts.preview.title': 'Preview',
     'settings.password.current': 'Current password',
     'settings.security.verification_code': 'Code',
     'common.waiting_for_data': 'Waiting…',
@@ -96,6 +99,9 @@ describe('AlertsView', () => {
     expect(wrapper.find('[data-test="smtp-host"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="webhook-url"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="inspection-lookback"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="rule-list"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="rule-card"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="preview-card"]').exists()).toBe(true);
   });
 
   it('shows an error message (not an infinite spinner) when the load fails', async () => {

--- a/nodelite-server/web/src/views/AlertsView.vue
+++ b/nodelite-server/web/src/views/AlertsView.vue
@@ -6,6 +6,8 @@ import AlertOverviewCard from '@/components/AlertOverviewCard.vue';
 import SmtpChannelCard from '@/components/SmtpChannelCard.vue';
 import WebhookChannelCard from '@/components/WebhookChannelCard.vue';
 import InspectionCard from '@/components/InspectionCard.vue';
+import RuleList from '@/components/RuleList.vue';
+import PreviewCard from '@/components/PreviewCard.vue';
 import ReauthFields from '@/components/ReauthFields.vue';
 import SettingsMessage from '@/components/SettingsMessage.vue';
 import { ApiAbortError } from '@/api/client';
@@ -85,6 +87,9 @@ async function save(): Promise<void> {
           <WebhookChannelCard v-model="draft.webhook" />
           <InspectionCard v-model="draft.inspection" />
         </div>
+
+        <RuleList v-model="draft.rules" />
+        <PreviewCard :preview="store.preview" />
       </template>
 
       <SettingsMessage


### PR DESCRIPTION
## Summary
Completes the Alerts page (Stage 2.5d) — the rule editor and the server-computed preview, building on the 2.5c shell/channels.

- **`RuleEditorCard.vue`** — edits one rule, bound to a `RuleDraft` via `defineModel`. `scope_mode` gates the `node_ids` vs `tags` CsvField; numeric inputs (`threshold`/`window_minutes`/`cooldown_minutes`) are integer/`step=1`/non-negative because the server stores them as `u64` (decimals would 4xx). Removal is emitted to the parent.
- **`RuleList.vue`** — binds `draft.rules` and mutates it in place (push/splice) so add/remove never loses sibling edits. Cards are keyed by a stable `uid` (not the array index, and not the user-editable `id`). Empty state + add button.
- **`PreviewCard.vue`** — read-only render of `store.preview`: inspection count strip, triggered-rule list with severity badges, and inspection highlights — each with its own empty state. Null preview → the "save once to preview" placeholder.
- **`AlertsView.vue`** — wires `<RuleList v-model="draft.rules">` and `<PreviewCard :preview="store.preview">` below the channel grid.

No server changes. All i18n keys already existed in `assets/ui-i18n.json`. The reactive draft remains the single source of truth — no DOM-as-state.

## Test plan
- [x] `pnpm lint` (max-warnings=0) clean
- [x] `pnpm typecheck` (vue-tsc --noEmit) clean
- [x] `pnpm test` — 68 files / 337 tests pass (new specs: RuleEditorCard, RuleList, PreviewCard; AlertsView updated)
- [x] `pnpm build` (vue-tsc --build + vite) clean
- [ ] Manual: `/alerts` add/remove rules without losing edits; scope_mode switches node_ids/tags; save persists + preview refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)