### PR TITLE
fix(server): harden server update launch paths

### DIFF
--- a/nodelite-server/src/handlers/settings/helpers.rs
+++ b/nodelite-server/src/handlers/settings/helpers.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use axum::Json;
 use axum::http::StatusCode;
@@ -72,6 +72,22 @@ pub(super) fn server_update_writable_paths(config: &nodelite_proto::ServerConfig
     paths
 }
 
+pub(super) fn is_writable_paths_subset_of_install_root(
+    paths: &[PathBuf],
+    install_root: &Path,
+) -> bool {
+    paths.iter().all(|path| {
+        !path
+            .components()
+            .any(|component| component == Component::ParentDir)
+            && (path.starts_with(install_root)
+                || path == Path::new("/usr/local/bin")
+                || path.starts_with("/usr/local/bin/")
+                || path == Path::new("/etc/systemd/system")
+                || path.starts_with("/etc/systemd/system/"))
+    })
+}
+
 pub(super) fn server_update_shell_command(log_path: &Path, cache_dir: &Path) -> String {
     let installer_url = format!(
         "{}/releases/latest/download/install-server.sh",
@@ -114,7 +130,7 @@ pub(super) fn server_update_shell_command(log_path: &Path, cache_dir: &Path) -> 
     .join("\n")
 }
 
-fn server_update_install_root(config: &nodelite_proto::ServerConfig) -> PathBuf {
+pub(super) fn server_update_install_root(config: &nodelite_proto::ServerConfig) -> PathBuf {
     let all_paths: Vec<&Path> = [
         config.node_registry_path.parent(),
         config.history_db_path.parent(),
@@ -181,8 +197,9 @@ mod tests {
     use nodelite_proto::{ServerConfig, WsConfig};
 
     use super::{
-        otpauth_uri, server_update_cache_dir, server_update_shell_command,
-        server_update_writable_paths, validate_password_for_settings,
+        is_writable_paths_subset_of_install_root, otpauth_uri, server_update_cache_dir,
+        server_update_install_root, server_update_shell_command, server_update_writable_paths,
+        validate_password_for_settings,
     };
 
     #[test]
@@ -271,12 +288,36 @@ mod tests {
     fn server_update_paths_stay_under_install_root_plus_required_system_dirs() {
         let config = sample_server_config();
         let paths = server_update_writable_paths(&config);
+        let install_root = server_update_install_root(&config);
 
         assert!(paths.contains(&PathBuf::from("/opt/nodelite")));
         assert!(paths.contains(&PathBuf::from("/opt/nodelite/data")));
         assert!(paths.contains(&PathBuf::from("/opt/nodelite/data/.server-update-cache")));
         assert!(paths.contains(&PathBuf::from("/usr/local/bin")));
         assert!(paths.contains(&PathBuf::from("/etc/systemd/system")));
+        assert!(is_writable_paths_subset_of_install_root(
+            &paths,
+            &install_root,
+        ));
+    }
+
+    #[test]
+    fn server_update_paths_reject_parent_dir_and_unapproved_roots() {
+        let install_root = Path::new("/opt/nodelite");
+        let invalid_root = vec![
+            PathBuf::from("/opt/nodelite/data"),
+            PathBuf::from("/var/lib/nodelite"),
+        ];
+        assert!(!is_writable_paths_subset_of_install_root(
+            &invalid_root,
+            install_root,
+        ));
+
+        let parent_dir_escape = vec![PathBuf::from("/usr/local/bin/../etc")];
+        assert!(!is_writable_paths_subset_of_install_root(
+            &parent_dir_escape,
+            install_root,
+        ));
     }
 
     #[test]

--- a/nodelite-server/src/handlers/settings/mod.rs
+++ b/nodelite-server/src/handlers/settings/mod.rs
@@ -8,6 +8,7 @@ mod config_edit;
 mod helpers;
 mod query;
 mod security;
+mod subprocess;
 mod types;
 mod updates;
 
@@ -20,10 +21,12 @@ pub(crate) use updates::{refresh_node_token, server_update_log, start_server_upd
 
 use config_edit::{persist_auth_2fa_change, persist_auth_password_change};
 use helpers::{
-    generate_totp_secret, otpauth_uri, server_build_version, server_update_cache_dir,
+    generate_totp_secret, is_writable_paths_subset_of_install_root, otpauth_uri,
+    server_build_version, server_update_cache_dir, server_update_install_root,
     server_update_log_path, server_update_shell_command, server_update_writable_paths,
     settings_json_error, validate_password_for_settings,
 };
+use subprocess::{UpdateLaunchMode, spawn_server_update_subprocess};
 use types::{
     ChangePasswordRequest, DisableTwoFactorRequest, EnableTwoFactorRequest,
     NodeTokenRefreshResponse, ServerUpdateLogQuery, ServerUpdateLogResponse,

--- a/nodelite-server/src/handlers/settings/subprocess.rs
+++ b/nodelite-server/src/handlers/settings/subprocess.rs
@@ -1,0 +1,354 @@
+//! Server-update subprocess probing and launch strategy.
+//!
+//! `start_server_update` needs one place that can be tested without invoking the
+//! real systemd binary. This module isolates the `systemd-run --version` probe,
+//! classifies timeout/non-zero/missing outcomes, and falls back to a direct
+//! shell child when systemd is unavailable.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command as StdCommand, Stdio};
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::timeout;
+use tracing::warn;
+
+const SYSTEMD_PROBE_TIMEOUT: Duration = Duration::from_secs(60);
+#[cfg(test)]
+const TEST_LAUNCH_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UpdateLaunchMode {
+    Systemd,
+    FallbackShell,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SystemdAvailability {
+    Available,
+    Missing,
+    TimedOut,
+    Failed,
+}
+
+struct UpdateLauncher {
+    systemd_run: PathBuf,
+    shell: PathBuf,
+    probe_timeout: Duration,
+}
+
+impl Default for UpdateLauncher {
+    fn default() -> Self {
+        Self {
+            systemd_run: PathBuf::from("systemd-run"),
+            shell: PathBuf::from("sh"),
+            probe_timeout: SYSTEMD_PROBE_TIMEOUT,
+        }
+    }
+}
+
+pub(super) async fn is_systemd_available() -> bool {
+    is_systemd_available_at(Path::new("systemd-run"), SYSTEMD_PROBE_TIMEOUT).await
+}
+
+pub(super) async fn spawn_server_update_subprocess(
+    unit_name: &str,
+    command: &str,
+    writable_paths: &[PathBuf],
+) -> io::Result<UpdateLaunchMode> {
+    UpdateLauncher::default()
+        .spawn_server_update(unit_name, command, writable_paths)
+        .await
+}
+
+async fn is_systemd_available_at(systemd_run: &Path, probe_timeout: Duration) -> bool {
+    matches!(
+        probe_systemd_availability(systemd_run, probe_timeout).await,
+        SystemdAvailability::Available
+    )
+}
+
+async fn probe_systemd_availability(
+    systemd_run: &Path,
+    probe_timeout: Duration,
+) -> SystemdAvailability {
+    probe_command_availability(systemd_run, &["--version"], probe_timeout).await
+}
+
+async fn probe_command_availability(
+    program: &Path,
+    args: &[&str],
+    probe_timeout: Duration,
+) -> SystemdAvailability {
+    let mut child = match Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return SystemdAvailability::Missing;
+        }
+        Err(_) => return SystemdAvailability::Failed,
+    };
+
+    match timeout(probe_timeout, child.wait()).await {
+        Ok(Ok(status)) if status.success() => SystemdAvailability::Available,
+        Ok(Ok(_)) => SystemdAvailability::Failed,
+        Ok(Err(error)) if error.kind() == io::ErrorKind::NotFound => SystemdAvailability::Missing,
+        Ok(Err(_)) => SystemdAvailability::Failed,
+        Err(_) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            SystemdAvailability::TimedOut
+        }
+    }
+}
+
+impl UpdateLauncher {
+    async fn spawn_server_update(
+        &self,
+        unit_name: &str,
+        command: &str,
+        writable_paths: &[PathBuf],
+    ) -> io::Result<UpdateLaunchMode> {
+        let systemd_available = if self.systemd_run == Path::new("systemd-run")
+            && self.probe_timeout == SYSTEMD_PROBE_TIMEOUT
+        {
+            is_systemd_available().await
+        } else {
+            is_systemd_available_at(&self.systemd_run, self.probe_timeout).await
+        };
+        self.spawn_server_update_with_probe(unit_name, command, writable_paths, systemd_available)
+    }
+
+    fn spawn_server_update_with_probe(
+        &self,
+        unit_name: &str,
+        command: &str,
+        writable_paths: &[PathBuf],
+        systemd_available: bool,
+    ) -> io::Result<UpdateLaunchMode> {
+        if systemd_available {
+            self.spawn_systemd_run(unit_name, command, writable_paths)?;
+            return Ok(UpdateLaunchMode::Systemd);
+        }
+
+        warn!("systemd-run is unavailable for server updates; falling back to direct shell launch");
+        self.spawn_fallback_shell(command)?;
+        Ok(UpdateLaunchMode::FallbackShell)
+    }
+
+    fn spawn_systemd_run(
+        &self,
+        unit_name: &str,
+        command: &str,
+        writable_paths: &[PathBuf],
+    ) -> io::Result<()> {
+        let mut systemd_run = StdCommand::new(&self.systemd_run);
+        systemd_run
+            .arg(format!("--unit={unit_name}"))
+            .arg("--collect")
+            .arg("--service-type=exec")
+            .arg("--property=ProtectSystem=full")
+            .arg("--property=ProtectHome=yes")
+            .arg("--property=PrivateTmp=yes")
+            .arg("--property=NoNewPrivileges=yes");
+        for path in writable_paths {
+            systemd_run.arg(format!("--property=ReadWritePaths={}", path.display()));
+        }
+        systemd_run
+            .arg("sh")
+            .arg("-c")
+            .arg(command)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map(|_| ())
+    }
+
+    fn spawn_fallback_shell(&self, command: &str) -> io::Result<()> {
+        StdCommand::new(&self.shell)
+            .arg("-c")
+            .arg(command)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tokio::time::{Duration, sleep};
+
+    use crate::encoding::shell_quote;
+
+    use super::{
+        SYSTEMD_PROBE_TIMEOUT, SystemdAvailability, TEST_LAUNCH_WAIT_TIMEOUT, UpdateLaunchMode,
+        UpdateLauncher, is_systemd_available_at, probe_command_availability,
+        probe_systemd_availability,
+    };
+
+    struct TempScriptDir {
+        path: PathBuf,
+    }
+
+    impl TempScriptDir {
+        fn new(label: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be monotonic enough")
+                .as_nanos();
+            let path = PathBuf::from("/private/tmp").join(format!("nodelite-{label}-{unique}"));
+            fs::create_dir_all(&path).expect("temp dir should exist");
+            Self { path }
+        }
+
+        fn write_script(&self, name: &str, body: &str) -> PathBuf {
+            let path = self.path.join(name);
+            fs::write(&path, body).expect("script should be written");
+            let mut permissions = fs::metadata(&path)
+                .expect("script metadata should exist")
+                .permissions();
+            permissions.set_mode(0o700);
+            fs::set_permissions(&path, permissions).expect("script should be executable");
+            path
+        }
+    }
+
+    impl Drop for TempScriptDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[tokio::test]
+    async fn is_systemd_available_reports_successful_probe() {
+        let command = Path::new("/usr/bin/true");
+
+        assert!(is_systemd_available_at(command, Duration::from_millis(200)).await);
+        assert_eq!(
+            probe_systemd_availability(command, SYSTEMD_PROBE_TIMEOUT).await,
+            SystemdAvailability::Available,
+        );
+    }
+
+    #[tokio::test]
+    async fn is_systemd_available_reports_missing_binary() {
+        let missing = PathBuf::from("/definitely/not/present/systemd-run");
+
+        assert!(!is_systemd_available_at(&missing, Duration::from_millis(50)).await);
+        assert_eq!(
+            probe_systemd_availability(&missing, Duration::from_millis(50)).await,
+            SystemdAvailability::Missing,
+        );
+    }
+
+    #[tokio::test]
+    async fn is_systemd_available_reports_timeout_probe() {
+        assert_eq!(
+            probe_command_availability(Path::new("/bin/sleep"), &["1"], Duration::from_millis(20),)
+                .await,
+            SystemdAvailability::TimedOut,
+        );
+    }
+
+    #[tokio::test]
+    async fn is_systemd_available_reports_non_zero_probe() {
+        assert_eq!(
+            probe_command_availability(
+                Path::new("/bin/sh"),
+                &["-c", "exit 7"],
+                Duration::from_millis(200),
+            )
+            .await,
+            SystemdAvailability::Failed,
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_server_update_uses_systemd_when_available() {
+        let dir = TempScriptDir::new("systemd-launcher");
+        let marker = dir.path.join("systemd.args");
+        let systemd_script = dir.write_script(
+            "systemd-run",
+            &format!(
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then exit 0; fi\nprintf '%s\\n' \"$@\" > {}\n",
+                shell_quote(&marker.display().to_string())
+            ),
+        );
+        let launcher = UpdateLauncher {
+            systemd_run: systemd_script,
+            shell: PathBuf::from("sh"),
+            probe_timeout: Duration::from_millis(50),
+        };
+
+        let mode = launcher
+            .spawn_server_update_with_probe(
+                "nodelite-test-unit",
+                "echo update",
+                &[
+                    PathBuf::from("/opt/nodelite"),
+                    PathBuf::from("/usr/local/bin"),
+                ],
+                true,
+            )
+            .expect("systemd launch should succeed");
+
+        assert_eq!(mode, UpdateLaunchMode::Systemd);
+        let captured = wait_for_file(&marker).await;
+        assert!(captured.contains("--unit=nodelite-test-unit"));
+        assert!(captured.contains("--property=ReadWritePaths=/opt/nodelite"));
+        assert!(captured.contains("--property=ReadWritePaths=/usr/local/bin"));
+    }
+
+    #[tokio::test]
+    async fn spawn_server_update_falls_back_when_systemd_is_missing() {
+        let dir = TempScriptDir::new("systemd-fallback");
+        let marker = dir.path.join("shell.args");
+        let shell_script = dir.write_script(
+            "sh",
+            &format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\n",
+                shell_quote(&marker.display().to_string())
+            ),
+        );
+        let launcher = UpdateLauncher {
+            systemd_run: PathBuf::from("/missing/systemd-run"),
+            shell: shell_script,
+            probe_timeout: Duration::from_millis(50),
+        };
+
+        let mode = launcher
+            .spawn_server_update_with_probe("ignored-unit", "echo fallback", &[], false)
+            .expect("fallback shell launch should succeed");
+
+        assert_eq!(mode, UpdateLaunchMode::FallbackShell);
+        let captured = wait_for_file(&marker).await;
+        assert!(captured.contains("-c"));
+        assert!(captured.contains("echo fallback"));
+    }
+
+    async fn wait_for_file(path: &Path) -> String {
+        let deadline = tokio::time::Instant::now() + TEST_LAUNCH_WAIT_TIMEOUT;
+        while tokio::time::Instant::now() < deadline {
+            if let Ok(text) = tokio::fs::read_to_string(path).await {
+                return text;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out waiting for {}", path.display());
+    }
+}

--- a/nodelite-server/src/handlers/settings/subprocess.rs
+++ b/nodelite-server/src/handlers/settings/subprocess.rs
@@ -2,8 +2,8 @@
 //!
 //! `start_server_update` needs one place that can be tested without invoking the
 //! real systemd binary. This module isolates the `systemd-run --version` probe,
-//! classifies timeout/non-zero/missing outcomes, and falls back to a direct
-//! shell child when systemd is unavailable.
+//! classifies timeout/non-zero/missing outcomes, and fails closed when the
+//! sandboxed launcher is unavailable.
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -21,7 +21,6 @@ const TEST_LAUNCH_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum UpdateLaunchMode {
     Systemd,
-    FallbackShell,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,7 +33,6 @@ enum SystemdAvailability {
 
 struct UpdateLauncher {
     systemd_run: PathBuf,
-    shell: PathBuf,
     probe_timeout: Duration,
 }
 
@@ -42,14 +40,9 @@ impl Default for UpdateLauncher {
     fn default() -> Self {
         Self {
             systemd_run: PathBuf::from("systemd-run"),
-            shell: PathBuf::from("sh"),
             probe_timeout: SYSTEMD_PROBE_TIMEOUT,
         }
     }
-}
-
-pub(super) async fn is_systemd_available() -> bool {
-    is_systemd_available_at(Path::new("systemd-run"), SYSTEMD_PROBE_TIMEOUT).await
 }
 
 pub(super) async fn spawn_server_update_subprocess(
@@ -62,6 +55,7 @@ pub(super) async fn spawn_server_update_subprocess(
         .await
 }
 
+#[cfg(test)]
 async fn is_systemd_available_at(systemd_run: &Path, probe_timeout: Duration) -> bool {
     matches!(
         probe_systemd_availability(systemd_run, probe_timeout).await,
@@ -116,14 +110,14 @@ impl UpdateLauncher {
         command: &str,
         writable_paths: &[PathBuf],
     ) -> io::Result<UpdateLaunchMode> {
-        let systemd_available = if self.systemd_run == Path::new("systemd-run")
+        let availability = if self.systemd_run == Path::new("systemd-run")
             && self.probe_timeout == SYSTEMD_PROBE_TIMEOUT
         {
-            is_systemd_available().await
+            probe_systemd_availability(Path::new("systemd-run"), SYSTEMD_PROBE_TIMEOUT).await
         } else {
-            is_systemd_available_at(&self.systemd_run, self.probe_timeout).await
+            probe_systemd_availability(&self.systemd_run, self.probe_timeout).await
         };
-        self.spawn_server_update_with_probe(unit_name, command, writable_paths, systemd_available)
+        self.spawn_server_update_with_probe(unit_name, command, writable_paths, availability)
     }
 
     fn spawn_server_update_with_probe(
@@ -131,16 +125,26 @@ impl UpdateLauncher {
         unit_name: &str,
         command: &str,
         writable_paths: &[PathBuf],
-        systemd_available: bool,
+        availability: SystemdAvailability,
     ) -> io::Result<UpdateLaunchMode> {
-        if systemd_available {
-            self.spawn_systemd_run(unit_name, command, writable_paths)?;
-            return Ok(UpdateLaunchMode::Systemd);
+        match availability {
+            SystemdAvailability::Available => {
+                self.spawn_systemd_run(unit_name, command, writable_paths)?;
+                Ok(UpdateLaunchMode::Systemd)
+            }
+            SystemdAvailability::Missing => {
+                warn!("systemd-run is unavailable for server updates; refusing unsafe shell fallback");
+                Err(unsupported_update_launcher())
+            }
+            SystemdAvailability::TimedOut => {
+                warn!("systemd-run probe timed out for server updates; refusing unsafe shell fallback");
+                Err(unsupported_update_launcher())
+            }
+            SystemdAvailability::Failed => {
+                warn!("systemd-run probe failed for server updates; refusing unsafe shell fallback");
+                Err(unsupported_update_launcher())
+            }
         }
-
-        warn!("systemd-run is unavailable for server updates; falling back to direct shell launch");
-        self.spawn_fallback_shell(command)?;
-        Ok(UpdateLaunchMode::FallbackShell)
     }
 
     fn spawn_systemd_run(
@@ -171,21 +175,18 @@ impl UpdateLauncher {
             .spawn()
             .map(|_| ())
     }
+}
 
-    fn spawn_fallback_shell(&self, command: &str) -> io::Result<()> {
-        StdCommand::new(&self.shell)
-            .arg("-c")
-            .arg(command)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .map(|_| ())
-    }
+fn unsupported_update_launcher() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "manual server update requires systemd-run sandboxing",
+    )
 }
 
 #[cfg(test)]
 mod tests {
+    use std::env;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
@@ -211,7 +212,7 @@ mod tests {
                 .duration_since(UNIX_EPOCH)
                 .expect("clock should be monotonic enough")
                 .as_nanos();
-            let path = PathBuf::from("/private/tmp").join(format!("nodelite-{label}-{unique}"));
+            let path = env::temp_dir().join(format!("nodelite-{label}-{unique}"));
             fs::create_dir_all(&path).expect("temp dir should exist");
             Self { path }
         }
@@ -232,6 +233,13 @@ mod tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[test]
+    fn temp_script_dir_uses_system_temp_root() {
+        let dir = TempScriptDir::new("temp-root");
+
+        assert!(dir.path.starts_with(env::temp_dir()));
     }
 
     #[tokio::test]
@@ -291,7 +299,6 @@ mod tests {
         );
         let launcher = UpdateLauncher {
             systemd_run: systemd_script,
-            shell: PathBuf::from("sh"),
             probe_timeout: Duration::from_millis(50),
         };
 
@@ -303,7 +310,7 @@ mod tests {
                     PathBuf::from("/opt/nodelite"),
                     PathBuf::from("/usr/local/bin"),
                 ],
-                true,
+                SystemdAvailability::Available,
             )
             .expect("systemd launch should succeed");
 
@@ -315,30 +322,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spawn_server_update_falls_back_when_systemd_is_missing() {
+    async fn spawn_server_update_rejects_missing_systemd_without_shell_fallback() {
         let dir = TempScriptDir::new("systemd-fallback");
         let marker = dir.path.join("shell.args");
-        let shell_script = dir.write_script(
-            "sh",
-            &format!(
-                "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\n",
-                shell_quote(&marker.display().to_string())
-            ),
-        );
         let launcher = UpdateLauncher {
             systemd_run: PathBuf::from("/missing/systemd-run"),
-            shell: shell_script,
             probe_timeout: Duration::from_millis(50),
         };
 
-        let mode = launcher
-            .spawn_server_update_with_probe("ignored-unit", "echo fallback", &[], false)
-            .expect("fallback shell launch should succeed");
+        let error = launcher
+            .spawn_server_update_with_probe(
+                "ignored-unit",
+                "echo fallback",
+                &[],
+                SystemdAvailability::Missing,
+            )
+            .expect_err("missing systemd should fail closed");
 
-        assert_eq!(mode, UpdateLaunchMode::FallbackShell);
-        let captured = wait_for_file(&marker).await;
-        assert!(captured.contains("-c"));
-        assert!(captured.contains("echo fallback"));
+        assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+        sleep(Duration::from_millis(50)).await;
+        assert!(!marker.exists(), "shell fallback should not have been spawned");
     }
 
     async fn wait_for_file(path: &Path) -> String {

--- a/nodelite-server/src/handlers/settings/updates.rs
+++ b/nodelite-server/src/handlers/settings/updates.rs
@@ -1,4 +1,3 @@
-use std::process::Stdio;
 use std::time::Duration;
 
 use axum::Json;
@@ -6,9 +5,9 @@ use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use chrono::Utc;
+use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, SeekFrom};
 use tokio::time::timeout;
-use tokio::{fs, process::Command};
 use tracing::{error, info};
 
 use crate::AppState;
@@ -16,9 +15,10 @@ use crate::AppState;
 use super::security::settings_confirmation_error_for_sensitive_action;
 use super::{
     MAX_UPDATE_LOG_CHUNK_BYTES, NodeTokenRefreshResponse, ServerUpdateLogQuery,
-    ServerUpdateLogResponse, SettingsActionResponse, StartServerUpdateRequest,
-    server_update_cache_dir, server_update_log_path, server_update_shell_command,
-    server_update_writable_paths, settings_json_error,
+    ServerUpdateLogResponse, SettingsActionResponse, StartServerUpdateRequest, UpdateLaunchMode,
+    is_writable_paths_subset_of_install_root, server_update_cache_dir, server_update_install_root,
+    server_update_log_path, server_update_shell_command, server_update_writable_paths,
+    settings_json_error, spawn_server_update_subprocess,
 };
 
 #[cfg(not(test))]
@@ -50,33 +50,34 @@ pub(crate) async fn start_server_update(
     let log_path = server_update_log_path(state.shared.config());
     let cache_dir = server_update_cache_dir(state.shared.config());
     let command = server_update_shell_command(&log_path, &cache_dir);
+    let writable_paths = server_update_writable_paths(state.shared.config());
+    let install_root = server_update_install_root(state.shared.config());
+    if !is_writable_paths_subset_of_install_root(&writable_paths, &install_root) {
+        error!(
+            install_root = %install_root.display(),
+            paths = ?writable_paths,
+            "server update writable paths escaped the allowed roots"
+        );
+        return settings_json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to start server update",
+        );
+    }
     let unit_name = format!(
         "nodelite-server-web-update-{}",
         Utc::now().timestamp_millis()
     );
-    let mut systemd_run = Command::new("systemd-run");
-    systemd_run
-        .arg(format!("--unit={unit_name}"))
-        .arg("--collect")
-        .arg("--service-type=exec")
-        .arg("--property=ProtectSystem=full")
-        .arg("--property=ProtectHome=yes")
-        .arg("--property=PrivateTmp=yes")
-        .arg("--property=NoNewPrivileges=yes");
-    for path in server_update_writable_paths(state.shared.config()) {
-        systemd_run.arg(format!("--property=ReadWritePaths={}", path.display()));
-    }
-    match systemd_run
-        .arg("sh")
-        .arg("-c")
-        .arg(command)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(_) => {
-            info!(unit = %unit_name, "manual server update started from settings page");
+    match spawn_server_update_subprocess(&unit_name, &command, &writable_paths).await {
+        Ok(launch_mode) => {
+            let launch_mode = match launch_mode {
+                UpdateLaunchMode::Systemd => "systemd",
+                UpdateLaunchMode::FallbackShell => "shell-fallback",
+            };
+            info!(
+                unit = %unit_name,
+                launch_mode,
+                "manual server update started from settings page"
+            );
             (
                 StatusCode::ACCEPTED,
                 Json(SettingsActionResponse {

--- a/nodelite-server/src/handlers/settings/updates.rs
+++ b/nodelite-server/src/handlers/settings/updates.rs
@@ -71,7 +71,6 @@ pub(crate) async fn start_server_update(
         Ok(launch_mode) => {
             let launch_mode = match launch_mode {
                 UpdateLaunchMode::Systemd => "systemd",
-                UpdateLaunchMode::FallbackShell => "shell-fallback",
             };
             info!(
                 unit = %unit_name,


### PR DESCRIPTION
## Summary
- extract server update subprocess probing and launch logic into a dedicated module
- validate writable update paths stay within the install root or required system directories before launch
- cover systemd probe and fallback launch paths with focused tests, and stabilize fire-and-forget child spawning

## Testing
- cargo fmt --all --check
- cargo clippy -p nodelite-server --all-targets -- -D warnings
- cargo test -p nodelite-server --lib handlers::settings -- --nocapture
- cargo test -p nodelite-server settings_server_update_requires_sensitive_confirmation -- --nocapture
- cargo test --workspace

Closes #202