### PR TITLE
Fix 2.3.0 release blockers

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -249,6 +249,8 @@ cargo check
 
 NodeLite provides a protected `/metrics` endpoint outputting Prometheus exposition text. It shares the read-only authentication with the dashboard, so scrapers must use the same Basic Auth credentials.
 
+By default, `/metrics` exports server / overview aggregates and a small set of node summary metrics only, keeping scrape responses small for large fleets. To export per-node CPU, uptime, memory, load, network, and other latest snapshot details, set `export_node_resource_metrics = true` under `[metrics]` in `server.toml`; to also export per-mount disk metrics, set `export_node_disk_metrics = true`. These switches increase series count and response size with node and mount count, so enable them only when Prometheus must retain those details.
+
 Verify with `curl` first:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ cargo check
 
 NodeLite 现在提供受保护的 `/metrics` 端点，输出 Prometheus exposition text。它和仪表盘共用只读认证，因此抓取端需要带上同一组 Basic Auth 凭据。
 
+默认 `/metrics` 只导出 server / overview 聚合和少量 node summary 指标，避免大规模集群下 scrape 响应体过大。如果需要按节点导出 CPU、uptime、memory、load、network 等最新快照细节，可在 `server.toml` 的 `[metrics]` 中设置 `export_node_resource_metrics = true`；如果还需要按挂载点导出磁盘指标，再设置 `export_node_disk_metrics = true`。这些开关会按节点数和挂载点数量增加 series 与响应体大小，建议只在确实需要 Prometheus 长期采集这些细节时开启。
+
 先用 `curl` 验证：
 
 ```bash

--- a/config/server.example.toml
+++ b/config/server.example.toml
@@ -40,6 +40,13 @@ metric_anomaly_session_limit = 5
 # SQLite 忙等待超时(秒)。
 sqlite_busy_timeout_secs = 5
 
+[metrics]
+# Prometheus 默认只导出 server/overview 与少量 node summary 指标,避免大规模 scrape 构建过大的文本体。
+# 开启后会额外按节点导出 CPU、uptime、memory、load、network 等最新快照细节。
+export_node_resource_metrics = false
+# 开启后会按节点和挂载点导出磁盘字节数与使用率;节点多或挂载点多时 series/body 会快速增长。
+export_node_disk_metrics = false
+
 [auth]
 # 前端只读访问用的基本认证用户名。
 username = "viewer"

--- a/nodelite-agent/src/collector.rs
+++ b/nodelite-agent/src/collector.rs
@@ -1,5 +1,8 @@
 //! 主机指标采集器入口:按目标平台分派到具体实现。
 
+use anyhow::{Context, Result};
+use nodelite_proto::{AgentConfig, NodeIdentity, NodeSnapshot};
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use tracing::warn;
 
@@ -25,6 +28,40 @@ mod collector_unsupported;
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub use collector_unsupported::{HostCollector, new_collector};
 
+/// Collect node identity on Tokio's blocking pool so startup does not run filesystem or FFI work
+/// on an async worker.
+pub async fn collect_identity_blocking(
+    collector: &mut HostCollector,
+    config: AgentConfig,
+    agent_version: String,
+) -> Result<NodeIdentity> {
+    with_collector_blocking(collector, move |collector| {
+        collector.collect_identity(&config, &agent_version)
+    })
+    .await
+}
+
+/// Collect a host snapshot on Tokio's blocking pool while preserving collector delta state.
+pub async fn collect_snapshot_blocking(collector: &mut HostCollector) -> Result<NodeSnapshot> {
+    with_collector_blocking(collector, HostCollector::collect_snapshot).await
+}
+
+async fn with_collector_blocking<T, F>(collector: &mut HostCollector, operation: F) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce(&mut HostCollector) -> Result<T> + Send + 'static,
+{
+    let mut owned = std::mem::replace(collector, new_collector());
+    let (returned, result) = tokio::task::spawn_blocking(move || {
+        let result = operation(&mut owned);
+        (owned, result)
+    })
+    .await
+    .context("collector blocking task failed")?;
+    *collector = returned;
+    result
+}
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn log_network_rate_anomalies(anomalies: shared::NetworkRateAnomalies) {
     for anomaly in [anomalies.rx, anomalies.tx].into_iter().flatten() {
@@ -37,5 +74,34 @@ fn log_network_rate_anomalies(anomalies: shared::NetworkRateAnomalies) {
             sample_count = anomaly.sample_count,
             "network rate is more than 100x above recent baseline; keeping sample",
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use anyhow::anyhow;
+
+    use super::{new_collector, with_collector_blocking};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collector_blocking_helper_keeps_async_runtime_responsive() {
+        let mut collector = new_collector();
+        let blocking = with_collector_blocking(&mut collector, |_collector| {
+            std::thread::sleep(Duration::from_millis(50));
+            Err::<(), _>(anyhow!("finished after blocking sleep"))
+        });
+        tokio::pin!(blocking);
+
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+            result = &mut blocking => panic!("blocking collector finished too early: {result:?}"),
+        }
+
+        let error = blocking
+            .await
+            .expect_err("test operation should return its sentinel error");
+        assert!(error.to_string().contains("finished after blocking sleep"));
     }
 }

--- a/nodelite-agent/src/runtime.rs
+++ b/nodelite-agent/src/runtime.rs
@@ -7,7 +7,7 @@ use nodelite_proto::{NoticeLevel, uses_insecure_remote_url};
 use tokio::time::{MissedTickBehavior, interval};
 use tracing::{info, warn};
 
-use crate::collector::new_collector;
+use crate::collector::{collect_identity_blocking, collect_snapshot_blocking, new_collector};
 use crate::config_io::load_agent_config;
 use crate::session::{AgentLogBuffer, run_forever};
 use crate::support::{
@@ -34,7 +34,12 @@ pub async fn run() -> Result<()> {
     let cli = Cli::parse();
     let config = load_agent_config(&cli.config).await?;
     let mut collector = new_collector();
-    let identity = collector.collect_identity(&config, agent_build_version())?;
+    let identity = collect_identity_blocking(
+        &mut collector,
+        config.clone(),
+        agent_build_version().to_string(),
+    )
+    .await?;
 
     info!(
         node_id = %identity.node_id,
@@ -51,7 +56,7 @@ pub async fn run() -> Result<()> {
     );
 
     if cli.sample_once {
-        return run_sample_once(&mut collector, &config);
+        return run_sample_once(&mut collector, &config).await;
     }
 
     spawn_insecure_transport_warning(
@@ -69,13 +74,16 @@ pub async fn run() -> Result<()> {
     .await
 }
 
-fn run_sample_once(
+async fn run_sample_once(
     collector: &mut crate::collector::HostCollector,
     config: &nodelite_proto::AgentConfig,
 ) -> Result<()> {
-    let snapshot = collector.collect_snapshot()?;
+    let snapshot = collect_snapshot_blocking(collector).await?;
+    let identity =
+        collect_identity_blocking(collector, config.clone(), agent_build_version().to_string())
+            .await?;
     let output = serde_json::json!({
-        "identity": collector.collect_identity(config, agent_build_version())?,
+        "identity": identity,
         "snapshot": snapshot,
     });
     println!(

--- a/nodelite-agent/src/session.rs
+++ b/nodelite-agent/src/session.rs
@@ -17,7 +17,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tracing::{info, warn};
 
-use crate::collector::HostCollector;
+use crate::collector::{HostCollector, collect_snapshot_blocking};
 use crate::config_io::update_token_in_config;
 
 /// Agent 本地最多暂存的待上报日志条数。超出后丢弃最旧项,避免断线期间内存无限增长。
@@ -367,7 +367,7 @@ fn incoming_ws_config(max_incoming_message_bytes: usize) -> WebSocketConfig {
 }
 
 async fn send_metrics(sender: &mut AgentWsSender, collector: &mut HostCollector) -> Result<()> {
-    let snapshot = collector.collect_snapshot()?;
+    let snapshot = collect_snapshot_blocking(collector).await?;
     send_wire_message(sender, &WireMessage::Metrics(MetricsMessage { snapshot })).await
 }
 

--- a/nodelite-proto/src/config.rs
+++ b/nodelite-proto/src/config.rs
@@ -23,7 +23,8 @@ use self::defaults::{
     default_connect_timeout_secs, default_hello_timeout_secs,
     default_insecure_transport_warn_interval_secs, default_max_incoming_message_bytes,
     default_max_outstanding_pings, default_max_sanitized_disks, default_max_sanitized_string_bytes,
-    default_metric_anomaly_session_limit, default_sqlite_busy_timeout_secs,
+    default_metric_anomaly_session_limit, default_metrics_export_node_disk_metrics,
+    default_metrics_export_node_resource_metrics, default_sqlite_busy_timeout_secs,
 };
 use self::raw::{RawAgentConfigFile, RawServerConfigFile};
 
@@ -131,6 +132,7 @@ pub struct ServerConfig {
     pub trusted_proxies: Vec<IpNet>,
     pub readonly_auth: Option<ReadonlyAuthConfig>,
     pub ws: WsConfig,
+    pub metrics: MetricsConfig,
     pub audit: AuditConfig,
     pub geoip: GeoIpConfig,
     pub alerting: AlertingConfig,
@@ -187,6 +189,15 @@ pub struct WsConfig {
     pub auth_fail_window_secs: u64,
     pub auth_fail_max_attempts: usize,
     pub auth_block_secs: u64,
+}
+
+/// Prometheus 导出粒度控制。默认保持轻量 summary,细节点资源指标需显式打开。
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MetricsConfig {
+    #[serde(default = "default_metrics_export_node_resource_metrics")]
+    pub export_node_resource_metrics: bool,
+    #[serde(default = "default_metrics_export_node_disk_metrics")]
+    pub export_node_disk_metrics: bool,
 }
 
 /// 审计日志存储与记录策略。

--- a/nodelite-proto/src/config/defaults.rs
+++ b/nodelite-proto/src/config/defaults.rs
@@ -108,6 +108,14 @@ pub(super) fn default_sqlite_busy_timeout_secs() -> u64 {
     DEFAULT_SQLITE_BUSY_TIMEOUT_SECS
 }
 
+pub(super) fn default_metrics_export_node_resource_metrics() -> bool {
+    false
+}
+
+pub(super) fn default_metrics_export_node_disk_metrics() -> bool {
+    false
+}
+
 pub(super) fn default_audit_enabled() -> bool {
     true
 }

--- a/nodelite-proto/src/config/raw.rs
+++ b/nodelite-proto/src/config/raw.rs
@@ -15,6 +15,7 @@ use super::defaults::{
     default_insecure_transport_warn_interval_secs, default_max_incoming_message_bytes,
     default_max_message_bytes, default_max_outstanding_pings, default_max_sanitized_disks,
     default_max_sanitized_string_bytes, default_metric_anomaly_session_limit,
+    default_metrics_export_node_disk_metrics, default_metrics_export_node_resource_metrics,
     default_node_registry_path, default_ping_interval_secs, default_refresh_interval_secs,
     default_report_interval_secs, default_snapshot_path, default_sqlite_busy_timeout_secs,
     default_stale_after_secs, default_trusted_proxies, default_ws_auth_block_secs,
@@ -27,7 +28,7 @@ use super::helpers::{
 };
 use super::{
     AgentConfig, AlertingConfig, AuditConfig, ConfigError, GeoIpConfig, GeoIpEdition,
-    GeoIpProvider, ReadonlyAuthConfig, ServerConfig, WsConfig,
+    GeoIpProvider, MetricsConfig, ReadonlyAuthConfig, ServerConfig, WsConfig,
 };
 use crate::validation::{
     ValidationError, normalize_string_list, validate_identifier, validate_non_empty,
@@ -48,6 +49,8 @@ pub(super) struct RawServerConfigFile {
     auth: RawAuthSection,
     #[serde(default)]
     ws: RawWsSection,
+    #[serde(default)]
+    metrics: RawMetricsSection,
     #[serde(default)]
     audit: RawAuditSection,
     #[serde(default)]
@@ -123,6 +126,15 @@ struct RawWsSection {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
+struct RawMetricsSection {
+    #[serde(default = "default_metrics_export_node_resource_metrics")]
+    export_node_resource_metrics: bool,
+    #[serde(default = "default_metrics_export_node_disk_metrics")]
+    export_node_disk_metrics: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawAuditSection {
     #[serde(default = "default_audit_enabled")]
     enabled: bool,
@@ -183,6 +195,15 @@ impl Default for RawWsSection {
             auth_fail_window_secs: default_ws_auth_fail_window_secs(),
             auth_fail_max_attempts: default_ws_auth_fail_max_attempts(),
             auth_block_secs: default_ws_auth_block_secs(),
+        }
+    }
+}
+
+impl Default for RawMetricsSection {
+    fn default() -> Self {
+        Self {
+            export_node_resource_metrics: default_metrics_export_node_resource_metrics(),
+            export_node_disk_metrics: default_metrics_export_node_disk_metrics(),
         }
     }
 }
@@ -296,6 +317,10 @@ impl RawServerConfigFile {
                 auth_fail_window_secs: self.ws.auth_fail_window_secs,
                 auth_fail_max_attempts: self.ws.auth_fail_max_attempts,
                 auth_block_secs: self.ws.auth_block_secs,
+            },
+            metrics: MetricsConfig {
+                export_node_resource_metrics: self.metrics.export_node_resource_metrics,
+                export_node_disk_metrics: self.metrics.export_node_disk_metrics,
             },
             audit,
             geoip,

--- a/nodelite-proto/src/config/tests.rs
+++ b/nodelite-proto/src/config/tests.rs
@@ -22,6 +22,15 @@ fn server_example_documents_install_section() {
 }
 
 #[test]
+fn server_example_documents_metrics_section() {
+    let example = include_str!("../../../config/server.example.toml");
+
+    assert!(example.contains("[metrics]"));
+    assert!(example.contains("export_node_resource_metrics"));
+    assert!(example.contains("export_node_disk_metrics"));
+}
+
+#[test]
 fn parses_server_config_with_defaults() {
     let config = parse_server_config(
         r#"
@@ -54,6 +63,8 @@ fn parses_server_config_with_defaults() {
         DEFAULT_WS_AUTH_FAIL_MAX_ATTEMPTS
     );
     assert_eq!(config.ws.auth_block_secs, DEFAULT_WS_AUTH_BLOCK_SECS);
+    assert!(!config.metrics.export_node_resource_metrics);
+    assert!(!config.metrics.export_node_disk_metrics);
     assert_eq!(
         config.node_registry_path,
         PathBuf::from("./config/server.json")
@@ -87,6 +98,25 @@ fn parses_server_config_with_defaults() {
         config.alerting.inspection.local_time,
         DEFAULT_ALERT_INSPECTION_LOCAL_TIME
     );
+}
+
+#[test]
+fn parses_server_config_with_metrics_overrides() {
+    let config = parse_server_config(
+        r#"
+        [server]
+        listen = "127.0.0.1:8080"
+        public_base_url = "https://monitor.example.com"
+
+        [metrics]
+        export_node_resource_metrics = true
+        export_node_disk_metrics = true
+        "#,
+    )
+    .expect("metrics config should parse");
+
+    assert!(config.metrics.export_node_resource_metrics);
+    assert!(config.metrics.export_node_disk_metrics);
 }
 
 #[test]

--- a/nodelite-proto/src/lib.rs
+++ b/nodelite-proto/src/lib.rs
@@ -23,8 +23,8 @@ pub use config::{
     DEFAULT_HISTORY_WRITE_INTERVAL_SECS, DEFAULT_MAX_MESSAGE_BYTES, DEFAULT_PING_INTERVAL_SECS,
     DEFAULT_REFRESH_INTERVAL_SECS, DEFAULT_REPORT_INTERVAL_SECS, DEFAULT_STALE_AFTER_SECS,
     GeoIpConfig, GeoIpEdition, GeoIpProvider, InspectionConfig, MAX_NODE_TAG_BYTES, MAX_NODE_TAGS,
-    ReadonlyAuthConfig, ServerConfig, WsConfig, normalize_totp_secret, parse_agent_config,
-    parse_server_config, upsert_toml_item_preserving_decor,
+    MetricsConfig, ReadonlyAuthConfig, ServerConfig, WsConfig, normalize_totp_secret,
+    parse_agent_config, parse_server_config, upsert_toml_item_preserving_decor,
 };
 pub use message::{
     AgentLogEntry, AgentLogsMessage, BrowserMessage, HelloMessage,

--- a/nodelite-server/Cargo.toml
+++ b/nodelite-server/Cargo.toml
@@ -50,6 +50,7 @@ which = "6"
 
 [dev-dependencies]
 proptest = "1.4"
+tokio = { workspace = true, features = ["test-util"] }
 tokio-tungstenite.workspace = true
 tower = "0.5"
 

--- a/nodelite-server/src/alerts/delivery.rs
+++ b/nodelite-server/src/alerts/delivery.rs
@@ -474,6 +474,24 @@ mod tests {
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
+    #[tokio::test]
+    async fn retry_delivery_stops_after_retryable_error_limit() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let error = retry_delivery(|| {
+            let attempts = Arc::clone(&attempts);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(AlertDeliveryError::SmtpTimeout)
+            }
+        })
+        .await
+        .expect_err("retryable errors should eventually fail");
+
+        assert!(matches!(error, AlertDeliveryError::SmtpTimeout));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
     fn sample_event() -> AlertEvent {
         AlertEvent {
             kind: AlertEventKind::Triggered,

--- a/nodelite-server/src/alerts/delivery/smtp.rs
+++ b/nodelite-server/src/alerts/delivery/smtp.rs
@@ -482,7 +482,10 @@ mod tests {
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use tokio::net::TcpListener;
 
-    use super::{build_alert_message, build_inspection_message, dot_stuff, send_alert_event};
+    use super::{
+        SMTP_TIMEOUT, build_alert_message, build_inspection_message, dot_stuff, send_alert_event,
+    };
+    use crate::alerts::delivery::AlertDeliveryError;
     use crate::alerts::evaluator::InspectionHighlight;
     use crate::alerts::{AlertEvent, AlertEventKind, AlertMetricReading};
 
@@ -527,6 +530,63 @@ mod tests {
                 .contains("Subject: [NodeLite] triggered CPU hot on Hong Kong")
         );
         assert!(session.message.contains("Metric: CpuUsagePercent"));
+    }
+
+    #[tokio::test]
+    async fn send_smtp_reports_protocol_error() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let addr = listener.local_addr().expect("listener should expose addr");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("smtp client should connect");
+            socket
+                .write_all(b"421 fake.smtp unavailable\r\n")
+                .await
+                .expect("error response should write");
+        });
+        let config = smtp_config(addr.port());
+
+        let error = send_alert_event(&config, &sample_event())
+            .await
+            .expect_err("smtp protocol error should fail delivery");
+        server.await.expect("fake smtp should join");
+
+        assert!(
+            matches!(error, AlertDeliveryError::Smtp(message) if message.contains("421 fake.smtp unavailable"))
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn send_smtp_times_out_waiting_for_greeting() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let addr = listener.local_addr().expect("listener should expose addr");
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.expect("smtp client should connect");
+            accepted_tx
+                .send(())
+                .expect("test should await accept signal");
+            let _hold_open = socket;
+            std::future::pending::<()>().await;
+        });
+        let config = smtp_config(addr.port());
+        let delivery =
+            tokio::spawn(async move { send_alert_event(&config, &sample_event()).await });
+
+        accepted_rx
+            .await
+            .expect("smtp server should accept connection");
+        tokio::time::advance(SMTP_TIMEOUT + std::time::Duration::from_millis(1)).await;
+        let error = delivery
+            .await
+            .expect("delivery task should join")
+            .expect_err("smtp greeting should time out");
+        server.abort();
+
+        assert!(matches!(error, AlertDeliveryError::SmtpTimeout));
     }
 
     #[test]

--- a/nodelite-server/src/handlers/api.rs
+++ b/nodelite-server/src/handlers/api.rs
@@ -373,7 +373,6 @@ pub(crate) async fn node_history(
         Ok(points) => Json(points).into_response(),
         Err(error) => {
             let history_error = match &error {
-                HistoryError::ConnectionNotInitialized => "connection_not_initialized",
                 HistoryError::Query(_) => "query_failed",
                 HistoryError::TaskFailed(_) => "task_failed",
             };

--- a/nodelite-server/src/handlers/metrics_exporter.rs
+++ b/nodelite-server/src/handlers/metrics_exporter.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 
 use crate::ServerReadiness;
 use crate::agent_logs::AgentLogStats;
-use nodelite_proto::{NodeSnapshot, NodeStatus, OverviewData};
+use nodelite_proto::{MetricsConfig, NodeSnapshot, NodeStatus, OverviewData};
 
 #[cfg(test)]
 pub(crate) fn render_prometheus_metrics(
@@ -11,19 +11,25 @@ pub(crate) fn render_prometheus_metrics(
     statuses: &[NodeStatus],
     overview: &OverviewData,
 ) -> String {
-    render_prometheus_metrics_from_iter(readiness, statuses.iter(), overview)
+    render_prometheus_metrics_from_iter(
+        readiness,
+        statuses.iter(),
+        overview,
+        MetricsConfig::default(),
+    )
 }
 
 pub(crate) fn render_prometheus_metrics_from_iter<'a>(
     readiness: &ServerReadiness,
     statuses: impl IntoIterator<Item = &'a NodeStatus>,
     overview: &OverviewData,
+    metrics_config: MetricsConfig,
 ) -> String {
     let mut emitter = MetricEmitter::default();
     render_server_metrics(&mut emitter, readiness);
     render_overview_metrics(&mut emitter, overview);
     for status in statuses {
-        render_node_metrics(&mut emitter, status);
+        render_node_metrics(&mut emitter, status, metrics_config);
     }
     emitter.finish()
 }
@@ -475,7 +481,7 @@ fn render_overview_metrics(emitter: &mut MetricEmitter, overview: &OverviewData)
     }
 }
 
-fn render_node_metrics(emitter: &mut MetricEmitter, status: &NodeStatus) {
+fn render_node_metrics(emitter: &mut MetricEmitter, status: &NodeStatus, config: MetricsConfig) {
     let node_id = status.identity.node_id.as_str();
     let node_labels = [("node_id", node_id)];
     let node_info_labels = [
@@ -515,35 +521,47 @@ fn render_node_metrics(emitter: &mut MetricEmitter, status: &NodeStatus) {
         );
     }
     if let Some(snapshot) = status.snapshot.as_ref() {
-        render_snapshot_metrics(emitter, node_id, snapshot);
+        render_snapshot_metrics(emitter, node_id, snapshot, config);
     }
 }
 
-fn render_snapshot_metrics(emitter: &mut MetricEmitter, node_id: &str, snapshot: &NodeSnapshot) {
+fn render_snapshot_metrics(
+    emitter: &mut MetricEmitter,
+    node_id: &str,
+    snapshot: &NodeSnapshot,
+    config: MetricsConfig,
+) {
     let node_labels = [("node_id", node_id)];
-    emitter.gauge(
-        "nodelite_node_snapshot_timestamp_seconds",
-        "Collection time of the latest node snapshot as a Unix timestamp.",
-        &node_labels,
-        snapshot.collected_at.timestamp(),
-    );
-    emitter.gauge(
-        "nodelite_node_uptime_seconds",
-        "Node uptime in seconds from the latest snapshot.",
-        &node_labels,
-        snapshot.uptime_secs,
-    );
-    if let Some(cpu_usage_percent) = snapshot.cpu_usage_percent.filter(|value| value.is_finite()) {
+    if config.export_node_resource_metrics {
         emitter.gauge(
-            "nodelite_node_cpu_usage_ratio",
-            "Latest CPU usage ratio reported by the node in the range 0..1.",
+            "nodelite_node_snapshot_timestamp_seconds",
+            "Collection time of the latest node snapshot as a Unix timestamp.",
             &node_labels,
-            cpu_usage_percent / 100.0,
+            snapshot.collected_at.timestamp(),
         );
+        emitter.gauge(
+            "nodelite_node_uptime_seconds",
+            "Node uptime in seconds from the latest snapshot.",
+            &node_labels,
+            snapshot.uptime_secs,
+        );
+        if let Some(cpu_usage_percent) =
+            snapshot.cpu_usage_percent.filter(|value| value.is_finite())
+        {
+            emitter.gauge(
+                "nodelite_node_cpu_usage_ratio",
+                "Latest CPU usage ratio reported by the node in the range 0..1.",
+                &node_labels,
+                cpu_usage_percent / 100.0,
+            );
+        }
+        render_memory_metrics(emitter, node_id, snapshot);
+        render_load_metrics(emitter, node_id, snapshot);
+        render_network_metrics(emitter, node_id, snapshot);
     }
-    render_memory_metrics(emitter, node_id, snapshot);
-    render_load_metrics(emitter, node_id, snapshot);
-    render_network_metrics(emitter, node_id, snapshot);
+    if config.export_node_disk_metrics {
+        render_disk_metrics(emitter, node_id, snapshot);
+    }
 }
 
 fn render_memory_metrics(emitter: &mut MetricEmitter, node_id: &str, snapshot: &NodeSnapshot) {
@@ -598,6 +616,35 @@ fn render_network_metrics(emitter: &mut MetricEmitter, node_id: &str, snapshot: 
                 "Latest aggregate network transfer rate reported by the node.",
                 &[("node_id", node_id), ("direction", direction)],
                 value,
+            );
+        }
+    }
+}
+
+fn render_disk_metrics(emitter: &mut MetricEmitter, node_id: &str, snapshot: &NodeSnapshot) {
+    for disk in &snapshot.disks {
+        for (state, value) in [
+            ("total", disk.total_bytes),
+            ("used", disk.used_bytes),
+            ("available", disk.available_bytes),
+        ] {
+            emitter.gauge(
+                "nodelite_node_disk_bytes",
+                "Latest disk byte totals reported by the node.",
+                &[
+                    ("node_id", node_id),
+                    ("mount_point", &disk.mount_point),
+                    ("state", state),
+                ],
+                value,
+            );
+        }
+        if disk.used_percent.is_finite() {
+            emitter.gauge(
+                "nodelite_node_disk_used_ratio",
+                "Latest disk used ratio reported by the node in the range 0..1.",
+                &[("node_id", node_id), ("mount_point", &disk.mount_point)],
+                disk.used_percent / 100.0,
             );
         }
     }

--- a/nodelite-server/src/handlers/metrics_exporter/tests.rs
+++ b/nodelite-server/src/handlers/metrics_exporter/tests.rs
@@ -5,14 +5,14 @@ use chrono::Utc;
 use super::{
     ApiCacheMetrics, RuntimeMetrics, SqliteWalCheckpointMetrics, SqliteWalCheckpointStats,
     WriterMetrics, WsMessageMetrics, render_agent_log_metrics, render_api_cache_metrics,
-    render_metrics_response_body_bytes, render_prometheus_metrics, render_runtime_metrics,
-    render_writer_metrics,
+    render_metrics_response_body_bytes, render_prometheus_metrics,
+    render_prometheus_metrics_from_iter, render_runtime_metrics, render_writer_metrics,
 };
 use crate::ServerReadiness;
 use crate::agent_logs::AgentLogStats;
 use nodelite_proto::{
-    DiskUsage, LoadAverage, MemoryUsage, NetworkCounters, NodeIdentity, NodeSnapshot, NodeStatus,
-    OverviewData,
+    DiskUsage, LoadAverage, MemoryUsage, MetricsConfig, NetworkCounters, NodeIdentity,
+    NodeSnapshot, NodeStatus, OverviewData,
 };
 
 #[test]
@@ -23,13 +23,18 @@ fn exporter_emits_help_and_type_once_per_family() {
 
     assert_eq!(body.matches("# HELP nodelite_node_online ").count(), 1);
     assert_eq!(body.matches("# TYPE nodelite_node_online gauge").count(), 1);
+    assert_eq!(body.matches("# HELP nodelite_nodes_total ").count(), 1);
+
+    let detailed_body = render_detailed_prometheus_metrics();
     assert_eq!(
-        body.matches("# HELP nodelite_node_cpu_usage_ratio ")
+        detailed_body
+            .matches("# HELP nodelite_node_cpu_usage_ratio ")
             .count(),
         1
     );
     assert_eq!(
-        body.matches("# TYPE nodelite_node_network_bytes_total counter")
+        detailed_body
+            .matches("# TYPE nodelite_node_network_bytes_total counter")
             .count(),
         1
     );
@@ -50,9 +55,7 @@ fn exporter_uses_info_metric_for_mutable_identity_labels() {
 
 #[test]
 fn exporter_exposes_snapshot_resource_metrics_for_each_node() {
-    let readiness = ServerReadiness::new(true);
-    let overview = sample_overview();
-    let body = render_prometheus_metrics(&readiness, &sample_statuses(), &overview);
+    let body = render_detailed_prometheus_metrics();
 
     assert_eq!(
         body.lines()
@@ -76,6 +79,65 @@ fn exporter_exposes_snapshot_resource_metrics_for_each_node() {
 }
 
 #[test]
+fn exporter_omits_snapshot_resource_metrics_by_default() {
+    let readiness = ServerReadiness::new(true);
+    let overview = sample_overview();
+    let statuses = sample_statuses();
+    let body = render_prometheus_metrics(&readiness, &statuses, &overview);
+    let detailed_body = render_prometheus_metrics_from_iter(
+        &readiness,
+        statuses.iter(),
+        &overview,
+        MetricsConfig {
+            export_node_resource_metrics: true,
+            export_node_disk_metrics: true,
+        },
+    );
+
+    assert!(body.contains("nodelite_node_info{"));
+    assert!(body.contains("nodelite_node_online{node_id=\"node-1\"} 1"));
+    for metric in [
+        "nodelite_node_snapshot_timestamp_seconds{",
+        "nodelite_node_uptime_seconds{",
+        "nodelite_node_cpu_usage_ratio{",
+        "nodelite_node_memory_bytes{",
+        "nodelite_node_load_average{",
+        "nodelite_node_network_bytes_total{",
+        "nodelite_node_network_rate_bytes_per_second{",
+        "nodelite_node_disk_bytes{",
+    ] {
+        assert!(!body.contains(metric), "default /metrics exported {metric}");
+    }
+    assert!(
+        body.lines().count() + 20 < detailed_body.lines().count(),
+        "default metrics body should have far fewer node detail lines"
+    );
+}
+
+#[test]
+fn exporter_can_enable_disk_metrics_explicitly() {
+    let readiness = ServerReadiness::new(true);
+    let overview = sample_overview();
+    let statuses = sample_statuses();
+    let body = render_prometheus_metrics_from_iter(
+        &readiness,
+        statuses.iter(),
+        &overview,
+        MetricsConfig {
+            export_node_disk_metrics: true,
+            ..MetricsConfig::default()
+        },
+    );
+
+    assert!(body.contains(
+        "nodelite_node_disk_bytes{node_id=\"node-1\",mount_point=\"/\",state=\"used\"} 500"
+    ));
+    assert!(
+        body.contains("nodelite_node_disk_used_ratio{node_id=\"node-1\",mount_point=\"/\"} 0.5")
+    );
+}
+
+#[test]
 fn exporter_skips_unknown_cpu_usage() {
     let readiness = ServerReadiness::new(true);
     let overview = sample_overview();
@@ -86,7 +148,15 @@ fn exporter_skips_unknown_cpu_usage() {
         .expect("sample node should have snapshot")
         .cpu_usage_percent = None;
 
-    let body = render_prometheus_metrics(&readiness, &statuses, &overview);
+    let body = render_prometheus_metrics_from_iter(
+        &readiness,
+        statuses.iter(),
+        &overview,
+        MetricsConfig {
+            export_node_resource_metrics: true,
+            ..MetricsConfig::default()
+        },
+    );
 
     assert_eq!(
         body.lines()
@@ -96,6 +166,21 @@ fn exporter_skips_unknown_cpu_usage() {
     );
     assert!(!body.contains("nodelite_node_cpu_usage_ratio{node_id=\"node-1\""));
     assert!(body.contains("nodelite_node_cpu_usage_ratio{node_id=\"node-2\""));
+}
+
+fn render_detailed_prometheus_metrics() -> String {
+    let readiness = ServerReadiness::new(true);
+    let overview = sample_overview();
+    let statuses = sample_statuses();
+    render_prometheus_metrics_from_iter(
+        &readiness,
+        statuses.iter(),
+        &overview,
+        MetricsConfig {
+            export_node_resource_metrics: true,
+            ..MetricsConfig::default()
+        },
+    )
 }
 
 #[test]

--- a/nodelite-server/src/handlers/settings/helpers.rs
+++ b/nodelite-server/src/handlers/settings/helpers.rs
@@ -349,6 +349,7 @@ mod tests {
                 auth_fail_max_attempts: 8,
                 auth_block_secs: 900,
             },
+            metrics: nodelite_proto::MetricsConfig::default(),
             audit: nodelite_proto::AuditConfig {
                 enabled: true,
                 db_path: PathBuf::from("/opt/nodelite/data/audit.sqlite3"),

--- a/nodelite-server/src/history.rs
+++ b/nodelite-server/src/history.rs
@@ -63,7 +63,6 @@ pub type HistoryResult<T> = std::result::Result<T, HistoryError>;
 /// 历史查询路径对外暴露的稳定错误边界。
 #[derive(Debug)]
 pub enum HistoryError {
-    ConnectionNotInitialized,
     Query(anyhow::Error),
     TaskFailed(anyhow::Error),
 }
@@ -71,7 +70,6 @@ pub enum HistoryError {
 impl std::fmt::Display for HistoryError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ConnectionNotInitialized => f.write_str("history connection not initialized"),
             Self::Query(_) => f.write_str("history query failed"),
             Self::TaskFailed(_) => f.write_str("history query task failed"),
         }
@@ -82,7 +80,6 @@ impl std::error::Error for HistoryError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Query(error) | Self::TaskFailed(error) => Some(error.root_cause()),
-            Self::ConnectionNotInitialized => None,
         }
     }
 }
@@ -100,8 +97,6 @@ pub struct HistoryStore {
     available: Arc<AtomicBool>,
     /// 持久化 SQLite 写连接,由 writer task 短暂持有。
     write_connection: Arc<Mutex<Option<Connection>>>,
-    /// 持久化 SQLite 查询连接,只在 query 路径短暂持有。
-    read_connection: Arc<Mutex<Option<Connection>>>,
     /// 节点 → 上一次成功节流通过的时间。仅短暂持有 lock(check + 乐观更新),
     /// 不再跨越 spawn_blocking,因此与 SQLite I/O 解耦。
     last_written_at: Arc<Mutex<HashMap<String, DateTime<Utc>>>>,
@@ -126,7 +121,6 @@ impl HistoryStore {
             db_path: Arc::new(db_path),
             available: Arc::new(AtomicBool::new(false)),
             write_connection: Arc::new(Mutex::new(None)),
-            read_connection: Arc::new(Mutex::new(None)),
             last_written_at: Arc::new(Mutex::new(HashMap::new())),
             last_pruned_at: Arc::new(AtomicI64::new(0)),
             artifacts_hardened_after_write: Arc::new(AtomicBool::new(false)),
@@ -143,21 +137,16 @@ impl HistoryStore {
         let sqlite_busy_timeout_secs = self.sqlite_busy_timeout_secs;
         let result = tokio::task::spawn_blocking(move || {
             let write_connection = initialize_database(db_path.as_ref(), sqlite_busy_timeout_secs)?;
-            let read_connection = open_read_connection(db_path.as_ref(), sqlite_busy_timeout_secs)?;
-            anyhow::Ok((write_connection, read_connection))
+            anyhow::Ok(write_connection)
         })
         .await
         .context("history database task failed");
 
         match result {
-            Ok(Ok((write_connection, read_connection))) => {
+            Ok(Ok(write_connection)) => {
                 {
                     let mut guard = self.write_connection.lock().await;
                     *guard = Some(write_connection);
-                }
-                {
-                    let mut guard = self.read_connection.lock().await;
-                    *guard = Some(read_connection);
                 }
                 self.available.store(true, Ordering::Relaxed);
                 self.spawn_writer_task().await;
@@ -329,18 +318,17 @@ impl HistoryStore {
             return Ok(Vec::new());
         }
 
-        let connection_arc = Arc::clone(&self.read_connection);
+        let db_path = Arc::clone(&self.db_path);
         let node_id = node_id.to_string();
         let clamped_window_hours = window_hours.clamp(1, DEFAULT_HISTORY_RETENTION_HOURS);
         let clamped_max_points = max_points.max(60);
         let since = Utc::now() - chrono::Duration::hours(clamped_window_hours as i64);
+        let sqlite_busy_timeout_secs = self.sqlite_busy_timeout_secs;
 
         tokio::task::spawn_blocking(move || {
-            let guard = connection_arc.blocking_lock();
-            let Some(ref connection) = *guard else {
-                return Err(HistoryError::ConnectionNotInitialized);
-            };
-            query_history(connection, &node_id, since, clamped_max_points)
+            let connection = open_read_connection(db_path.as_ref(), sqlite_busy_timeout_secs)
+                .map_err(HistoryError::Query)?;
+            query_history(&connection, &node_id, since, clamped_max_points)
                 .map_err(HistoryError::from)
         })
         .await
@@ -367,17 +355,16 @@ impl HistoryStore {
             return Ok(Vec::new());
         }
 
-        let connection_arc = Arc::clone(&self.read_connection);
+        let db_path = Arc::clone(&self.db_path);
         let node_id = node_id.to_string();
         let clamped_max_points = max_points.max(60);
+        let sqlite_busy_timeout_secs = self.sqlite_busy_timeout_secs;
 
         tokio::task::spawn_blocking(move || {
-            let guard = connection_arc.blocking_lock();
-            let Some(ref connection) = *guard else {
-                return Err(HistoryError::ConnectionNotInitialized);
-            };
+            let connection = open_read_connection(db_path.as_ref(), sqlite_busy_timeout_secs)
+                .map_err(HistoryError::Query)?;
             query_history_between(
-                connection,
+                &connection,
                 &node_id,
                 clamped_start,
                 clamped_end,

--- a/nodelite-server/src/history/tests/init_tests.rs
+++ b/nodelite-server/src/history/tests/init_tests.rs
@@ -53,7 +53,8 @@ fn history_database_artifacts_are_mode_600() {
 
 #[tokio::test]
 async fn query_history_reports_query_error_when_read_database_is_missing() {
-    let store = HistoryStore::new(PathBuf::from("./data/history.sqlite3"), 5);
+    let db_path = temp_history_db_path("missing-query-db");
+    let store = HistoryStore::new(db_path.clone(), 5);
     store.available.store(true, Ordering::Relaxed);
 
     let error = store
@@ -62,11 +63,16 @@ async fn query_history_reports_query_error_when_read_database_is_missing() {
         .expect_err("query should surface read connection error");
 
     assert!(matches!(error, HistoryError::Query(_)));
+
+    if let Some(parent) = db_path.parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
 }
 
 #[tokio::test]
 async fn query_history_range_reports_query_error_when_read_database_is_missing() {
-    let store = HistoryStore::new(PathBuf::from("./data/history.sqlite3"), 5);
+    let db_path = temp_history_db_path("missing-range-query-db");
+    let store = HistoryStore::new(db_path.clone(), 5);
     store.available.store(true, Ordering::Relaxed);
 
     let now = Utc::now();
@@ -76,6 +82,10 @@ async fn query_history_range_reports_query_error_when_read_database_is_missing()
         .expect_err("range query should surface read connection error");
 
     assert!(matches!(error, HistoryError::Query(_)));
+
+    if let Some(parent) = db_path.parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
 }
 
 #[test]

--- a/nodelite-server/src/history/tests/init_tests.rs
+++ b/nodelite-server/src/history/tests/init_tests.rs
@@ -52,20 +52,20 @@ fn history_database_artifacts_are_mode_600() {
 }
 
 #[tokio::test]
-async fn query_history_reports_connection_not_initialized() {
+async fn query_history_reports_query_error_when_read_database_is_missing() {
     let store = HistoryStore::new(PathBuf::from("./data/history.sqlite3"), 5);
     store.available.store(true, Ordering::Relaxed);
 
     let error = store
         .query_history("hk-01", 1, 60)
         .await
-        .expect_err("query should surface typed connection error");
+        .expect_err("query should surface read connection error");
 
-    assert!(matches!(error, HistoryError::ConnectionNotInitialized));
+    assert!(matches!(error, HistoryError::Query(_)));
 }
 
 #[tokio::test]
-async fn query_history_range_reports_connection_not_initialized() {
+async fn query_history_range_reports_query_error_when_read_database_is_missing() {
     let store = HistoryStore::new(PathBuf::from("./data/history.sqlite3"), 5);
     store.available.store(true, Ordering::Relaxed);
 
@@ -73,9 +73,9 @@ async fn query_history_range_reports_connection_not_initialized() {
     let error = store
         .query_history_range("hk-01", now - Duration::hours(1), now, 60)
         .await
-        .expect_err("range query should surface typed connection error");
+        .expect_err("range query should surface read connection error");
 
-    assert!(matches!(error, HistoryError::ConnectionNotInitialized));
+    assert!(matches!(error, HistoryError::Query(_)));
 }
 
 #[test]

--- a/nodelite-server/src/history/tests/reader_tests.rs
+++ b/nodelite-server/src/history/tests/reader_tests.rs
@@ -163,3 +163,58 @@ async fn query_history_does_not_wait_for_write_connection_lock() {
         let _ = std::fs::remove_dir(parent);
     }
 }
+
+#[tokio::test]
+async fn concurrent_history_queries_use_independent_read_connections() {
+    let db_path = temp_history_db_path("query-concurrent-readers");
+    let mut connection = initialize_database(&db_path, 5).expect("database should initialize");
+    let hardened = AtomicBool::new(false);
+    let start = Utc::now() - Duration::hours(2);
+    for index in 0..240 {
+        write_history_point(
+            &db_path,
+            &mut connection,
+            &HistoryPoint {
+                node_id: "hk-01".to_string(),
+                recorded_at: start + Duration::seconds(index * 30),
+                cpu_usage_percent: Some(index as f64),
+                memory_used_percent: 50.0,
+                rx_bytes_per_sec: Some(index as f64),
+                tx_bytes_per_sec: Some(index as f64 / 2.0),
+                latency_ms: Some((index % 10) as u64),
+                disk_used_percent: Some(60.0),
+            },
+            None,
+            &hardened,
+        )
+        .expect("history point should persist");
+    }
+    drop(connection);
+
+    let store = HistoryStore::new(db_path.clone(), 5);
+    store.initialize().await;
+    assert!(store.is_available());
+
+    let end = start + Duration::seconds(240 * 30);
+    let tasks = (0..8)
+        .map(|_| {
+            let store = store.clone();
+            tokio::spawn(async move { store.query_history_range("hk-01", start, end, 120).await })
+        })
+        .collect::<Vec<_>>();
+
+    for task in tasks {
+        let points = task
+            .await
+            .expect("query task should not panic")
+            .expect("history query should succeed");
+        assert!(!points.is_empty());
+        assert!(points.len() <= 120);
+    }
+    store.shutdown().await;
+
+    let _ = std::fs::remove_file(&db_path);
+    if let Some(parent) = db_path.parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
+}

--- a/nodelite-server/src/history/tests/writer_tests.rs
+++ b/nodelite-server/src/history/tests/writer_tests.rs
@@ -61,33 +61,6 @@ async fn record_status_flushes_through_writer_task_to_sqlite() {
 }
 
 #[tokio::test]
-async fn history_writer_does_not_wait_for_read_connection_lock() {
-    let db_path = temp_history_db_path("writer-write-connection");
-    let store = HistoryStore::new(db_path.clone(), 5);
-    store.initialize().await;
-    assert!(store.is_available());
-
-    let read_guard = store.read_connection.lock().await;
-    let status = fake_status_for("hk-01", Utc::now());
-    store.record_status(&status).await;
-    tokio::time::timeout(std::time::Duration::from_secs(1), store.shutdown())
-        .await
-        .expect("writer flush should not wait for read connection lock");
-    drop(read_guard);
-
-    let connection = initialize_database(&db_path, 5).expect("re-open database");
-    let count: i64 = connection
-        .query_row("SELECT COUNT(*) FROM history_points", [], |row| row.get(0))
-        .expect("count query");
-    assert_eq!(count, 1);
-
-    let _ = std::fs::remove_file(&db_path);
-    if let Some(parent) = db_path.parent() {
-        let _ = std::fs::remove_dir(parent);
-    }
-}
-
-#[tokio::test]
 async fn record_status_does_not_throttle_after_queue_full_drop() {
     let db_path = temp_history_db_path("queue-full-throttle");
     let store = HistoryStore::new(db_path.clone(), 5);

--- a/nodelite-server/src/state.rs
+++ b/nodelite-server/src/state.rs
@@ -384,7 +384,7 @@ impl SharedState {
 
         let body = {
             let registry = self.registry.read().await;
-            Bytes::from(registry.render_metrics_body(readiness))
+            Bytes::from(registry.render_metrics_body(readiness, self.config.metrics))
         };
         self.metrics_body_bytes
             .store(body.len() as u64, Ordering::Relaxed);

--- a/nodelite-server/src/state/registry.rs
+++ b/nodelite-server/src/state/registry.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use nodelite_proto::{
-    GeoIpLocation, NodeIdentity, NodeListItem, NodeSnapshot, NodeStatus, OverviewData,
+    GeoIpLocation, MetricsConfig, NodeIdentity, NodeListItem, NodeSnapshot, NodeStatus,
+    OverviewData,
 };
 
 use super::overview::build_overview_from_iter;
@@ -271,7 +272,11 @@ impl Registry {
         build_overview_from_iter(self.nodes.values().map(|entry| &entry.status))
     }
 
-    pub(super) fn render_metrics_body(&self, readiness: &ServerReadiness) -> String {
+    pub(super) fn render_metrics_body(
+        &self,
+        readiness: &ServerReadiness,
+        metrics_config: MetricsConfig,
+    ) -> String {
         let overview = self.overview();
         render_prometheus_metrics_from_iter(
             readiness,
@@ -280,6 +285,7 @@ impl Registry {
                 .filter_map(|node_id| self.nodes.get(node_id))
                 .map(|entry| &entry.status),
             &overview,
+            metrics_config,
         )
     }
 

--- a/nodelite-server/src/state/tests/mod.rs
+++ b/nodelite-server/src/state/tests/mod.rs
@@ -51,6 +51,7 @@ fn sample_config() -> ServerConfig {
             auth_fail_max_attempts: 12,
             auth_block_secs: 900,
         },
+        metrics: nodelite_proto::MetricsConfig::default(),
         audit: nodelite_proto::AuditConfig {
             enabled: true,
             db_path: PathBuf::from("/tmp/nodelite-test-audit.sqlite3"),

--- a/nodelite-server/src/test_support.rs
+++ b/nodelite-server/src/test_support.rs
@@ -74,6 +74,7 @@ pub(crate) fn test_server_config(
             totp_secret: None,
         }),
         ws: test_ws_config(128, 128),
+        metrics: nodelite_proto::MetricsConfig::default(),
         audit: AuditConfig {
             enabled: true,
             db_path: history_path.with_file_name("audit.sqlite3"),

--- a/nodelite-server/src/tests/sanitize_snapshot_tests.rs
+++ b/nodelite-server/src/tests/sanitize_snapshot_tests.rs
@@ -28,6 +28,7 @@ fn sanitize_snapshot_clamps_invalid_metrics() {
             auth_fail_max_attempts: 6,
             auth_block_secs: 600,
         },
+        metrics: nodelite_proto::MetricsConfig::default(),
         audit: nodelite_proto::AuditConfig {
             enabled: true,
             db_path: PathBuf::from("./data/audit.sqlite3"),
@@ -199,6 +200,7 @@ fn sanitize_caps_disk_field_string_length() {
             auth_fail_max_attempts: 6,
             auth_block_secs: 600,
         },
+        metrics: nodelite_proto::MetricsConfig::default(),
         audit: nodelite_proto::AuditConfig {
             enabled: true,
             db_path: PathBuf::from("./data/audit.sqlite3"),
@@ -294,6 +296,7 @@ fn sanitize_snapshot_caps_disk_count_and_tracks_clean_reports() {
             auth_fail_max_attempts: 6,
             auth_block_secs: 600,
         },
+        metrics: nodelite_proto::MetricsConfig::default(),
         audit: nodelite_proto::AuditConfig {
             enabled: true,
             db_path: PathBuf::from("./data/audit.sqlite3"),
@@ -404,6 +407,7 @@ fn sanitize_snapshot_deduplicates_repeated_disk_devices() {
             auth_fail_max_attempts: 6,
             auth_block_secs: 600,
         },
+        metrics: nodelite_proto::MetricsConfig::default(),
         audit: nodelite_proto::AuditConfig {
             enabled: true,
             db_path: PathBuf::from("./data/audit.sqlite3"),

--- a/nodelite-server/tests/integration/metrics_collection.rs
+++ b/nodelite-server/tests/integration/metrics_collection.rs
@@ -66,9 +66,9 @@ async fn prometheus_metrics_export_reflects_current_nodes() -> Result<()> {
     assert!(metrics.contains("nodelite_node_online{node_id=\"itest-metrics-03\""));
     assert!(metrics.contains("nodelite_node_info{node_id=\"itest-metrics-02\""));
     assert!(metrics.contains("nodelite_node_info{node_id=\"itest-metrics-03\""));
-    assert!(metrics.contains("nodelite_node_snapshot_timestamp_seconds"));
-    assert!(metrics.contains("nodelite_node_cpu_usage_ratio"));
-    assert!(metrics.contains("nodelite_node_network_bytes_total"));
+    assert!(!metrics.contains("nodelite_node_snapshot_timestamp_seconds"));
+    assert!(!metrics.contains("nodelite_node_cpu_usage_ratio"));
+    assert!(!metrics.contains("nodelite_node_network_bytes_total"));
     assert!(metrics.contains("nodelite_network_rate_bytes_per_second{direction=\"rx\"}"));
     assert!(metrics.contains("nodelite_history_queue_depth"));
     assert!(metrics.contains("nodelite_audit_queue_depth"));

--- a/nodelite-server/web/src/components/NodeMap.vue
+++ b/nodelite-server/web/src/components/NodeMap.vue
@@ -138,6 +138,7 @@ watch([geojson, theme], repaint);
 }
 .map-stage {
   position: relative;
+  width: 100%;
   aspect-ratio: 16 / 8;
   min-height: 280px;
   background:
@@ -150,7 +151,8 @@ watch([geojson, theme], repaint);
 @media (max-width: 640px) {
   .map-stage {
     aspect-ratio: 16 / 10;
-    min-height: 200px;
+    min-height: 0;
+    height: clamp(160px, 45vw, 200px);
   }
 }
 .map-grid {


### PR DESCRIPTION
## Summary
- Add SMTP delivery regression coverage for protocol failure, greeting timeout, and retry exhaustion.
- Move agent host identity and snapshot collection onto the blocking pool.
- Keep default /metrics lightweight while gating detailed node resource and disk metrics behind config.
- Let history queries use independent read-only SQLite connections so readers can run concurrently.
- Fix the dashboard map mobile overflow found during browser verification.

## Issues
Closes #203
Closes #168
Closes #161
Closes #158

## Validation
- NODELITE_SKIP_WEB_BUILD=1 cargo test --workspace
- NODELITE_SKIP_WEB_BUILD=1 cargo clippy --all-targets -- -D warnings
- cargo build -p nodelite-server -p nodelite-agent
- pnpm --dir nodelite-server/web build
- Manual load tests:
  - history pressure: history_p95_ms=19.66, history_dropped_writes=0
  - payload size: metrics_body_bytes=147679/147679/147679, metrics_p95_ms=9.77, dropped writes=0
  - large fleet: 500 nodes metrics_p95_ms=4.07, 1000 nodes metrics_p95_ms=6.30
- Manual runtime verification with server plus two online agents and one offline node:
  - /api/overview reported total=3, online=2, offline=1
  - /api/nodes returned all three verification nodes
  - /api/nodes/verify-node-1/history returned recorded samples
  - default /metrics exported summary metrics only, detailed per-node CPU/disk metrics absent, nodelite_history_dropped_writes_total=0, body=10009 bytes
- Browser verification:
  - desktop 1440x900 dashboard showed sidebar, overview stats, health matrix, map, 3 node cards, online/offline states, and no horizontal overflow
  - mobile 390x844 dashboard showed the same core structure, no horizontal overflow, and map stage shrank within its card
  - fresh credentialless reload after browser verification had no new console errors