### PR TITLE
Stage 3.5a — Browser WebSocket endpoint (server)

### DIFF
--- a/nodelite-proto/src/lib.rs
+++ b/nodelite-proto/src/lib.rs
@@ -26,9 +26,10 @@ pub use config::{
     parse_agent_config, parse_server_config,
 };
 pub use message::{
-    AgentLogEntry, AgentLogsMessage, HelloMessage, MIN_SUPPORTED_WIRE_PROTOCOL_VERSION,
-    MetricsMessage, NoticeLevel, PingMessage, PongMessage, RefreshTokenRequestMessage,
-    RefreshTokenResponseMessage, ServerNoticeMessage, WIRE_PROTOCOL_VERSION, WireMessage,
+    AgentLogEntry, AgentLogsMessage, BrowserMessage, HelloMessage,
+    MIN_SUPPORTED_WIRE_PROTOCOL_VERSION, MetricsMessage, NoticeLevel, PingMessage, PongMessage,
+    RefreshTokenRequestMessage, RefreshTokenResponseMessage, ServerNoticeMessage,
+    WIRE_PROTOCOL_VERSION, WireMessage,
 };
 pub use model::{
     DiskUsage, HistoryPoint, LoadAverage, MemoryUsage, NetworkCounters, NodeIdentity,

--- a/nodelite-proto/src/message.rs
+++ b/nodelite-proto/src/message.rs
@@ -1,9 +1,10 @@
 //! Agent 与 Server 之间通过 WebSocket 交换的消息定义。
 //! 所有消息均为 JSON 文本帧,顶层使用 `type` 字段进行内部标记式枚举区分。
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::model::{NodeIdentity, NodeSnapshot};
+use crate::model::{NodeIdentity, NodeListItem, NodeSnapshot, OverviewData};
 
 /// 当前 WebSocket 线协议版本。
 ///
@@ -119,6 +120,43 @@ pub enum NoticeLevel {
     Info,
     Warn,
     Error,
+}
+
+/// Server → 浏览器 WebSocket(`/ws/browser`)通道上的消息。
+///
+/// 与 Agent 通道的 [`WireMessage`] 区分:浏览器通道是只读监控推送,客户端只发送
+/// 应用层 [`BrowserMessage::Ping`](浏览器 `WebSocket` API 无法发送协议级 ping 帧)。
+///
+/// 除全量 `InitialState` 外都是**增量**:单节点变化只发该节点一行,而非整张列表。
+/// 每条消息携带 `generated_at`,客户端据此做单调时间戳守卫,丢弃乱序/过期消息。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BrowserMessage {
+    /// 连接建立(以及重连 / 服务端 lag 恢复)时下发的全量快照,客户端整体替换本地状态。
+    InitialState {
+        generated_at: DateTime<Utc>,
+        overview: OverviewData,
+        nodes: Vec<NodeListItem>,
+    },
+    /// 概览聚合数字更新(整体替换,体积很小)。
+    OverviewUpdate {
+        generated_at: DateTime<Utc>,
+        overview: OverviewData,
+    },
+    /// 单节点增量:新增或更新一行,客户端按 `node_id` 合并进本地 Map。
+    NodeUpsert {
+        generated_at: DateTime<Utc>,
+        node: NodeListItem,
+    },
+    /// 单节点移除(注销),客户端按 `node_id` 删除。
+    NodeRemoved {
+        generated_at: DateTime<Utc>,
+        node_id: String,
+    },
+    /// 应用层心跳:客户端发送 `Ping`,服务端回 `Pong`。
+    Ping,
+    /// 服务端对客户端 `Ping` 的应答。
+    Pong,
 }
 
 #[cfg(test)]
@@ -261,5 +299,87 @@ mod tests {
             let decoded: WireMessage = serde_json::from_str(&encoded).expect("decode");
             assert_eq!(message, decoded);
         }
+    }
+
+    /// 验证所有 BrowserMessage 子类型(含增量与心跳)都能完整序列化和反序列化。
+    #[test]
+    fn round_trips_browser_messages() {
+        use super::BrowserMessage;
+        use crate::model::{
+            NodeListIdentity, NodeListItem, NodeListLoadAverage, NodeListMemoryUsage,
+            NodeListSnapshot, OverviewData,
+        };
+
+        let generated_at = Utc.with_ymd_and_hms(2026, 5, 31, 12, 0, 0).unwrap();
+        let overview = OverviewData {
+            generated_at,
+            total_nodes: 3,
+            online_nodes: 2,
+            offline_nodes: 1,
+            total_rx_bytes: 1000,
+            total_tx_bytes: 2000,
+            current_rx_bytes_per_sec: 12.5,
+            current_tx_bytes_per_sec: 24.0,
+            average_latency_ms: Some(7.5),
+        };
+        let node = NodeListItem {
+            identity: NodeListIdentity {
+                node_id: "hk-01".to_string(),
+                node_label: "Hong Kong 01".to_string(),
+                hostname: "hk-01".to_string(),
+                tags: vec!["apac".to_string()],
+            },
+            snapshot: Some(NodeListSnapshot {
+                cpu_usage_percent: Some(33.0),
+                load: NodeListLoadAverage { one: 0.5 },
+                memory: NodeListMemoryUsage {
+                    total_bytes: 2048,
+                    used_bytes: 1024,
+                },
+            }),
+            latency_ms: Some(9),
+            online: true,
+        };
+
+        let initial = BrowserMessage::InitialState {
+            generated_at,
+            overview: overview.clone(),
+            nodes: vec![node.clone()],
+        };
+        let overview_update = BrowserMessage::OverviewUpdate {
+            generated_at,
+            overview,
+        };
+        let upsert = BrowserMessage::NodeUpsert {
+            generated_at,
+            node,
+        };
+        let removed = BrowserMessage::NodeRemoved {
+            generated_at,
+            node_id: "hk-01".to_string(),
+        };
+
+        for message in [
+            initial,
+            overview_update,
+            upsert,
+            removed,
+            BrowserMessage::Ping,
+            BrowserMessage::Pong,
+        ] {
+            let encoded = serde_json::to_string(&message).expect("encode");
+            let decoded: BrowserMessage = serde_json::from_str(&encoded).expect("decode");
+            assert_eq!(message, decoded);
+        }
+
+        // 标记式枚举的线格式:单元变体只剩一个 `type` 字段。
+        assert_eq!(
+            serde_json::to_string(&BrowserMessage::Ping).expect("encode"),
+            r#"{"type":"ping"}"#
+        );
+        // 客户端发来的 ping 文本帧必须能被服务端解析为 Ping。
+        let parsed: BrowserMessage =
+            serde_json::from_str(r#"{"type":"ping"}"#).expect("parse client ping");
+        assert_eq!(parsed, BrowserMessage::Ping);
     }
 }

