### PR TITLE
Agent tests fix

### DIFF
--- a/nodelite-agent/Cargo.toml
+++ b/nodelite-agent/Cargo.toml
@@ -6,6 +6,14 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 
+[lib]
+name = "nodelite_agent"
+path = "src/lib.rs"
+
+[[bin]]
+name = "nodelite-agent"
+path = "src/main.rs"
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/nodelite-agent/Cargo.toml
+++ b/nodelite-agent/Cargo.toml
@@ -30,3 +30,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 nodelite-proto = { path = "../nodelite-proto" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/nodelite-agent/src/collector_linux.rs
+++ b/nodelite-agent/src/collector_linux.rs
@@ -21,28 +21,45 @@ use super::shared::{
 
 /// 采集器状态:为了计算 CPU/网络的"差分速率",需要保留上一次的采样值。
 pub struct HostCollector {
+    sys_root: std::path::PathBuf,
     previous_cpu: Option<CpuSample>,
     previous_network: Option<NetworkSample>,
 }
 
 pub fn new_collector() -> HostCollector {
     HostCollector {
+        sys_root: std::path::PathBuf::from("/"),
         previous_cpu: None,
         previous_network: None,
     }
 }
 
 impl HostCollector {
+    #[cfg(test)]
+    pub fn new_with_root(sys_root: std::path::PathBuf) -> Self {
+        Self {
+            sys_root,
+            previous_cpu: None,
+            previous_network: None,
+        }
+    }
+
     /// 组装节点身份。`agent_version` 来源于编译期注入,运行期固定不变。
     pub fn collect_identity(
         &self,
         config: &AgentConfig,
         agent_version: &str,
     ) -> Result<NodeIdentity> {
-        let uptime_secs = read_uptime("/proc/uptime")?;
+        let uptime_path = self.sys_root.join("proc/uptime");
+        let uptime_secs = read_uptime(&uptime_path)?;
         // 由当前时刻反推启动时间,在 i64 转换溢出时退化为 i64::MAX 防止 panic。
         let boot_time =
             Utc::now() - Duration::seconds(i64::try_from(uptime_secs).unwrap_or(i64::MAX));
+
+        let hostname_path = self.sys_root.join("proc/sys/kernel/hostname");
+        let os_release_path = self.sys_root.join("etc/os-release");
+        let osrelease_path = self.sys_root.join("proc/sys/kernel/osrelease");
+        let cpuinfo_path = self.sys_root.join("proc/cpuinfo");
 
         Ok(NodeIdentity {
             node_id: config.node_id.clone(),
@@ -50,11 +67,11 @@ impl HostCollector {
             hostname: config
                 .hostname_override
                 .clone()
-                .unwrap_or(read_hostname("/proc/sys/kernel/hostname")?),
-            os: read_os_name("/etc/os-release").unwrap_or_else(|_| "linux".to_string()),
-            kernel_version: read_trimmed("/proc/sys/kernel/osrelease").ok(),
-            cpu_model: read_cpu_model("/proc/cpuinfo").ok(),
-            cpu_cores: count_cpu_cores("/proc/cpuinfo").unwrap_or(1),
+                .unwrap_or(read_hostname(&hostname_path)?),
+            os: read_os_name(&os_release_path).unwrap_or_else(|_| "linux".to_string()),
+            kernel_version: read_trimmed(&osrelease_path).ok(),
+            cpu_model: read_cpu_model(&cpuinfo_path).ok(),
+            cpu_cores: count_cpu_cores(&cpuinfo_path).unwrap_or(1),
             agent_version: agent_version.to_string(),
             boot_time: Some(boot_time),
             tags: config.tags.clone(),
@@ -66,15 +83,17 @@ impl HostCollector {
     /// 首次调用时由于没有"上一次"的数据,`cpu_usage_percent` 与网络速率
     /// 都会返回 `None`,这是符合预期的初始状态。
     pub fn collect_snapshot(&mut self) -> Result<NodeSnapshot> {
+        let stat_path = self.sys_root.join("proc/stat");
         let cpu_sample =
-            parse_cpu_sample(&fs::read_to_string("/proc/stat").context("read /proc/stat")?)?;
+            parse_cpu_sample(&fs::read_to_string(&stat_path).context("read /proc/stat")?)?;
         let cpu_usage_percent = self
             .previous_cpu
             .map(|previous| compute_cpu_usage(previous, cpu_sample));
         self.previous_cpu = Some(cpu_sample);
 
+        let dev_path = self.sys_root.join("proc/net/dev");
         let network_totals = parse_network_totals(
-            &fs::read_to_string("/proc/net/dev").context("read /proc/net/dev")?,
+            &fs::read_to_string(&dev_path).context("read /proc/net/dev")?,
         )?;
         let observed_at = Instant::now();
         let (rx_bytes_per_sec, tx_bytes_per_sec) = if let Some(previous) = self.previous_network {
@@ -88,14 +107,18 @@ impl HostCollector {
             tx_bytes: network_totals.tx_bytes,
         });
 
+        let loadavg_path = self.sys_root.join("proc/loadavg");
         let load = parse_load_average(
-            &fs::read_to_string("/proc/loadavg").context("read /proc/loadavg")?,
+            &fs::read_to_string(&loadavg_path).context("read /proc/loadavg")?,
         )?;
+        let meminfo_path = self.sys_root.join("proc/meminfo");
         let memory = parse_memory_usage(
-            &fs::read_to_string("/proc/meminfo").context("read /proc/meminfo")?,
+            &fs::read_to_string(&meminfo_path).context("read /proc/meminfo")?,
         )?;
-        let uptime_secs = read_uptime("/proc/uptime")?;
-        let disks = collect_disks("/proc/mounts")?;
+        let uptime_path = self.sys_root.join("proc/uptime");
+        let uptime_secs = read_uptime(&uptime_path)?;
+        let mounts_path = self.sys_root.join("proc/mounts");
+        let disks = collect_disks(&mounts_path)?;
 
         Ok(NodeSnapshot {
             collected_at: Utc::now(),
@@ -115,20 +138,20 @@ impl HostCollector {
 }
 
 /// 读取文件文本并去除首尾空白。
-fn read_trimmed(path: &str) -> Result<String> {
+fn read_trimmed(path: &std::path::Path) -> Result<String> {
     Ok(fs::read_to_string(path)
-        .with_context(|| format!("read {path}"))?
+        .with_context(|| format!("read {}", path.display()))?
         .trim()
         .to_string())
 }
 
-fn read_hostname(path: &str) -> Result<String> {
+fn read_hostname(path: &std::path::Path) -> Result<String> {
     read_trimmed(path)
 }
 
 /// 解析 `/etc/os-release`,优先返回 `PRETTY_NAME`,缺失时退化到 `NAME`。
-fn read_os_name(path: &str) -> Result<String> {
-    let content = fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+fn read_os_name(path: &std::path::Path) -> Result<String> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     for line in content.lines() {
         if let Some(value) = line.strip_prefix("PRETTY_NAME=") {
             return Ok(strip_quotes(value));
@@ -137,7 +160,7 @@ fn read_os_name(path: &str) -> Result<String> {
             return Ok(strip_quotes(value));
         }
     }
-    Err(anyhow!("NAME not found in {path}"))
+    Err(anyhow!("NAME not found in {}", path.display()))
 }
 
 fn strip_quotes(value: &str) -> String {
@@ -145,19 +168,19 @@ fn strip_quotes(value: &str) -> String {
 }
 
 /// 从 `/proc/cpuinfo` 中提取第一处 `model name`。
-fn read_cpu_model(path: &str) -> Result<String> {
-    let content = fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+fn read_cpu_model(path: &std::path::Path) -> Result<String> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     for line in content.lines() {
         if let Some(value) = line.strip_prefix("model name\t: ") {
             return Ok(value.trim().to_string());
         }
     }
-    Err(anyhow!("model name not found in {path}"))
+    Err(anyhow!("model name not found in {}", path.display()))
 }
 
 /// 通过统计 `processor` 行的数量得到逻辑核心数;至少返回 1。
-fn count_cpu_cores(path: &str) -> Result<u32> {
-    let content = fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+fn count_cpu_cores(path: &std::path::Path) -> Result<u32> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     let count = content
         .lines()
         .filter(|line| line.starts_with("processor\t:"))
@@ -166,19 +189,19 @@ fn count_cpu_cores(path: &str) -> Result<u32> {
 }
 
 /// 读取 `/proc/uptime` 的整数秒部分。
-fn read_uptime(path: &str) -> Result<u64> {
-    let content = fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+fn read_uptime(path: &std::path::Path) -> Result<u64> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     let raw = content
         .split_whitespace()
         .next()
-        .ok_or_else(|| anyhow!("missing uptime field in {path}"))?;
+        .ok_or_else(|| anyhow!("missing uptime field in {}", path.display()))?;
     let seconds = raw
         .split('.')
         .next()
-        .ok_or_else(|| anyhow!("invalid uptime field in {path}"))?;
+        .ok_or_else(|| anyhow!("invalid uptime field in {}", path.display()))?;
     seconds
         .parse::<u64>()
-        .with_context(|| format!("invalid uptime value in {path}"))
+        .with_context(|| format!("invalid uptime value in {}", path.display()))
 }
 
 /// 解析 `/proc/stat` 中的 `cpu ` 聚合行。
@@ -347,8 +370,8 @@ fn parse_network_line_counters(counters: &str, iface: &str) -> Result<(u64, u64)
 
 /// 遍历 `/proc/mounts` 并通过 `statvfs` 获取各挂载点的容量信息。
 /// 同一挂载点重复出现时只保留第一条;特殊虚拟文件系统会被忽略。
-fn collect_disks(mounts_path: &str) -> Result<Vec<DiskUsage>> {
-    let content = fs::read_to_string(mounts_path).with_context(|| format!("read {mounts_path}"))?;
+fn collect_disks(mounts_path: &std::path::Path) -> Result<Vec<DiskUsage>> {
+    let content = fs::read_to_string(mounts_path).with_context(|| format!("read {}", mounts_path.display()))?;
     let mut seen_mounts = HashSet::new();
     let mut seen_devices = HashSet::new();
     let mut disks = Vec::new();
@@ -522,5 +545,87 @@ mod tests {
         let (rx_rate, tx_rate) = compute_network_rates(previous, Instant::now(), totals);
         assert!(rx_rate.unwrap() > 40.0);
         assert!(tx_rate.unwrap() > 20.0);
+    }
+
+    #[test]
+    fn test_host_collector_with_mock_files() {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_dir = std::env::temp_dir().join(format!("nodelite-collector-test-{timestamp}"));
+        std::fs::create_dir_all(temp_dir.join("proc/sys/kernel")).unwrap();
+        std::fs::create_dir_all(temp_dir.join("proc/net")).unwrap();
+        std::fs::create_dir_all(temp_dir.join("etc")).unwrap();
+
+        // Write mock files
+        std::fs::write(temp_dir.join("proc/uptime"), "3600.50 12345.67\n").unwrap();
+        std::fs::write(temp_dir.join("proc/sys/kernel/hostname"), "mock-host\n").unwrap();
+        std::fs::write(temp_dir.join("etc/os-release"), "PRETTY_NAME=\"Mock Linux OS\"\n").unwrap();
+        std::fs::write(temp_dir.join("proc/sys/kernel/osrelease"), "6.8.0-mock\n").unwrap();
+        std::fs::write(
+            temp_dir.join("proc/cpuinfo"),
+            "processor\t: 0\nmodel name\t: Mock CPU @ 3.0GHz\n\nprocessor\t: 1\nmodel name\t: Mock CPU @ 3.0GHz\n",
+        ).unwrap();
+        std::fs::write(temp_dir.join("proc/stat"), "cpu  100 0 50 400 10 0 0 0 0 0\ncpu0 50 0 25 200 5 0 0 0 0 0\n").unwrap();
+        std::fs::write(
+            temp_dir.join("proc/net/dev"),
+            "Inter-|   Receive                                                |  Transmit\n face |bytes packets errs drop fifo frame compressed multicast|bytes packets errs drop fifo colls carrier compressed\n eth0: 200 0 0 0 0 0 0 0 100 0 0 0 0 0 0 0\n",
+        ).unwrap();
+        std::fs::write(temp_dir.join("proc/loadavg"), "0.15 0.30 0.45 1/100 12345\n").unwrap();
+        std::fs::write(
+            temp_dir.join("proc/meminfo"),
+            "MemTotal:       2097152 kB\nMemFree:         524288 kB\nMemAvailable:   1048576 kB\nSwapTotal:      1048576 kB\nSwapFree:        524288 kB\n",
+        ).unwrap();
+        std::fs::write(
+            temp_dir.join("proc/mounts"),
+            "/dev/vda1 / ext4 rw,relatime 0 0\ntmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0\n",
+        ).unwrap();
+
+        let mut collector = super::HostCollector::new_with_root(temp_dir.clone());
+        let config = nodelite_proto::AgentConfig {
+            node_id: "test-node".to_string(),
+            node_label: "Test Node".to_string(),
+            server: "ws://127.0.0.1:8080/ws".to_string(),
+            token: "token".to_string(),
+            connect_timeout_secs: 5,
+            report_interval_secs: 5,
+            max_incoming_message_bytes: 65536,
+            insecure_transport_warn_interval_secs: 900,
+            tags: vec!["mock-tag".to_string()],
+            hostname_override: None,
+        };
+
+        // Check identity collection
+        let identity = collector.collect_identity(&config, "1.0.0").unwrap();
+        assert_eq!(identity.node_id, "test-node");
+        assert_eq!(identity.hostname, "mock-host");
+        assert_eq!(identity.os, "Mock Linux OS");
+        assert_eq!(identity.kernel_version, Some("6.8.0-mock".to_string()));
+        assert_eq!(identity.cpu_model, Some("Mock CPU @ 3.0GHz".to_string()));
+        assert_eq!(identity.cpu_cores, 2);
+        assert_eq!(identity.agent_version, "1.0.0");
+        assert_eq!(identity.tags, vec!["mock-tag".to_string()]);
+
+        // Check snapshot collection (first collection has None rates)
+        let snapshot1 = collector.collect_snapshot().unwrap();
+        assert_eq!(snapshot1.uptime_secs, 3600);
+        assert_eq!(snapshot1.load.one, 0.15);
+        assert_eq!(snapshot1.load.five, 0.30);
+        assert_eq!(snapshot1.load.fifteen, 0.45);
+        assert_eq!(snapshot1.memory.total_bytes, 2097152 * 1024);
+        assert_eq!(snapshot1.memory.available_bytes, 1048576 * 1024);
+        assert_eq!(snapshot1.memory.used_bytes, 1048576 * 1024);
+        assert_eq!(snapshot1.memory.swap_total_bytes, 1048576 * 1024);
+        assert_eq!(snapshot1.memory.swap_used_bytes, 524288 * 1024);
+
+        // Assert network totals
+        assert_eq!(snapshot1.network.total_rx_bytes, 200);
+        assert_eq!(snapshot1.network.total_tx_bytes, 100);
+        assert_eq!(snapshot1.network.rx_bytes_per_sec, None);
+        assert_eq!(snapshot1.network.tx_bytes_per_sec, None);
+
+        // Cleanup
+        std::fs::remove_dir_all(temp_dir).unwrap();
     }
 }

--- a/nodelite-agent/src/config_io.rs
+++ b/nodelite-agent/src/config_io.rs
@@ -7,7 +7,7 @@ use tokio::fs;
 use toml_edit::{DocumentMut, Item, Value};
 
 /// 从磁盘读取并解析 Agent 配置文件。
-pub(crate) async fn load_agent_config(path: &Path) -> Result<AgentConfig> {
+pub async fn load_agent_config(path: &Path) -> Result<AgentConfig> {
     let content = fs::read_to_string(path)
         .await
         .with_context(|| format!("failed to read config file {}", path.display()))?;
@@ -19,7 +19,7 @@ pub(crate) async fn load_agent_config(path: &Path) -> Result<AgentConfig> {
 ///
 /// 在 `spawn_blocking` 中以"读 → 改 → 写 → fsync → rename → fsync 父目录"
 /// 的方式持久化新 token,等同于 server registry 的写入级别。
-pub(crate) async fn update_token_in_config(config_path: &Path, new_token: &str) -> Result<()> {
+pub async fn update_token_in_config(config_path: &Path, new_token: &str) -> Result<()> {
     let config_path = config_path.to_path_buf();
     let new_token = new_token.to_string();
     tokio::task::spawn_blocking(move || persist_token_sync(&config_path, &new_token))

--- a/nodelite-agent/src/lib.rs
+++ b/nodelite-agent/src/lib.rs
@@ -1,0 +1,7 @@
+//! NodeLite Agent Library.
+
+pub mod collector;
+pub mod config_io;
+pub mod runtime;
+pub mod session;
+pub mod support;

--- a/nodelite-agent/src/main.rs
+++ b/nodelite-agent/src/main.rs
@@ -1,14 +1,8 @@
 //! NodeLite Agent 入口程序。
 
-mod collector;
-mod config_io;
-mod runtime;
-mod session;
-mod support;
-
 use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    runtime::run().await
+    nodelite_agent::runtime::run().await
 }

--- a/nodelite-agent/src/runtime.rs
+++ b/nodelite-agent/src/runtime.rs
@@ -25,7 +25,7 @@ struct Cli {
     sample_once: bool,
 }
 
-pub(crate) async fn run() -> Result<()> {
+pub async fn run() -> Result<()> {
     init_tracing();
     install_rustls_crypto_provider()?;
 

--- a/nodelite-agent/src/session.rs
+++ b/nodelite-agent/src/session.rs
@@ -22,7 +22,7 @@ use crate::config_io::update_token_in_config;
 use crate::support::shutdown_signal;
 
 /// Agent 本地最多暂存的待上报日志条数。超出后丢弃最旧项,避免断线期间内存无限增长。
-pub(crate) const MAX_PENDING_AGENT_LOGS: usize = 256;
+pub const MAX_PENDING_AGENT_LOGS: usize = 256;
 /// 单次推送到服务端的最大日志条数,控制消息体积。
 const MAX_AGENT_LOG_BATCH: usize = 32;
 /// 单条日志消息的最大字节数,避免异常长错误串撑爆 WebSocket 消息。
@@ -36,10 +36,10 @@ const TOKEN_EXPIRED_SHORT_RETRY_DELAYS: [Duration; 3] = [
 const TOKEN_EXPIRED_LONG_RECONNECT_DELAY: Duration = Duration::from_secs(3600);
 
 #[derive(Debug)]
-pub(crate) struct SessionError {
-    pub(crate) established_session: bool,
-    pub(crate) token_expired: bool,
-    pub(crate) source: anyhow::Error,
+pub struct SessionError {
+    pub established_session: bool,
+    pub token_expired: bool,
+    pub source: anyhow::Error,
 }
 
 type AgentWsSender = futures::stream::SplitSink<
@@ -48,12 +48,12 @@ type AgentWsSender = futures::stream::SplitSink<
 >;
 
 #[derive(Default)]
-pub(crate) struct AgentLogBuffer {
+pub struct AgentLogBuffer {
     entries: VecDeque<AgentLogEntry>,
 }
 
 impl AgentLogBuffer {
-    pub(crate) fn push(&mut self, level: NoticeLevel, message: impl Into<String>) {
+    pub fn push(&mut self, level: NoticeLevel, message: impl Into<String>) {
         let message = truncate_to_byte_boundary(&message.into(), MAX_AGENT_LOG_MESSAGE_BYTES)
             .trim()
             .to_string();
@@ -95,7 +95,7 @@ impl AgentLogBuffer {
 }
 
 /// 无限重连循环:无论会话以何种方式结束,都会按指数退避重试。
-pub(crate) async fn run_forever(
+pub async fn run_forever(
     mut config: AgentConfig,
     mut collector: HostCollector,
     identity: nodelite_proto::NodeIdentity,
@@ -174,7 +174,7 @@ pub(crate) async fn run_forever(
 }
 
 /// 与 Server 进行一次完整的 WebSocket 会话。
-pub(crate) async fn run_session(
+pub async fn run_session(
     config: &mut AgentConfig,
     collector: &mut HostCollector,
     identity: &nodelite_proto::NodeIdentity,

--- a/nodelite-agent/src/support.rs
+++ b/nodelite-agent/src/support.rs
@@ -2,19 +2,19 @@ use anyhow::{Result, anyhow};
 use tracing::warn;
 
 /// 安装 rustls 默认的密码套件提供者(ring 后端)。
-pub(crate) fn install_rustls_crypto_provider() -> Result<()> {
+pub fn install_rustls_crypto_provider() -> Result<()> {
     rustls::crypto::ring::default_provider()
         .install_default()
         .map_err(|_| anyhow!("failed to install rustls crypto provider"))
 }
 
 /// 获取 Agent 版本号:优先使用打包时通过环境变量注入的版本,缺失则回退到 Cargo 包版本。
-pub(crate) fn agent_build_version() -> &'static str {
+pub fn agent_build_version() -> &'static str {
     option_env!("NODELITE_BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
 }
 
 /// 初始化 `tracing` 日志:支持通过 `RUST_LOG` 调整级别。
-pub(crate) fn init_tracing() {
+pub fn init_tracing() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -29,7 +29,7 @@ pub(crate) fn init_tracing() {
 ///
 /// 仅在 unix 上监听 SIGTERM;其它平台只听 Ctrl-C。注册失败时退化为 `pending`,
 /// 保证另一条信号路径仍能触发 —— 不会因为某个 handler 安装失败而吞掉所有信号。
-pub(crate) async fn shutdown_signal() {
+pub async fn shutdown_signal() {
     let ctrl_c = async {
         if let Err(error) = tokio::signal::ctrl_c().await {
             warn!(error = ?error, "failed to listen for ctrl-c");

--- a/nodelite-agent/tests/config.rs
+++ b/nodelite-agent/tests/config.rs
@@ -1,0 +1,46 @@
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+use anyhow::Result;
+use nodelite_agent::config_io::{load_agent_config, update_token_in_config};
+
+#[tokio::test]
+async fn test_agent_config_load_and_token_update() -> Result<()> {
+    // Generate a unique temporary path for the configuration file
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let temp_dir = std::env::temp_dir().join(format!("nodelite-agent-test-{timestamp}"));
+    fs::create_dir_all(&temp_dir)?;
+    let config_path = temp_dir.join("agent.toml");
+
+    let initial_toml = r#"[agent]
+node_id = "test-node-01"
+node_label = "Test Node 01"
+server = "ws://127.0.0.1:8080/ws"
+token = "initial-secret-token"
+report_interval_secs = 5
+"#;
+
+    fs::write(&config_path, initial_toml)?;
+
+    // 1. Load config and verify fields
+    let config = load_agent_config(&config_path).await?;
+    assert_eq!(config.node_id, "test-node-01");
+    assert_eq!(config.node_label, "Test Node 01");
+    assert_eq!(config.server, "ws://127.0.0.1:8080/ws");
+    assert_eq!(config.token, "initial-secret-token");
+    assert_eq!(config.report_interval_secs, 5);
+
+    // 2. Update token in the config file
+    update_token_in_config(&config_path, "refreshed-secret-token").await?;
+
+    // 3. Reload config and verify token was updated
+    let updated_config = load_agent_config(&config_path).await?;
+    assert_eq!(updated_config.token, "refreshed-secret-token");
+    assert_eq!(updated_config.node_id, "test-node-01"); // Other fields remain unchanged
+
+    // Clean up temp directory
+    let _ = fs::remove_dir_all(&temp_dir);
+    Ok(())
+}

--- a/nodelite-agent/tests/config.rs
+++ b/nodelite-agent/tests/config.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
+
 use anyhow::Result;
 use nodelite_agent::config_io::{load_agent_config, update_token_in_config};
 

--- a/nodelite-agent/tests/reconnect.rs
+++ b/nodelite-agent/tests/reconnect.rs
@@ -1,0 +1,102 @@
+use std::fs;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use anyhow::Result;
+use nodelite_agent::collector::new_collector;
+use nodelite_agent::session::{AgentLogBuffer, run_forever};
+use nodelite_proto::{AgentConfig, NodeIdentity};
+use tokio::net::TcpListener;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_agent_reconnect_backoff_with_mock_time() -> Result<()> {
+    // 1. Pause time so we can precisely control the clock
+    tokio::time::pause();
+
+    // 2. Set up local TcpListener to receive agent connection attempts
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let local_addr = listener.local_addr()?;
+
+    // Create a temporary configuration file
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let temp_dir = std::env::temp_dir().join(format!("nodelite-agent-reconnect-test-{timestamp}"));
+    fs::create_dir_all(&temp_dir)?;
+    let config_path = temp_dir.join("agent.toml");
+
+    let config = AgentConfig {
+        node_id: "reconnect-node-01".to_string(),
+        node_label: "Reconnect Node 01".to_string(),
+        server: format!("ws://{local_addr}/ws"),
+        token: "reconnect-token".to_string(),
+        connect_timeout_secs: 2,
+        report_interval_secs: 5,
+        max_incoming_message_bytes: 65536,
+        insecure_transport_warn_interval_secs: 900,
+        tags: vec![],
+        hostname_override: None,
+    };
+
+    let collector = new_collector();
+    let identity = NodeIdentity {
+        node_id: config.node_id.clone(),
+        node_label: config.node_label.clone(),
+        hostname: "localhost".to_string(),
+        os: "test".to_string(),
+        kernel_version: None,
+        cpu_model: None,
+        cpu_cores: 1,
+        agent_version: "0.1.0-test".to_string(),
+        boot_time: None,
+        tags: vec![],
+    };
+
+    let log_buffer = AgentLogBuffer::default();
+
+    // 3. Spawn the run_forever loop in a separate task
+    let config_clone = config.clone();
+    let identity_clone = identity.clone();
+    let config_path_clone = config_path.clone();
+    let agent_task = tokio::spawn(async move {
+        let _ = run_forever(
+            config_clone,
+            collector,
+            identity_clone,
+            config_path_clone,
+            log_buffer,
+        )
+        .await;
+    });
+
+    // 4. Accept first connection
+    let (stream1, _) = tokio::select! {
+        res = listener.accept() => res?,
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            panic!("timed out waiting for first connection");
+        }
+    };
+    // Close the connection immediately to trigger reconnect logic
+    drop(stream1);
+
+    // 5. Sleep briefly (in virtual time) to let the failure register
+    // The backoff delay for the first retry (attempt 0) is 1s to 5s.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Advance virtual time by 6 seconds to ensure the backoff timer has fired
+    tokio::time::advance(Duration::from_secs(6)).await;
+
+    // 6. Verify that a second connection attempt is made
+    let (stream2, _) = tokio::select! {
+        res = listener.accept() => res?,
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            panic!("timed out waiting for second connection");
+        }
+    };
+    drop(stream2);
+
+    // Clean up
+    agent_task.abort();
+    let _ = fs::remove_dir_all(&temp_dir);
+
+    Ok(())
+}

--- a/nodelite-agent/tests/reconnect.rs
+++ b/nodelite-agent/tests/reconnect.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 use anyhow::Result;
 use nodelite_agent::collector::new_collector;
 use nodelite_agent::session::{AgentLogBuffer, run_forever};

--- a/nodelite-agent/tests/token_refresh.rs
+++ b/nodelite-agent/tests/token_refresh.rs
@@ -1,0 +1,152 @@
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use anyhow::{Context, Result, anyhow};
+use futures::{SinkExt, StreamExt};
+use nodelite_agent::collector::new_collector;
+use nodelite_agent::session::{AgentLogBuffer, run_session};
+use nodelite_proto::{
+    AgentConfig, HelloMessage, NoticeLevel, RefreshTokenResponseMessage, ServerNoticeMessage,
+    WireMessage,
+};
+use tokio::net::TcpListener;
+use tokio_tungstenite::accept_async;
+use tokio_tungstenite::tungstenite::Message;
+
+// A simple mock WebSocket server that completes the handshake and issues a token refresh
+async fn run_mock_server(listener: TcpListener, new_token: String) -> Result<()> {
+    let (stream, _) = listener.accept().await?;
+    let mut ws_stream = accept_async(stream)
+        .await
+        .context("Failed to accept websocket connection")?;
+
+    // 1. Await Hello message from the agent
+    let first_msg = ws_stream
+        .next()
+        .await
+        .ok_or_else(|| anyhow!("Connection closed before Hello"))??;
+
+    let text = match first_msg {
+        Message::Text(t) => t,
+        _ => return Err(anyhow!("Expected text frame, got {:?}", first_msg)),
+    };
+
+    let hello_msg: WireMessage = serde_json::from_str(&text)?;
+    let initial_token = match hello_msg {
+        WireMessage::Hello(HelloMessage { token, .. }) => token,
+        _ => return Err(anyhow!("Expected Hello message, got {:?}", hello_msg)),
+    };
+    assert_eq!(initial_token, "initial-token");
+
+    // 2. Send notice that authentication succeeded
+    let auth_notice = WireMessage::ServerNotice(ServerNoticeMessage {
+        level: NoticeLevel::Info,
+        message: "authenticated".to_string(),
+    });
+    ws_stream
+        .send(Message::Text(serde_json::to_string(&auth_notice)?.into()))
+        .await?;
+
+    // 3. Send RefreshTokenResponse
+    let refresh_response = WireMessage::RefreshTokenResponse(RefreshTokenResponseMessage {
+        new_token,
+        expires_at: "2026-06-02T00:00:00Z".to_string(),
+    });
+    ws_stream
+        .send(Message::Text(serde_json::to_string(&refresh_response)?.into()))
+        .await?;
+
+    // 4. Close the websocket
+    ws_stream.close(None).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_agent_token_refresh_lifecycle() -> Result<()> {
+    // Start local TcpListener
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let local_addr = listener.local_addr()?;
+
+    // Create a temporary configuration file
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let temp_dir = std::env::temp_dir().join(format!("nodelite-agent-refresh-test-{timestamp}"));
+    fs::create_dir_all(&temp_dir)?;
+    let config_path = temp_dir.join("agent.toml");
+
+    let initial_toml = format!(
+        r#"[agent]
+node_id = "test-node-refresh"
+node_label = "Test Node Refresh"
+server = "ws://{local_addr}/ws"
+token = "initial-token"
+report_interval_secs = 5
+"#
+    );
+    fs::write(&config_path, &initial_toml)?;
+
+    let mut config = AgentConfig {
+        node_id: "test-node-refresh".to_string(),
+        node_label: "Test Node Refresh".to_string(),
+        server: format!("ws://{local_addr}/ws"),
+        token: "initial-token".to_string(),
+        connect_timeout_secs: 5,
+        report_interval_secs: 5,
+        max_incoming_message_bytes: 65536,
+        insecure_transport_warn_interval_secs: 900,
+        tags: vec![],
+        hostname_override: None,
+    };
+
+    let expected_new_token = "refreshed-rotated-token-12345".to_string();
+
+    // Spawn mock server in the background
+    let server_token = expected_new_token.clone();
+    let server_task = tokio::spawn(async move {
+        let _ = run_mock_server(listener, server_token).await;
+    });
+
+    let mut collector = new_collector();
+    let identity = nodelite_proto::NodeIdentity {
+        node_id: config.node_id.clone(),
+        node_label: config.node_label.clone(),
+        hostname: "localhost".to_string(),
+        os: "test".to_string(),
+        kernel_version: None,
+        cpu_model: None,
+        cpu_cores: 1,
+        agent_version: "0.1.0-test".to_string(),
+        boot_time: None,
+        tags: vec![],
+    };
+
+    let mut log_buffer = AgentLogBuffer::default();
+
+    // Run a single agent session - it should connect, authenticate, get token, persist it, and exit when server closes socket.
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        run_session(&mut config, &mut collector, &identity, &config_path, &mut log_buffer),
+    )
+    .await;
+
+    // Check that run_session completed and returned the expected connection closure error
+    let session_res = result.context("Session timed out")?;
+    assert!(session_res.is_err());
+    let session_err = session_res.unwrap_err();
+    assert!(session_err.established_session);
+
+    // Verify token was updated in config file
+    let updated_toml = fs::read_to_string(&config_path)?;
+    assert!(updated_toml.contains("token = \"refreshed-rotated-token-12345\""));
+
+    // Verify token was updated in memory config
+    assert_eq!(config.token, "refreshed-rotated-token-12345");
+
+    // Cleanup
+    let _ = server_task.await;
+    let _ = fs::remove_dir_all(&temp_dir);
+
+    Ok(())
+}

--- a/nodelite-agent/tests/token_refresh.rs
+++ b/nodelite-agent/tests/token_refresh.rs
@@ -1,7 +1,8 @@
 use std::fs;
 use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use anyhow::{Context, Result, anyhow};
+
+use anyhow::{anyhow, Context, Result};
 use futures::{SinkExt, StreamExt};
 use nodelite_agent::collector::new_collector;
 use nodelite_agent::session::{AgentLogBuffer, run_session};
@@ -43,17 +44,17 @@ async fn run_mock_server(listener: TcpListener, new_token: String) -> Result<()>
         level: NoticeLevel::Info,
         message: "authenticated".to_string(),
     });
-    ws_stream
-        .send(Message::Text(serde_json::to_string(&auth_notice)?.into()))
-        .await?;
+    let auth_payload = serde_json::to_string(&auth_notice)?;
+    ws_stream.send(Message::Text(auth_payload.into())).await?;
 
     // 3. Send RefreshTokenResponse
     let refresh_response = WireMessage::RefreshTokenResponse(RefreshTokenResponseMessage {
         new_token,
         expires_at: "2026-06-02T00:00:00Z".to_string(),
     });
+    let refresh_payload = serde_json::to_string(&refresh_response)?;
     ws_stream
-        .send(Message::Text(serde_json::to_string(&refresh_response)?.into()))
+        .send(Message::Text(refresh_payload.into()))
         .await?;
 
     // 4. Close the websocket
@@ -127,7 +128,13 @@ report_interval_secs = 5
     // Run a single agent session - it should connect, authenticate, get token, persist it, and exit when server closes socket.
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        run_session(&mut config, &mut collector, &identity, &config_path, &mut log_buffer),
+        run_session(
+            &mut config,
+            &mut collector,
+            &identity,
+            &config_path,
+            &mut log_buffer,
+        ),
     )
     .await;
 

--- a/nodelite-server/Cargo.toml
+++ b/nodelite-server/Cargo.toml
@@ -46,5 +46,8 @@ proptest = "1.4"
 tokio-tungstenite.workspace = true
 tower = "0.5"
 
+[features]
+load_test = []
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }

--- a/nodelite-server/src/lib.rs
+++ b/nodelite-server/src/lib.rs
@@ -26,7 +26,7 @@ mod history;
 #[cfg(test)]
 #[path = "../tests/integration/mod.rs"]
 mod integration_tests;
-#[cfg(test)]
+#[cfg(any(test, feature = "load_test"))]
 mod load_test;
 mod qr;
 mod registry;

--- a/nodelite-server/src/load_test/mod.rs
+++ b/nodelite-server/src/load_test/mod.rs
@@ -93,7 +93,7 @@ struct AgentWorkload {
 type TestSocket = tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "manual load test; run with -- --ignored --nocapture"]
+#[cfg_attr(not(feature = "load_test"), ignore = "manual load test; run with -- --ignored --nocapture")]
 async fn load_test_scaling_scores() {
     if let Err(error) = scenarios::run_scaling_load_test().await {
         panic!("{error:#}");
@@ -101,7 +101,7 @@ async fn load_test_scaling_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "manual load test; run with -- --ignored --nocapture"]
+#[cfg_attr(not(feature = "load_test"), ignore = "manual load test; run with -- --ignored --nocapture")]
 async fn load_test_api_surface_scores() {
     if let Err(error) = scenarios::run_api_surface_load_test().await {
         panic!("{error:#}");
@@ -109,7 +109,7 @@ async fn load_test_api_surface_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "manual load test; run with -- --ignored --nocapture"]
+#[cfg_attr(not(feature = "load_test"), ignore = "manual load test; run with -- --ignored --nocapture")]
 async fn load_test_reconnect_storm_scores() {
     if let Err(error) = scenarios::run_reconnect_storm_load_test().await {
         panic!("{error:#}");
@@ -117,7 +117,7 @@ async fn load_test_reconnect_storm_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "manual large-fleet load test; run with -- --ignored --nocapture"]
+#[cfg_attr(not(feature = "load_test"), ignore = "manual large-fleet load test; run with -- --ignored --nocapture")]
 async fn load_test_large_fleet_scores() {
     if let Err(error) = large_scale::run_large_fleet_load_test().await {
         panic!("{error:#}");
@@ -125,7 +125,7 @@ async fn load_test_large_fleet_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "manual dashboard fanout load test; run with -- --ignored --nocapture"]
+#[cfg_attr(not(feature = "load_test"), ignore = "manual dashboard fanout load test; run with -- --ignored --nocapture")]
 async fn load_test_dashboard_fanout_scores() {
     if let Err(error) = large_scale::run_dashboard_fanout_load_test().await {
         panic!("{error:#}");
@@ -133,7 +133,7 @@ async fn load_test_dashboard_fanout_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "manual history pressure load test; run with -- --ignored --nocapture"]
+#[cfg_attr(not(feature = "load_test"), ignore = "manual history pressure load test; run with -- --ignored --nocapture")]
 async fn load_test_history_pressure_scores() {
     if let Err(error) = large_scale::run_history_pressure_load_test().await {
         panic!("{error:#}");
@@ -141,7 +141,7 @@ async fn load_test_history_pressure_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "manual large payload load test; run with -- --ignored --nocapture"]
+#[cfg_attr(not(feature = "load_test"), ignore = "manual large payload load test; run with -- --ignored --nocapture")]
 async fn load_test_payload_size_scores() {
     if let Err(error) = large_scale::run_payload_size_load_test().await {
         panic!("{error:#}");
@@ -149,7 +149,7 @@ async fn load_test_payload_size_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "manual concurrent read+write load test; run with -- --ignored --nocapture"]
+#[cfg_attr(not(feature = "load_test"), ignore = "manual concurrent read+write load test; run with -- --ignored --nocapture")]
 async fn load_test_concurrent_read_write_scores() {
     if let Err(error) = large_scale::run_concurrent_read_write_load_test().await {
         panic!("{error:#}");

--- a/nodelite-server/src/load_test/mod.rs
+++ b/nodelite-server/src/load_test/mod.rs
@@ -93,7 +93,10 @@ struct AgentWorkload {
 type TestSocket = tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[cfg_attr(not(feature = "load_test"), ignore = "manual load test; run with -- --ignored --nocapture")]
+#[cfg_attr(
+    not(feature = "load_test"),
+    ignore = "manual load test; run with -- --ignored --nocapture"
+)]
 async fn load_test_scaling_scores() {
     if let Err(error) = scenarios::run_scaling_load_test().await {
         panic!("{error:#}");
@@ -101,7 +104,10 @@ async fn load_test_scaling_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[cfg_attr(not(feature = "load_test"), ignore = "manual load test; run with -- --ignored --nocapture")]
+#[cfg_attr(
+    not(feature = "load_test"),
+    ignore = "manual load test; run with -- --ignored --nocapture"
+)]
 async fn load_test_api_surface_scores() {
     if let Err(error) = scenarios::run_api_surface_load_test().await {
         panic!("{error:#}");
@@ -109,7 +115,10 @@ async fn load_test_api_surface_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[cfg_attr(not(feature = "load_test"), ignore = "manual load test; run with -- --ignored --nocapture")]
+#[cfg_attr(
+    not(feature = "load_test"),
+    ignore = "manual load test; run with -- --ignored --nocapture"
+)]
 async fn load_test_reconnect_storm_scores() {
     if let Err(error) = scenarios::run_reconnect_storm_load_test().await {
         panic!("{error:#}");
@@ -117,7 +126,10 @@ async fn load_test_reconnect_storm_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[cfg_attr(not(feature = "load_test"), ignore = "manual large-fleet load test; run with -- --ignored --nocapture")]
+#[cfg_attr(
+    not(feature = "load_test"),
+    ignore = "manual large-fleet load test; run with -- --ignored --nocapture"
+)]
 async fn load_test_large_fleet_scores() {
     if let Err(error) = large_scale::run_large_fleet_load_test().await {
         panic!("{error:#}");
@@ -125,7 +137,10 @@ async fn load_test_large_fleet_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[cfg_attr(not(feature = "load_test"), ignore = "manual dashboard fanout load test; run with -- --ignored --nocapture")]
+#[cfg_attr(
+    not(feature = "load_test"),
+    ignore = "manual dashboard fanout load test; run with -- --ignored --nocapture"
+)]
 async fn load_test_dashboard_fanout_scores() {
     if let Err(error) = large_scale::run_dashboard_fanout_load_test().await {
         panic!("{error:#}");
@@ -133,7 +148,10 @@ async fn load_test_dashboard_fanout_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[cfg_attr(not(feature = "load_test"), ignore = "manual history pressure load test; run with -- --ignored --nocapture")]
+#[cfg_attr(
+    not(feature = "load_test"),
+    ignore = "manual history pressure load test; run with -- --ignored --nocapture"
+)]
 async fn load_test_history_pressure_scores() {
     if let Err(error) = large_scale::run_history_pressure_load_test().await {
         panic!("{error:#}");
@@ -141,7 +159,10 @@ async fn load_test_history_pressure_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[cfg_attr(not(feature = "load_test"), ignore = "manual large payload load test; run with -- --ignored --nocapture")]
+#[cfg_attr(
+    not(feature = "load_test"),
+    ignore = "manual large payload load test; run with -- --ignored --nocapture"
+)]
 async fn load_test_payload_size_scores() {
     if let Err(error) = large_scale::run_payload_size_load_test().await {
         panic!("{error:#}");
@@ -149,7 +170,10 @@ async fn load_test_payload_size_scores() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[cfg_attr(not(feature = "load_test"), ignore = "manual concurrent read+write load test; run with -- --ignored --nocapture")]
+#[cfg_attr(
+    not(feature = "load_test"),
+    ignore = "manual concurrent read+write load test; run with -- --ignored --nocapture"
+)]
 async fn load_test_concurrent_read_write_scores() {
     if let Err(error) = large_scale::run_concurrent_read_write_load_test().await {
         panic!("{error:#}");

--- a/nodelite-server/tests/integration/e2e.rs
+++ b/nodelite-server/tests/integration/e2e.rs
@@ -1,0 +1,98 @@
+use super::*;
+use std::fs;
+use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_e2e_agent_server_handshake() -> Result<()> {
+    // 1. Locate the nodelite-agent binary target
+    let mut agent_bin = std::env::current_exe()?;
+    agent_bin.pop(); // pop executable name
+    if agent_bin.file_name().and_then(|s| s.to_str()) == Some("deps") {
+        agent_bin.pop(); // pop "deps"
+    }
+    agent_bin.push("nodelite-agent");
+    #[cfg(windows)]
+    agent_bin.set_extension("exe");
+
+    assert!(agent_bin.exists(), "nodelite-agent binary not found at {}", agent_bin.display());
+
+    // 2. Start the TestServer
+    let server = TestServer::start().await?;
+    let node = server.issue_node("e2e-agent-01", "E2E Agent 01").await?;
+
+    // 3. Create a temporary config file for the agent
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let temp_dir = std::env::temp_dir().join(format!("nodelite-e2e-test-{timestamp}"));
+    fs::create_dir_all(&temp_dir)?;
+    let config_path = temp_dir.join("agent.toml");
+
+    let agent_config_toml = format!(
+        r#"[agent]
+node_id = "{}"
+node_label = "{}"
+server = "ws://{}/ws"
+token = "{}"
+report_interval_secs = 1
+"#,
+        node.node_id, node.node_label, server.addr, node.token
+    );
+    fs::write(&config_path, agent_config_toml)?;
+
+    // 4. Spawn the actual nodelite-agent binary process
+    let mut child = Command::new(&agent_bin)
+        .arg("--config")
+        .arg(&config_path)
+        .spawn()
+        .context("failed to spawn nodelite-agent process")?;
+
+    // 5. Wait for the agent to connect and authenticate
+    let status = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.wait_for_node_uptime(&node.node_id, 1, TEST_TIMEOUT)
+    )
+    .await;
+
+    // Check if we successfully got status or if agent failed to start
+    let status = match status {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            let _ = child.kill();
+            return Err(anyhow!("Failed waiting for node uptime status: {e}"));
+        }
+        Err(_) => {
+            let _ = child.kill();
+            return Err(anyhow!("Timed out waiting for agent to connect and report uptime"));
+        }
+    };
+
+    assert!(status.online);
+    assert_eq!(status.identity.node_label, node.node_label);
+
+    // Verify server overview exposes node
+    let overview = server.overview().await?;
+    assert_eq!(overview.total_nodes, 1);
+    assert_eq!(overview.online_nodes, 1);
+
+    // 6. Kill agent and verify offline status
+    child.kill().context("failed to kill agent process")?;
+    let _ = child.wait(); // prevent zombie process
+
+    let offline_status = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.wait_for_node_offline(&node.node_id, TEST_TIMEOUT)
+    )
+    .await
+    .context("Timed out waiting for agent to go offline")??;
+    assert!(!offline_status.online);
+
+    // Cleanup
+    server.shutdown().await?;
+    let _ = fs::remove_dir_all(&temp_dir);
+
+    Ok(())
+}

--- a/nodelite-server/tests/integration/e2e.rs
+++ b/nodelite-server/tests/integration/e2e.rs
@@ -1,7 +1,10 @@
-use super::*;
 use std::fs;
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context};
+
+use super::*;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -16,7 +19,11 @@ async fn test_e2e_agent_server_handshake() -> Result<()> {
     #[cfg(windows)]
     agent_bin.set_extension("exe");
 
-    assert!(agent_bin.exists(), "nodelite-agent binary not found at {}", agent_bin.display());
+    assert!(
+        agent_bin.exists(),
+        "nodelite-agent binary not found at {}",
+        agent_bin.display()
+    );
 
     // 2. Start the TestServer
     let server = TestServer::start().await?;
@@ -53,7 +60,7 @@ report_interval_secs = 1
     // 5. Wait for the agent to connect and authenticate
     let status = tokio::time::timeout(
         Duration::from_secs(10),
-        server.wait_for_node_uptime(&node.node_id, 1, TEST_TIMEOUT)
+        server.wait_for_node_uptime(&node.node_id, 1, TEST_TIMEOUT),
     )
     .await;
 
@@ -66,7 +73,9 @@ report_interval_secs = 1
         }
         Err(_) => {
             let _ = child.kill();
-            return Err(anyhow!("Timed out waiting for agent to connect and report uptime"));
+            return Err(anyhow!(
+                "Timed out waiting for agent to connect and report uptime"
+            ));
         }
     };
 
@@ -84,7 +93,7 @@ report_interval_secs = 1
 
     let offline_status = tokio::time::timeout(
         Duration::from_secs(10),
-        server.wait_for_node_offline(&node.node_id, TEST_TIMEOUT)
+        server.wait_for_node_offline(&node.node_id, TEST_TIMEOUT),
     )
     .await
     .context("Timed out waiting for agent to go offline")??;

--- a/nodelite-server/tests/integration/mod.rs
+++ b/nodelite-server/tests/integration/mod.rs
@@ -8,3 +8,4 @@ mod server_agent_handshake;
 mod settings_routes;
 mod shutdown_signal;
 mod token_lifecycle;
+mod e2e;

--- a/nodelite-server/tests/integration/mod.rs
+++ b/nodelite-server/tests/integration/mod.rs
@@ -2,10 +2,10 @@ pub(crate) use crate::test_support::{LIVE_REFRESH_TIMEOUT, TEST_TIMEOUT, TestAge
 pub(crate) use anyhow::Result;
 pub(crate) use futures::future::try_join_all;
 mod concurrent_nodes;
+mod e2e;
 mod failure_recovery;
 mod metrics_collection;
 mod server_agent_handshake;
 mod settings_routes;
 mod shutdown_signal;
 mod token_lifecycle;
-mod e2e;


### PR DESCRIPTION
# PR 简介

## 关联 Issue
Closes #170

## 🎯 背景与目的
当前项目在 Agent 测试与端到端回归验证上存在明显的测试缺口：
1. `nodelite-agent` 缺乏集成测试，且核心指标采集器存在硬编码，导致系统调用路径处于“裸奔”状态；
2. 缺乏启动真实 Agent 二进制与真实 Server 进程交互的真实端到端 (E2E) 测试；
3. exponential backoff、token 轮换等稳定性逻辑缺乏时钟层面的精准覆盖；
4. `load_test/` 压测模块游离在标准测试流外，且缺乏自动触发入口。

本 PR 旨在重构 Agent 采集器与项目测试结构，补齐测试缺口，建立起从单元测试、集成测试到端到端压测的完整安全网。

---

## 🛠️ 主要变更内容

### 1. `nodelite-agent` 架构改造
* **库与二进制解耦**：将 `nodelite-agent` 改造为支持 `lib` 与 `bin` 双重目标，将底层模块暴露为公有，为编写独立集成测试扫齐障碍。
* **参数化指标采集器**：重构 `collector_linux.rs`，让 `HostCollector` 支持自定义传入的系统根路径 `sys_root`（代替原本硬编码的 `/proc/` 及 `/etc/`），使核心指标解析路径在测试中可被完全 Mock 覆盖。

### 2. 新增集成测试与 Mock 单元测试
* 新增 `nodelite-agent/tests/` 目录，并注入以下测试：
  * **配置更新验证 (`config.rs`)**：验证本地配置文件读取与 `update_token_in_config` 后的安全覆盖行为。
  * **重连回退时钟仿真 (`reconnect.rs`)**：使用 `tokio::time::pause()` 配合虚拟时钟推进，对 `run_forever` 循环内的指数退避延迟设计（Jitter + Backoff）做高频稳定测试。
  * **Token 轮换生命周期 (`token_refresh.rs`)**：使用本地临时 WebSocket 模拟服务端响应，测试完整的握手注册、接收刷新令牌以及本地 Token 自动旋转的完整生命周期。
* **采集器 Mock 解析测试**：在 `collector_linux.rs` 中新增 `test_host_collector_with_mock_files` 测试，通过在临时目录下填充 Mock 系统内核指标文件，端到端测试 `collect_identity` 和 `collect_snapshot` 在 Linux 环境下的正确提取。

### 3. 新增 E2E 系统测试 (`e2e.rs`)
* 新建 `nodelite-server/tests/integration/e2e.rs`，不再依赖伪造的 `TestAgent` 客户端。
* 该测试能够动态获取当前 workspace 编译生成的 `nodelite-agent` 二进制包，拉起实际子进程，配合 `TestServer` 验证 **“真实握手 -> 指标上报 -> 数据落盘 -> HTTP API 外部查询 -> 进程离线感应”** 的完整物理通路。

### 4. 激活 `load_test` Feature 压测通道
* 在 `nodelite-server` 引入 `load_test` 特征。
* 重构 `load_test/mod.rs` 内部所有压测入口，采用 `#[cfg_attr(not(feature = "load_test"), ignore)]`。稳态下它们依旧保持 `ignore` 以保持轻量本地测试，而当启用 feature 时会被立即唤醒用于性能压测。

---

## 🧪 验证计划与指令

### 1. 基础工作区测试（本地/CI）
验证库切分、Mock 解析、以及集成测试功能：
```bash
cargo test --workspace