### PR TITLE
perf(server): share AlertingConfig via Arc in alert runtime

### DIFF
--- a/nodelite-server/src/alerts/runtime.rs
+++ b/nodelite-server/src/alerts/runtime.rs
@@ -27,11 +27,11 @@ const MAX_CONCURRENT_DELIVERIES: usize = 8;
 #[derive(Debug)]
 enum DeliveryJob {
     Alert {
-        config: AlertingConfig,
+        config: Arc<AlertingConfig>,
         event: AlertEvent,
     },
     Inspection {
-        config: AlertingConfig,
+        config: Arc<AlertingConfig>,
         occurred_at: DateTime<Utc>,
         local_date: NaiveDate,
         lookback_hours: u64,
@@ -42,12 +42,12 @@ enum DeliveryJob {
 #[derive(Debug)]
 enum DeliveryResult {
     Alert {
-        config: AlertingConfig,
+        config: Arc<AlertingConfig>,
         event: AlertEvent,
         result: Result<(), AlertDeliveryError>,
     },
     Inspection {
-        config: AlertingConfig,
+        config: Arc<AlertingConfig>,
         local_date: NaiveDate,
         report: InspectionReport,
         result: Result<(), AlertDeliveryError>,
@@ -55,7 +55,7 @@ enum DeliveryResult {
 }
 
 pub(crate) fn spawn_alert_runtime(
-    alerting: Arc<RwLock<AlertingConfig>>,
+    alerting: Arc<RwLock<Arc<AlertingConfig>>>,
     shared: SharedState,
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {
@@ -65,7 +65,7 @@ pub(crate) fn spawn_alert_runtime(
 }
 
 async fn run_alert_runtime(
-    alerting: Arc<RwLock<AlertingConfig>>,
+    alerting: Arc<RwLock<Arc<AlertingConfig>>>,
     shared: SharedState,
     shutdown: CancellationToken,
 ) {
@@ -89,7 +89,7 @@ async fn run_alert_runtime(
                 );
                 let config = {
                     let alerting = alerting.read().await;
-                    alerting.clone()
+                    Arc::clone(&alerting)
                 };
                 if !config.enabled {
                     tracker.clear();
@@ -216,14 +216,14 @@ fn process_delivery_results(
 fn enqueue_alert_delivery(
     delivery_tx: &mpsc::Sender<DeliveryJob>,
     tracker: &mut AlertStateTracker,
-    config: &AlertingConfig,
+    config: &Arc<AlertingConfig>,
     event: &AlertEvent,
     now: DateTime<Utc>,
 ) {
     if try_enqueue(
         delivery_tx,
         DeliveryJob::Alert {
-            config: config.clone(),
+            config: Arc::clone(config),
             event: event.clone(),
         },
     )
@@ -243,7 +243,7 @@ fn enqueue_alert_delivery(
 fn enqueue_inspection_delivery(
     delivery_tx: &mpsc::Sender<DeliveryJob>,
     inspection_dispatch: &mut InspectionDispatchState,
-    config: &AlertingConfig,
+    config: &Arc<AlertingConfig>,
     report: InspectionReport,
     local_date: NaiveDate,
     now: DateTime<Utc>,
@@ -251,7 +251,7 @@ fn enqueue_inspection_delivery(
     if try_enqueue(
         delivery_tx,
         DeliveryJob::Inspection {
-            config: config.clone(),
+            config: Arc::clone(config),
             occurred_at: now,
             local_date,
             lookback_hours: config.inspection.lookback_hours,
@@ -276,7 +276,7 @@ fn enqueue_inspection_delivery(
 fn handle_alert_delivery_result(
     tracker: &mut AlertStateTracker,
     delivery_tx: &mpsc::Sender<DeliveryJob>,
-    config: &AlertingConfig,
+    config: &Arc<AlertingConfig>,
     event: &AlertEvent,
     result: Result<(), AlertDeliveryError>,
 ) {

--- a/nodelite-server/src/app_state.rs
+++ b/nodelite-server/src/app_state.rs
@@ -41,7 +41,9 @@ pub(crate) struct AppState {
     /// 同型但实例独立,使浏览器连接与 agent 连接各自计数、互不挤占配额。
     pub(crate) browser_ws_admission: WsAdmissionController,
     pub(crate) readonly_auth: Arc<RwLock<ReadonlyRouteAuth>>,
-    pub(crate) alerting: Arc<RwLock<AlertingConfig>>,
+    /// 内层 `Arc` 让告警运行时和投递任务以指针克隆共享配置快照,
+    /// 更新时整体替换内层 `Arc`(见 `handlers/settings/alerts.rs`)。
+    pub(crate) alerting: Arc<RwLock<Arc<AlertingConfig>>>,
     pub(crate) two_factor_sessions: TwoFactorSessions,
     pub(crate) config_path: Arc<PathBuf>,
     /// 进程级关停信号。axum graceful shutdown 之后由 `run_server` 触发,
@@ -132,7 +134,7 @@ impl AppState {
             readonly_auth: Arc::new(RwLock::new(ReadonlyRouteAuth::from_config(
                 config.readonly_auth.clone(),
             ))),
-            alerting: Arc::new(RwLock::new(config.alerting.clone())),
+            alerting: Arc::new(RwLock::new(Arc::new(config.alerting.clone()))),
             two_factor_sessions: TwoFactorSessions::new(),
             config_path,
             shutdown: CancellationToken::new(),

--- a/nodelite-server/src/handlers/settings/alerts.rs
+++ b/nodelite-server/src/handlers/settings/alerts.rs
@@ -60,7 +60,7 @@ pub(crate) async fn update_alert_settings(
 
     {
         let mut alerting = state.alerting.write().await;
-        *alerting = next_config;
+        *alerting = std::sync::Arc::new(next_config);
     }
 
     Json(build_alert_settings_response(&state).await).into_response()
@@ -69,7 +69,7 @@ pub(crate) async fn update_alert_settings(
 async fn build_alert_settings_response(state: &AppState) -> AlertSettingsResponse {
     let alerting = {
         let alerting = state.alerting.read().await;
-        alerting.clone()
+        std::sync::Arc::clone(&alerting)
     };
     let statuses = state.shared.list_statuses().await;
     AlertSettingsResponse {

--- a/nodelite-server/src/startup.rs
+++ b/nodelite-server/src/startup.rs
@@ -175,7 +175,7 @@ async fn initialize_server_runtime(
         ws_admission: WsAdmissionController::new(&config.ws),
         browser_ws_admission: WsAdmissionController::new(&config.ws),
         readonly_auth: Arc::new(RwLock::new(readonly_route_auth)),
-        alerting: Arc::new(RwLock::new(config.alerting.clone())),
+        alerting: Arc::new(RwLock::new(Arc::new(config.alerting.clone()))),
         two_factor_sessions: TwoFactorSessions::new(),
         config_path: Arc::new(config_path.to_path_buf()),
         shutdown,


### PR DESCRIPTION
## Summary
- 告警运行时每 30s tick 和每个投递 job 此前都会深克隆整份 `AlertingConfig`（含规则、SMTP 凭证、webhook 配置）
- 将 `AppState.alerting` 从 `Arc<RwLock<AlertingConfig>>` 改为 `Arc<RwLock<Arc<AlertingConfig>>>`：读取和投递 job 传递均为指针克隆，设置更新时整体替换内层 `Arc`
- 对应项目报告 `report/project-report-2026-06-11.md` 性能项 #3

## Test plan
- [x] `cargo test -p nodelite-server alerts`（41 passed）
- [x] `cargo test -p nodelite-server settings`（36 passed）
- [x] `cargo clippy --all-targets` 零警告
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)