--- a/nodelite-proto/src/message.rs
+++ b/nodelite-proto/src/message.rs
@@ -350,10 +350,7 @@ mod tests {
             generated_at,
             overview,
         };
-        let upsert = BrowserMessage::NodeUpsert {
-            generated_at,
-            node,
-        };
+        let upsert = BrowserMessage::NodeUpsert { generated_at, node };
         let removed = BrowserMessage::NodeRemoved {
             generated_at,
             node_id: "hk-01".to_string(),

--- a/nodelite-server/src/app_state.rs
+++ b/nodelite-server/src/app_state.rs
@@ -35,6 +35,9 @@ pub(crate) struct AppState {
     pub(crate) registry: NodeRegistry,
     pub(crate) shared: SharedState,
     pub(crate) ws_admission: WsAdmissionController,
+    /// 浏览器 WebSocket(`/ws/browser`)的并发准入控制器。与 `ws_admission`
+    /// 同型但实例独立,使浏览器连接与 agent 连接各自计数、互不挤占配额。
+    pub(crate) browser_ws_admission: WsAdmissionController,
     pub(crate) readonly_auth: Arc<RwLock<ReadonlyRouteAuth>>,
     pub(crate) alerting: Arc<RwLock<AlertingConfig>>,
     pub(crate) two_factor_sessions: TwoFactorSessions,
@@ -121,6 +124,7 @@ impl AppState {
             registry,
             shared: SharedState::new(config.clone()),
             ws_admission: WsAdmissionController::new(&config.ws),
+            browser_ws_admission: WsAdmissionController::new(&config.ws),
             readonly_auth: Arc::new(RwLock::new(ReadonlyRouteAuth::from_config(
                 config.readonly_auth.clone(),
             ))),

--- a/nodelite-server/src/handlers/auth_routes.rs
+++ b/nodelite-server/src/handlers/auth_routes.rs
@@ -111,6 +111,12 @@ pub(crate) async fn require_readonly_auth(
     if basic_authorized {
         clear_readonly_auth_failures(&state, &meta);
         if two_factor_enabled {
+            // WebSocket 升级握手无法跟随 302 重定向(浏览器 `new WebSocket()` 不暴露
+            // redirect),返回 401 + JSON。WS 客户端据此 fallback 到一次 `/api/bootstrap`
+            // 探测,由统一 api 客户端完成到 /verify-2fa 的真实跳转。
+            if is_websocket_upgrade(&headers) {
+                return websocket_two_factor_required_response();
+            }
             return issue_two_factor_redirect(&state).await;
         }
         return next.run(request).await;
@@ -389,6 +395,33 @@ fn clear_readonly_auth_failures(state: &AppState, meta: &ReadonlyAuthMeta) {
             .sensitive_readonly_auth_admission
             .clear_auth_failures(meta.client_ip);
     }
+}
+
+/// 判断请求是否为 WebSocket 升级握手。依据 `Upgrade` 头是否包含 `websocket`
+/// token(大小写不敏感、容忍逗号分隔),与 axum `WebSocketUpgrade` 的识别一致。
+fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::UPGRADE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(',')
+                .any(|token| token.trim().eq_ignore_ascii_case("websocket"))
+        })
+}
+
+/// 受保护的 WebSocket 端点要求 2FA 时的响应。浏览器 `new WebSocket()` 无法跟随
+/// HTTP 302,因此返回 401 + JSON 而非重定向;WS 客户端据此跳转 /verify-2fa。
+fn websocket_two_factor_required_response() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "ok": false,
+            "message": "two_factor_required",
+            "endpoint": "/verify-2fa",
+        })),
+    )
+        .into_response()
 }
 
 async fn issue_two_factor_redirect(state: &AppState) -> Response {

--- a/nodelite-server/src/lib_tests.rs
+++ b/nodelite-server/src/lib_tests.rs
@@ -624,6 +624,130 @@ fn readonly_auth_route_accepts_valid_basic_auth() {
     });
 }
 
+/// 构造一个开启/关闭 2FA 的受保护认证测试状态,返回 (state, temp_dir)。
+async fn two_factor_auth_test_state(label: &str, enable_2fa: bool) -> (AppState, PathBuf) {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic enough")
+        .as_nanos();
+    let temp_dir = std::env::temp_dir().join(format!("nodelite-{label}-{unique}"));
+    std::fs::create_dir_all(&temp_dir).expect("temp dir should exist");
+    let mut config = test_server_config(
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080)),
+        "https://monitor.example.com".to_string(),
+        temp_dir.join("server.json"),
+        temp_dir.join("history.sqlite3"),
+        temp_dir.join("snapshot.json"),
+    );
+    config.readonly_auth = Some(nodelite_proto::ReadonlyAuthConfig {
+        username: "viewer".to_string(),
+        password: "secret".to_string(),
+        enable_2fa,
+        totp_secret: enable_2fa.then(|| "JBSWY3DPEHPK3PXP".to_string()),
+    });
+    let state = AppState::test_fixture(config.into(), Arc::new(temp_dir.join("server.toml")))
+        .await
+        .expect("state fixture should build");
+    (state, temp_dir)
+}
+
+#[test]
+fn websocket_upgrade_requiring_two_factor_returns_401_json_not_redirect() {
+    let runtime = Runtime::new().expect("runtime should build");
+    runtime.block_on(async {
+        let (state, temp_dir) = two_factor_auth_test_state("ws-2fa-401", true).await;
+        let app: Router = Router::new()
+            .route("/ws/browser", get(protected_ok))
+            .route_layer(from_fn_with_state(state.clone(), require_readonly_auth))
+            .with_state(state);
+        let response = app
+            .oneshot(ws_upgrade_request(
+                "/ws/browser",
+                Some(TEST_BASIC_AUTH_HEADER),
+                SocketAddr::V4(SocketAddrV4::new(
+                    "198.51.100.24".parse().expect("ip"),
+                    51234,
+                )),
+            ))
+            .await
+            .expect("response should be produced");
+
+        // 浏览器 WS 握手无法跟随 302,因此必须是 401 + JSON,且不带 Location 头。
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(response.headers().get(header::LOCATION).is_none());
+        let body = to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .expect("body should read");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["ok"], serde_json::Value::Bool(false));
+        assert_eq!(json["message"], "two_factor_required");
+        assert_eq!(json["endpoint"], "/verify-2fa");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    });
+}
+
+#[test]
+fn http_request_requiring_two_factor_still_redirects() {
+    let runtime = Runtime::new().expect("runtime should build");
+    runtime.block_on(async {
+        let (state, temp_dir) = two_factor_auth_test_state("http-2fa-302", true).await;
+        let app: Router = Router::new()
+            .route("/api/overview", get(protected_ok))
+            .route_layer(from_fn_with_state(state.clone(), require_readonly_auth))
+            .with_state(state);
+        // 没有 Upgrade 头的普通 HTTP 请求:行为不变,仍是 302 → /verify-2fa。
+        let response = app
+            .oneshot(protected_request(
+                "GET",
+                "/api/overview",
+                Some(TEST_BASIC_AUTH_HEADER),
+                SocketAddr::V4(SocketAddrV4::new(
+                    "198.51.100.24".parse().expect("ip"),
+                    51234,
+                )),
+            ))
+            .await
+            .expect("response should be produced");
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::LOCATION)
+                .expect("location header"),
+            "/verify-2fa"
+        );
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    });
+}
+
+#[test]
+fn websocket_upgrade_without_two_factor_passes_through() {
+    let runtime = Runtime::new().expect("runtime should build");
+    runtime.block_on(async {
+        let (state, temp_dir) = two_factor_auth_test_state("ws-no-2fa-pass", false).await;
+        let app: Router = Router::new()
+            .route("/ws/browser", get(protected_ok))
+            .route_layer(from_fn_with_state(state.clone(), require_readonly_auth))
+            .with_state(state);
+        // 2FA 未开启时,带 Upgrade 头的请求应正常放行到 handler(不受 WS 检测影响)。
+        let response = app
+            .oneshot(ws_upgrade_request(
+                "/ws/browser",
+                Some(TEST_BASIC_AUTH_HEADER),
+                SocketAddr::V4(SocketAddrV4::new(
+                    "198.51.100.24".parse().expect("ip"),
+                    51234,
+                )),
+            ))
+            .await
+            .expect("response should be produced");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    });
+}
+
 #[test]
 fn readonly_auth_route_logs_missing_basic_auth_reason() {
     let runtime = Runtime::new().expect("runtime should build");
@@ -1468,6 +1592,25 @@ fn protected_request(
     peer_addr: SocketAddr,
 ) -> Request<Body> {
     let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(auth_header) = auth_header {
+        builder = builder.header(header::AUTHORIZATION, auth_header);
+    }
+    let mut request = builder.body(Body::empty()).expect("request should build");
+    request.extensions_mut().insert(ConnectInfo(peer_addr));
+    request
+}
+
+/// 构造一个带 `Upgrade: websocket` 头的 GET 请求,模拟浏览器 WebSocket 握手。
+fn ws_upgrade_request(
+    uri: &str,
+    auth_header: Option<&str>,
+    peer_addr: SocketAddr,
+) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header(header::CONNECTION, "Upgrade")
+        .header(header::UPGRADE, "websocket");
     if let Some(auth_header) = auth_header {
         builder = builder.header(header::AUTHORIZATION, auth_header);
     }

--- a/nodelite-server/src/startup.rs
+++ b/nodelite-server/src/startup.rs
@@ -46,7 +46,7 @@ use crate::history::HistoryStore;
 use crate::registry::NodeRegistry;
 use crate::snapshot::{load_snapshot, persist_snapshot, spawn_snapshot_persistor};
 use crate::state::SharedState;
-use crate::ws::ws_handler;
+use crate::ws::{ws_browser_handler, ws_handler};
 
 pub(crate) const PROTECTED_CONTENT_SECURITY_POLICY: &str = "default-src 'self'; img-src 'self' data:; \
      connect-src 'self' https://raw.githubusercontent.com https://api.github.com; font-src 'self'; \
@@ -161,6 +161,7 @@ async fn initialize_server_runtime(
         registry,
         shared,
         ws_admission: WsAdmissionController::new(&config.ws),
+        browser_ws_admission: WsAdmissionController::new(&config.ws),
         readonly_auth: Arc::new(RwLock::new(readonly_route_auth)),
         alerting: Arc::new(RwLock::new(config.alerting.clone())),
         two_factor_sessions: TwoFactorSessions::new(),
@@ -319,6 +320,7 @@ pub(crate) fn build_router(state: AppState) -> Router {
         .route("/api/nodes/{node_id}/history", get(node_history))
         .route("/api/nodes/{node_id}/logs", get(node_logs))
         .route("/api/audit-log", get(audit_log))
+        .route("/ws/browser", get(ws_browser_handler))
         .route("/api/settings", get(settings))
         .route("/api/settings/alerts", get(alert_settings))
         .route("/api/settings/update/server/log", get(server_update_log))

--- a/nodelite-server/src/state.rs
+++ b/nodelite-server/src/state.rs
@@ -23,7 +23,7 @@ use chrono::Utc;
 use nodelite_proto::{
     NodeIdentity, NodeListItem, NodeSnapshot, NodeStatus, OverviewData, ServerConfig,
 };
-use tokio::sync::{Mutex, RwLock, oneshot};
+use tokio::sync::{Mutex, RwLock, broadcast, oneshot};
 
 use self::registry::Registry;
 pub(crate) use self::session_control::{
@@ -46,6 +46,16 @@ use crate::ServerReadiness;
 use crate::handlers::metrics_exporter::{
     ApiCacheMetrics, SqliteWalCheckpointMetrics, WsMessageMetrics,
 };
+
+/// 浏览器视图脏信号。节点视图发生任意变化(注册 / 快照 / 延迟 / 离线 / 批量过期)时
+/// 广播一次,促使每个浏览器 WebSocket 会话重算节点列表、与上次发送的快照做 diff,
+/// 再发出增量。无 payload:会话总是重新读取完整视图,不需要携带变化详情。
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BrowserViewDirty;
+
+/// 浏览器脏信号广播通道容量。200 节点 × 1Hz ≈ 200 信号/秒;某个会话若停顿超过
+/// 约 1.3 秒(256 / 200)就会 Lagged,届时会话回退到重发 InitialState 全量同步。
+const BROWSER_VIEW_DIRTY_CHANNEL_CAPACITY: usize = 256;
 
 /// 共享状态的对外句柄,可以低成本地克隆给每个异步任务。
 #[derive(Clone)]
@@ -77,6 +87,8 @@ pub struct SharedState {
     ws_messages_pong_total: Arc<AtomicU64>,
     ws_messages_refresh_token_request_total: Arc<AtomicU64>,
     session_control_queue_full_total: Arc<AtomicU64>,
+    /// 节点视图变化时向所有浏览器 WebSocket 会话广播脏信号。
+    browser_view_dirty_tx: broadcast::Sender<BrowserViewDirty>,
     #[cfg(test)]
     metrics_cache_builds: Arc<AtomicU64>,
 }
@@ -111,6 +123,7 @@ impl SharedState {
             ws_messages_pong_total: Arc::new(AtomicU64::new(0)),
             ws_messages_refresh_token_request_total: Arc::new(AtomicU64::new(0)),
             session_control_queue_full_total: Arc::new(AtomicU64::new(0)),
+            browser_view_dirty_tx: broadcast::channel(BROWSER_VIEW_DIRTY_CHANNEL_CAPACITY).0,
             #[cfg(test)]
             metrics_cache_builds: Arc::new(AtomicU64::new(0)),
         }
@@ -362,6 +375,23 @@ impl SharedState {
         registry.overview()
     }
 
+    /// 供浏览器 WebSocket 会话读取当前概览聚合(在准备发送 OverviewUpdate 时惰性调用)。
+    pub(crate) async fn overview_snapshot(&self) -> OverviewData {
+        self.overview_data().await
+    }
+
+    /// 订阅浏览器视图脏信号。每个浏览器会话持有一个 receiver,在信号到达后
+    /// 重算节点列表并发出增量。
+    pub(crate) fn subscribe_browser_updates(&self) -> broadcast::Receiver<BrowserViewDirty> {
+        self.browser_view_dirty_tx.subscribe()
+    }
+
+    /// 广播一次浏览器视图脏信号。没有订阅者(无浏览器连接)时 `send` 返回
+    /// `Err`,直接忽略即可。
+    fn notify_browser_view_dirty(&self) {
+        let _ = self.browser_view_dirty_tx.send(BrowserViewDirty);
+    }
+
     /// 启动时从磁盘快照恢复状态,所有节点都视为离线直至首次心跳到达。
     pub async fn restore_statuses(&self, statuses: Vec<NodeStatus>) {
         let mut registry = self.registry.write().await;
@@ -374,6 +404,7 @@ impl SharedState {
         self.overview_revision.fetch_add(1, Ordering::AcqRel);
         self.nodes_revision.fetch_add(1, Ordering::AcqRel);
         self.metrics_revision.fetch_add(1, Ordering::AcqRel);
+        self.notify_browser_view_dirty();
     }
 
     /// 单节点快照 / 延迟更新只让 nodes 视图立刻失效。
@@ -382,6 +413,7 @@ impl SharedState {
     /// 缓存连带打穿(见 issue #160)。
     fn bump_nodes_revision_only(&self) {
         self.nodes_revision.fetch_add(1, Ordering::AcqRel);
+        self.notify_browser_view_dirty();
     }
 
     fn json_slot_for(&self, kind: ApiBodyKind) -> &Arc<Mutex<JsonViewSlot>> {

--- a/nodelite-server/src/test_support.rs
+++ b/nodelite-server/src/test_support.rs
@@ -17,17 +17,18 @@ use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tower_http::trace::TraceLayer;
 
 use crate::handlers::{metrics, node_history, node_status, nodes, overview, require_readonly_auth};
 use crate::registry::{IssueNodeRequest, NodeRegistry, issue_node};
 use crate::set_protected_response_headers;
 use crate::state::{SessionRefreshReply, SharedState};
-use crate::ws::ws_handler;
+use crate::ws::{ws_browser_handler, ws_handler};
 use nodelite_proto::{
-    AuditConfig, DiskUsage, HelloMessage, HistoryPoint, LoadAverage, MemoryUsage, NetworkCounters,
-    NodeIdentity, NodeSnapshot, NodeStatus, NoticeLevel, OverviewData, ReadonlyAuthConfig,
-    RefreshTokenResponseMessage, ServerConfig, WireMessage, WsConfig,
+    AuditConfig, BrowserMessage, DiskUsage, HelloMessage, HistoryPoint, LoadAverage, MemoryUsage,
+    NetworkCounters, NodeIdentity, NodeSnapshot, NodeStatus, NoticeLevel, OverviewData,
+    ReadonlyAuthConfig, RefreshTokenResponseMessage, ServerConfig, WireMessage, WsConfig,
 };
 
 pub const TEST_BASIC_AUTH_HEADER: &str = "Basic dmlld2VyOnNlY3JldA==";
@@ -183,6 +184,7 @@ impl TestServer {
             .route("/api/nodes", get(nodes))
             .route("/api/nodes/{node_id}", get(node_status))
             .route("/api/nodes/{node_id}/history", get(node_history))
+            .route("/ws/browser", get(ws_browser_handler))
             .route_layer(from_fn(set_protected_response_headers))
             .route_layer(from_fn_with_state(state.clone(), require_readonly_auth));
         let app = Router::new()
@@ -519,6 +521,101 @@ impl TestAgent {
         })
         .await
         .context("timed out waiting for business message")?
+    }
+}
+
+/// 浏览器 WebSocket(`/ws/browser`)测试客户端。
+pub struct TestBrowserClient {
+    socket: TestSocket,
+}
+
+impl TestBrowserClient {
+    /// 带正确 Basic Auth 连接 `/ws/browser`。
+    pub async fn connect(server: &TestServer) -> Result<Self> {
+        let mut request = format!("ws://{}/ws/browser", server.addr)
+            .into_client_request()
+            .context("build browser ws request")?;
+        request.headers_mut().insert(
+            tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
+            tokio_tungstenite::tungstenite::http::HeaderValue::from_static(TEST_BASIC_AUTH_HEADER),
+        );
+        let (socket, _response) = connect_async(request)
+            .await
+            .context("connect browser ws client")?;
+        Ok(Self { socket })
+    }
+
+    /// 不带认证连接,期望握手被拒为 HTTP 401。
+    pub async fn expect_unauthorized(server: &TestServer) -> Result<()> {
+        let url = format!("ws://{}/ws/browser", server.addr);
+        match connect_async(url).await {
+            Err(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+                let status = response.status();
+                if status == tokio_tungstenite::tungstenite::http::StatusCode::UNAUTHORIZED {
+                    Ok(())
+                } else {
+                    bail!("expected 401 for unauthenticated browser ws, got {status}")
+                }
+            }
+            Ok(_) => bail!("expected unauthenticated browser ws connect to be rejected"),
+            Err(other) => bail!("expected http 401 error, got {other}"),
+        }
+    }
+
+    /// 接收下一条 `BrowserMessage`(忽略协议级 ping/pong / 二进制帧)。
+    pub async fn next_message(&mut self, timeout_duration: Duration) -> Result<BrowserMessage> {
+        timeout(timeout_duration, async {
+            loop {
+                match self.socket.next().await {
+                    Some(Ok(Message::Text(text))) => {
+                        return serde_json::from_str::<BrowserMessage>(&text)
+                            .context("decode browser message");
+                    }
+                    Some(Ok(Message::Close(frame))) => {
+                        bail!("browser ws closed before message: {frame:?}");
+                    }
+                    Some(Ok(_)) => {} // 忽略协议级 ping/pong/binary
+                    Some(Err(error)) => bail!("browser ws receive error: {error}"),
+                    None => bail!("browser ws stream ended"),
+                }
+            }
+        })
+        .await
+        .context("timed out waiting for browser message")?
+    }
+
+    /// 循环接收直到出现满足谓词的 `BrowserMessage`,跳过其它消息(如 OverviewUpdate)。
+    pub async fn next_matching<F>(
+        &mut self,
+        timeout_duration: Duration,
+        mut predicate: F,
+    ) -> Result<BrowserMessage>
+    where
+        F: FnMut(&BrowserMessage) -> bool,
+    {
+        timeout(timeout_duration, async {
+            loop {
+                let message = self.next_message(TEST_TIMEOUT).await?;
+                if predicate(&message) {
+                    return Ok(message);
+                }
+            }
+        })
+        .await
+        .context("timed out waiting for matching browser message")?
+    }
+
+    /// 发送应用层 `Ping`。
+    pub async fn send_ping(&mut self) -> Result<()> {
+        let payload = serde_json::to_string(&BrowserMessage::Ping).context("encode ping")?;
+        self.socket
+            .send(Message::Text(payload.into()))
+            .await
+            .context("send browser ping")
+    }
+
+    pub async fn close(mut self) -> Result<()> {
+        self.socket.close(None).await.context("close browser ws")
     }
 }
 

--- a/nodelite-server/src/ws.rs
+++ b/nodelite-server/src/ws.rs
@@ -10,10 +10,13 @@
 //! 这是 server 内部最大的一段状态机,把它放到独立模块,使 main.rs 只剩
 //! "组装路由 + 启动后台任务"的骨架。
 
+mod browser;
 mod handshake;
 mod protocol;
 mod refresh;
 mod session;
+
+pub use browser::ws_browser_handler;
 
 use std::net::{IpAddr, SocketAddr};
 

--- a/nodelite-server/src/ws/browser.rs
+++ b/nodelite-server/src/ws/browser.rs
@@ -1,0 +1,214 @@
+//! 浏览器 WebSocket 会话(`/ws/browser`)。
+//!
+//! 与 agent `/ws` 区分:浏览器通道是**只读监控推送**,认证由 `require_readonly_auth`
+//! 中间件在升级前完成(Basic Auth + 可选 2FA)。会话流程:
+//!   1. 准入:每 IP 并发上限(RAII permit,与 agent 连接各自计数);
+//!   2. 升级为 WebSocket;
+//!   3. 立即下发全量 `InitialState`;
+//!   4. 订阅 `SharedState` 脏信号,去抖(≤1/秒)后重算节点列表、与上次发送的
+//!      快照做 diff,发出 `NodeUpsert` / `NodeRemoved` 增量 + `OverviewUpdate`;
+//!   5. 处理客户端应用层 `Ping`(回 `Pong`);
+//!   6. 连接关闭时 RAII permit 自动归还配额、广播订阅自动退订。
+//!
+//! 增量(而非全量)是带宽收益的来源:单节点变化只发该节点一行。服务端用
+//! "重算 + diff" 推导出变化行 —— 既无需注册表暴露细粒度变更钩子,也天然覆盖
+//! 节点移除(diff 发现某 id 消失即发 `NodeRemoved`)。
+
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{ConnectInfo, State};
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use chrono::Utc;
+use futures::stream::SplitSink;
+use futures::{SinkExt, StreamExt};
+use nodelite_proto::{BrowserMessage, NodeListItem};
+use tokio::sync::broadcast;
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::warn;
+
+use crate::AppState;
+use crate::admission::{resolve_client_ip, ws_admission_error_response};
+use crate::state::SharedState;
+
+type BrowserSink = SplitSink<WebSocket, Message>;
+
+/// 浏览器视图增量去抖间隔:脏信号到达后最多每秒重算一次并发出增量。
+const BROWSER_PUSH_DEBOUNCE: Duration = Duration::from_secs(1);
+
+/// `/ws/browser` 入口。认证已由 `require_readonly_auth` 中间件完成;这里只做
+/// 并发准入(每 IP 上限)与协议升级。
+pub async fn ws_browser_handler(
+    State(state): State<AppState>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let config = state.shared.config();
+    let client_ip = resolve_client_ip(&config.trusted_proxies, peer_addr, &headers);
+    let permit = match state.browser_ws_admission.try_acquire(client_ip) {
+        Ok(permit) => permit,
+        Err(error) => return ws_admission_error_response(error),
+    };
+    let max_message_bytes = config.max_message_bytes;
+    ws.max_frame_size(max_message_bytes)
+        .max_message_size(max_message_bytes)
+        .on_upgrade(move |socket| async move {
+            // permit 持有到会话结束;drop 时自动把连接配额归还给该 IP。
+            let _permit = permit;
+            if let Err(error) = run_browser_session(state.shared.clone(), socket).await {
+                warn!(error = %error, "browser websocket session ended with error");
+            }
+        })
+        .into_response()
+}
+
+/// 单个浏览器会话主循环。
+async fn run_browser_session(shared: SharedState, socket: WebSocket) -> anyhow::Result<()> {
+    let (mut sender, mut receiver) = socket.split();
+    let mut updates = shared.subscribe_browser_updates();
+
+    // 1. 立即发送全量 InitialState,并记录"上次发送的快照"用于后续 diff。
+    let mut last_nodes = send_initial_state(&shared, &mut sender).await?;
+
+    // 2. 去抖计时器:脏信号只置 `dirty`,真正的重算 + 发送推迟到下一次 tick。
+    //    `interval` 首个 tick 立即触发,此时 dirty=false 是无害空转。
+    let mut debounce = interval(BROWSER_PUSH_DEBOUNCE);
+    debounce.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut dirty = false;
+
+    loop {
+        tokio::select! {
+            biased;
+            incoming = receiver.next() => {
+                match incoming {
+                    None | Some(Err(_)) => return Ok(()), // 客户端关闭或传输错误 → 结束会话
+                    Some(Ok(message)) => {
+                        if handle_client_message(&mut sender, message).await? {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+            recv = updates.recv() => {
+                match recv {
+                    Ok(_) => dirty = true,
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        // 落后丢信号:客户端状态可能不一致 → 重发全量 InitialState 强制重同步。
+                        last_nodes = send_initial_state(&shared, &mut sender).await?;
+                        dirty = false;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                }
+            }
+            _ = debounce.tick() => {
+                if dirty {
+                    dirty = false;
+                    push_incremental_updates(&shared, &mut sender, &mut last_nodes).await?;
+                }
+            }
+        }
+    }
+}
+
+/// 处理客户端发来的消息。返回 `true` 表示应结束会话。
+///
+/// 浏览器只会发应用层 `Ping`;其它文本消息一律忽略(协议向前兼容)。协议级
+/// Ping/Pong 帧由底层自动应答,这里收到也忽略。
+async fn handle_client_message(
+    sender: &mut BrowserSink,
+    message: Message,
+) -> anyhow::Result<bool> {
+    match message {
+        Message::Text(text) => {
+            if let Ok(BrowserMessage::Ping) = serde_json::from_str::<BrowserMessage>(&text) {
+                send_browser_message(sender, &BrowserMessage::Pong).await?;
+            }
+            Ok(false)
+        }
+        Message::Close(_) => Ok(true),
+        _ => Ok(false),
+    }
+}
+
+/// 发送全量 `InitialState`,返回按 `node_id` 索引的"已发送快照",供后续 diff。
+async fn send_initial_state(
+    shared: &SharedState,
+    sender: &mut BrowserSink,
+) -> anyhow::Result<HashMap<String, NodeListItem>> {
+    let nodes = shared.list_node_summaries().await;
+    let overview = shared.overview_snapshot().await;
+    let message = BrowserMessage::InitialState {
+        generated_at: Utc::now(),
+        overview,
+        nodes: nodes.clone(),
+    };
+    send_browser_message(sender, &message).await?;
+    Ok(index_by_node_id(nodes))
+}
+
+/// 重算当前节点列表,与上次发送的快照 diff,发出增量 + 概览更新。
+async fn push_incremental_updates(
+    shared: &SharedState,
+    sender: &mut BrowserSink,
+    last_nodes: &mut HashMap<String, NodeListItem>,
+) -> anyhow::Result<()> {
+    let current = shared.list_node_summaries().await;
+    let generated_at = Utc::now();
+
+    // 新增 / 变更的行 → NodeUpsert。
+    let mut seen: HashSet<String> = HashSet::with_capacity(current.len());
+    for node in &current {
+        seen.insert(node.identity.node_id.clone());
+        if last_nodes.get(&node.identity.node_id) != Some(node) {
+            send_browser_message(
+                sender,
+                &BrowserMessage::NodeUpsert {
+                    generated_at,
+                    node: node.clone(),
+                },
+            )
+            .await?;
+        }
+    }
+
+    // 上次有、这次没有的行 → NodeRemoved。
+    let removed: Vec<String> = last_nodes
+        .keys()
+        .filter(|id| !seen.contains(*id))
+        .cloned()
+        .collect();
+    for node_id in removed {
+        send_browser_message(sender, &BrowserMessage::NodeRemoved { generated_at, node_id })
+            .await?;
+    }
+
+    *last_nodes = index_by_node_id(current);
+
+    // 概览聚合每次脏 tick 重算一次(已被去抖到 ≤1/秒),惰性计算避免高频重算。
+    let overview = shared.overview_snapshot().await;
+    send_browser_message(sender, &BrowserMessage::OverviewUpdate { generated_at, overview }).await
+}
+
+fn index_by_node_id(nodes: Vec<NodeListItem>) -> HashMap<String, NodeListItem> {
+    nodes
+        .into_iter()
+        .map(|node| (node.identity.node_id.clone(), node))
+        .collect()
+}
+
+async fn send_browser_message(
+    sender: &mut BrowserSink,
+    message: &BrowserMessage,
+) -> anyhow::Result<()> {
+    let payload = serde_json::to_string(message)
+        .map_err(|error| anyhow!("failed to serialize browser message: {error}"))?;
+    sender
+        .send(Message::Text(payload.into()))
+        .await
+        .map_err(|error| anyhow!("failed to send browser message: {error}"))
+}

--- a/nodelite-server/src/ws/browser.rs
+++ b/nodelite-server/src/ws/browser.rs
@@ -119,10 +119,7 @@ async fn run_browser_session(shared: SharedState, socket: WebSocket) -> anyhow::
 ///
 /// 浏览器只会发应用层 `Ping`;其它文本消息一律忽略(协议向前兼容)。协议级
 /// Ping/Pong 帧由底层自动应答,这里收到也忽略。
-async fn handle_client_message(
-    sender: &mut BrowserSink,
-    message: Message,
-) -> anyhow::Result<bool> {
+async fn handle_client_message(sender: &mut BrowserSink, message: Message) -> anyhow::Result<bool> {
     match message {
         Message::Text(text) => {
             if let Ok(BrowserMessage::Ping) = serde_json::from_str::<BrowserMessage>(&text) {
@@ -183,15 +180,28 @@ async fn push_incremental_updates(
         .cloned()
         .collect();
     for node_id in removed {
-        send_browser_message(sender, &BrowserMessage::NodeRemoved { generated_at, node_id })
-            .await?;
+        send_browser_message(
+            sender,
+            &BrowserMessage::NodeRemoved {
+                generated_at,
+                node_id,
+            },
+        )
+        .await?;
     }
 
     *last_nodes = index_by_node_id(current);
 
     // 概览聚合每次脏 tick 重算一次(已被去抖到 ≤1/秒),惰性计算避免高频重算。
     let overview = shared.overview_snapshot().await;
-    send_browser_message(sender, &BrowserMessage::OverviewUpdate { generated_at, overview }).await
+    send_browser_message(
+        sender,
+        &BrowserMessage::OverviewUpdate {
+            generated_at,
+            overview,
+        },
+    )
+    .await
 }
 
 fn index_by_node_id(nodes: Vec<NodeListItem>) -> HashMap<String, NodeListItem> {

--- a/nodelite-server/tests/integration/browser_websocket.rs
+++ b/nodelite-server/tests/integration/browser_websocket.rs
@@ -1,0 +1,90 @@
+use super::*;
+
+use nodelite_proto::BrowserMessage;
+
+/// 未认证的浏览器 WebSocket 升级握手必须被拒为 HTTP 401。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn browser_ws_rejects_unauthenticated_connection() -> Result<()> {
+    let server = TestServer::start().await?;
+    TestBrowserClient::expect_unauthorized(&server).await?;
+    server.shutdown().await
+}
+
+/// 连接建立后,服务端立即下发一条全量 `InitialState`。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn browser_ws_sends_initial_state_on_connect() -> Result<()> {
+    let server = TestServer::start().await?;
+    let mut browser = TestBrowserClient::connect(&server).await?;
+
+    let message = browser.next_message(TEST_TIMEOUT).await?;
+    match message {
+        BrowserMessage::InitialState {
+            overview, nodes, ..
+        } => {
+            assert_eq!(overview.total_nodes, 0);
+            assert!(nodes.is_empty());
+        }
+        other => panic!("expected InitialState, got {other:?}"),
+    }
+
+    browser.close().await?;
+    server.shutdown().await
+}
+
+/// 浏览器连接后再有 agent 注册并上报,浏览器应收到该节点的增量 `NodeUpsert`。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn browser_ws_pushes_node_upsert_when_agent_registers() -> Result<()> {
+    let server = TestServer::start().await?;
+    // 先连浏览器,确保它的 InitialState 是空的,后续节点变化只能通过增量到达。
+    let mut browser = TestBrowserClient::connect(&server).await?;
+    let initial = browser.next_message(TEST_TIMEOUT).await?;
+    assert!(matches!(initial, BrowserMessage::InitialState { .. }));
+
+    // agent 注册 + 上报 → 触发 SharedState 脏信号。
+    let node = server
+        .issue_node("itest-browser-01", "Integration Browser 01")
+        .await?;
+    let mut agent = TestAgent::connect(&server, &node).await?;
+    agent.send_fake_metrics(1).await?;
+
+    // 浏览器应收到该节点的 NodeUpsert(跳过其间可能的 OverviewUpdate)。
+    let upsert = browser
+        .next_matching(TEST_TIMEOUT, |message| {
+            matches!(
+                message,
+                BrowserMessage::NodeUpsert { node, .. } if node.identity.node_id == "itest-browser-01"
+            )
+        })
+        .await?;
+    match upsert {
+        BrowserMessage::NodeUpsert { node, .. } => {
+            assert_eq!(node.identity.node_id, "itest-browser-01");
+            assert!(node.online);
+        }
+        other => panic!("expected NodeUpsert, got {other:?}"),
+    }
+
+    agent.disconnect().await?;
+    browser.close().await?;
+    server.shutdown().await
+}
+
+/// 客户端发送应用层 `Ping`,服务端必须回 `Pong`。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn browser_ws_replies_pong_to_ping() -> Result<()> {
+    let server = TestServer::start().await?;
+    let mut browser = TestBrowserClient::connect(&server).await?;
+    let initial = browser.next_message(TEST_TIMEOUT).await?;
+    assert!(matches!(initial, BrowserMessage::InitialState { .. }));
+
+    browser.send_ping().await?;
+    let pong = browser
+        .next_matching(TEST_TIMEOUT, |message| {
+            matches!(message, BrowserMessage::Pong)
+        })
+        .await?;
+    assert!(matches!(pong, BrowserMessage::Pong));
+
+    browser.close().await?;
+    server.shutdown().await
+}

--- a/nodelite-server/tests/integration/mod.rs
+++ b/nodelite-server/tests/integration/mod.rs
@@ -1,6 +1,9 @@
-pub(crate) use crate::test_support::{LIVE_REFRESH_TIMEOUT, TEST_TIMEOUT, TestAgent, TestServer};
+pub(crate) use crate::test_support::{
+    LIVE_REFRESH_TIMEOUT, TEST_TIMEOUT, TestAgent, TestBrowserClient, TestServer,
+};
 pub(crate) use anyhow::Result;
 pub(crate) use futures::future::try_join_all;
+mod browser_websocket;
 mod concurrent_nodes;
 mod failure_recovery;
 mod metrics_collection;


### PR DESCRIPTION
## Summary

First PR of Stage 3.5 (real-time push updates). Adds the **server-side** browser WebSocket endpoint `/ws/browser` so the SPA dashboard can receive incremental push updates instead of polling. No client wiring yet — that's PR 3.5b/3.5c.

Two commits:

### 1. `fix(auth)` — WS-aware 2FA middleware
`require_readonly_auth` returned `302 → /verify-2fa` when 2FA is required. The browser `new WebSocket()` API can't follow a 302 during the upgrade handshake — it just fires `onerror` with no signal. Now, WebSocket upgrade requests (detected via the `Upgrade: websocket` header) get **401 + JSON** `{ok:false, message:"two_factor_required", endpoint:"/verify-2fa"}` instead. Plain HTTP requests are unaffected (still 302). This is the prerequisite for the endpoint.

### 2. `feat(ws)` — `/ws/browser` endpoint
- **Auth**: reuses `require_readonly_auth` (Basic Auth + optional 2FA) before upgrade; a dedicated per-IP admission counter keeps browser and agent quotas separate.
- **Protocol** (`nodelite-proto::BrowserMessage`): `InitialState` (full snapshot on connect/reconnect/lag), `NodeUpsert`/`NodeRemoved` (per-node increments — one node ticking sends one row, not the whole list), `OverviewUpdate` (small aggregate), `Ping`/`Pong` (app-level heartbeat). Every message carries `generated_at` for client-side ordering.
- **Change propagation**: `SharedState` gains a broadcast "view dirty" signal, published from the existing `bump_*_revision` sites. Each session debounces to ≤1/sec, recomputes the node list, and **diffs against its last-sent snapshot** to emit increments — no registry changes, and removal falls out of the diff. On broadcast `Lagged`, the session re-sends `InitialState` to resync.

## Test plan

- [x] `BrowserMessage` serialization round-trip (proto)
- [x] Middleware unit tests: WS upgrade + 2FA → 401 JSON; plain HTTP + 2FA → 302; WS + no 2FA → pass-through
- [x] Integration: unauthenticated connect → 401; `InitialState` on connect; `NodeUpsert` when an agent registers; `Ping` → `Pong`
- [x] `cargo test --workspace` green (18 agent + 50 proto + 252 server)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Out of scope (later in Stage 3.5)
- Client `WsClient` singleton + store incremental merging → PR 3.5b
- Replacing `DashboardView` polling with WS subscriptions → PR 3.5c