### PR TITLE
test(ws): browser push safety net before centralized diff rewrite

### DIFF
--- a/nodelite-server/src/test_support.rs
+++ b/nodelite-server/src/test_support.rs
@@ -632,6 +632,15 @@ impl TestBrowserClient {
         .context("timed out waiting for matching browser message")?
     }
 
+    /// 断言给定窗口内服务端没有推送任何 `BrowserMessage`(用于静默期验证)。
+    pub async fn expect_no_message(&mut self, window: Duration) -> Result<()> {
+        match timeout(window, self.next_message(window * 2)).await {
+            Err(_) => Ok(()),
+            Ok(Ok(message)) => bail!("expected no browser message within window, got {message:?}"),
+            Ok(Err(error)) => Err(error).context("browser ws failed while expecting silence"),
+        }
+    }
+
     /// 发送应用层 `Ping`。
     pub async fn send_ping(&mut self) -> Result<()> {
         let payload = serde_json::to_string(&BrowserMessage::Ping).context("encode ping")?;

--- a/nodelite-server/src/ws/browser.rs
+++ b/nodelite-server/src/ws/browser.rs
@@ -262,3 +262,158 @@ async fn send_browser_message(
         .await
         .map_err(|error| anyhow!("failed to send browser message: {error}"))
 }
+
+#[cfg(test)]
+mod tests {
+    use nodelite_proto::NodeListIdentity;
+
+    use super::*;
+
+    fn list_item(node_id: &str) -> NodeListItem {
+        NodeListItem {
+            identity: NodeListIdentity {
+                node_id: node_id.to_string(),
+                node_label: format!("{node_id} label"),
+                hostname: format!("{node_id}.internal"),
+                tags: Vec::new(),
+            },
+            geoip_country: None,
+            geoip_city: None,
+            geoip_latitude: None,
+            geoip_longitude: None,
+            location_override_country: None,
+            location_override_city: None,
+            location_override_latitude: None,
+            location_override_longitude: None,
+            snapshot: None,
+            latency_ms: None,
+            online: true,
+        }
+    }
+
+    fn upsert_ids<'a>(diff: &NodeListDiff<'a>) -> Vec<&'a str> {
+        diff.upserts
+            .iter()
+            .map(|node| node.identity.node_id.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn diff_reports_new_node_as_upsert() {
+        let last = HashMap::new();
+        let current = vec![list_item("hk-01")];
+
+        let diff = diff_node_lists(&last, &current);
+
+        assert_eq!(upsert_ids(&diff), vec!["hk-01"]);
+        assert!(diff.removed.is_empty());
+    }
+
+    #[test]
+    fn diff_reports_changed_node_as_upsert() {
+        let last = index_by_node_id(vec![list_item("hk-01")]);
+        let mut changed = list_item("hk-01");
+        changed.latency_ms = Some(42);
+        let current = vec![changed];
+
+        let diff = diff_node_lists(&last, &current);
+
+        assert_eq!(upsert_ids(&diff), vec!["hk-01"]);
+        assert!(diff.removed.is_empty());
+    }
+
+    #[test]
+    fn diff_skips_unchanged_node() {
+        let last = index_by_node_id(vec![list_item("hk-01")]);
+        let current = vec![list_item("hk-01")];
+
+        let diff = diff_node_lists(&last, &current);
+
+        assert!(diff.upserts.is_empty());
+        assert!(diff.removed.is_empty());
+    }
+
+    #[test]
+    fn diff_reports_missing_node_as_removed() {
+        let last = index_by_node_id(vec![list_item("hk-01"), list_item("jp-01")]);
+        let current = vec![list_item("hk-01")];
+
+        let diff = diff_node_lists(&last, &current);
+
+        assert!(diff.upserts.is_empty());
+        assert_eq!(diff.removed, vec!["jp-01".to_string()]);
+    }
+
+    #[test]
+    fn diff_handles_mixed_changes_in_one_pass() {
+        let last = index_by_node_id(vec![
+            list_item("unchanged"),
+            list_item("changed"),
+            list_item("removed"),
+        ]);
+        let mut changed = list_item("changed");
+        changed.online = false;
+        let current = vec![list_item("unchanged"), changed, list_item("added")];
+
+        let diff = diff_node_lists(&last, &current);
+
+        assert_eq!(upsert_ids(&diff), vec!["changed", "added"]);
+        assert_eq!(diff.removed, vec!["removed".to_string()]);
+    }
+
+    #[test]
+    fn diff_of_two_empty_lists_is_empty() {
+        let diff = diff_node_lists(&HashMap::new(), &[]);
+
+        assert!(diff.upserts.is_empty());
+        assert!(diff.removed.is_empty());
+    }
+
+    #[test]
+    fn index_by_node_id_keys_each_item_by_its_id() {
+        let indexed = index_by_node_id(vec![list_item("hk-01"), list_item("jp-01")]);
+
+        assert_eq!(indexed.len(), 2);
+        assert_eq!(indexed["hk-01"].identity.node_id, "hk-01");
+        assert_eq!(indexed["jp-01"].identity.node_id, "jp-01");
+    }
+
+    #[test]
+    fn classify_replies_pong_to_app_level_ping() {
+        let payload = serde_json::to_string(&BrowserMessage::Ping).expect("ping should serialize");
+
+        let action = classify_client_message(&Message::Text(payload.into()));
+
+        assert_eq!(action, ClientAction::ReplyPong);
+    }
+
+    #[test]
+    fn classify_ignores_other_browser_messages() {
+        let payload = serde_json::to_string(&BrowserMessage::Pong).expect("pong should serialize");
+
+        let action = classify_client_message(&Message::Text(payload.into()));
+
+        assert_eq!(action, ClientAction::Ignore);
+    }
+
+    #[test]
+    fn classify_ignores_invalid_json_text() {
+        let action = classify_client_message(&Message::Text("{not-json}".into()));
+
+        assert_eq!(action, ClientAction::Ignore);
+    }
+
+    #[test]
+    fn classify_ignores_binary_frames() {
+        let action = classify_client_message(&Message::Binary(vec![1, 2, 3].into()));
+
+        assert_eq!(action, ClientAction::Ignore);
+    }
+
+    #[test]
+    fn classify_ends_session_on_close_frame() {
+        let action = classify_client_message(&Message::Close(None));
+
+        assert_eq!(action, ClientAction::End);
+    }
+}

--- a/nodelite-server/src/ws/browser.rs
+++ b/nodelite-server/src/ws/browser.rs
@@ -115,20 +115,43 @@ async fn run_browser_session(shared: SharedState, socket: WebSocket) -> anyhow::
     }
 }
 
-/// 处理客户端发来的消息。返回 `true` 表示应结束会话。
-///
-/// 浏览器只会发应用层 `Ping`;其它文本消息一律忽略(协议向前兼容)。协议级
-/// Ping/Pong 帧由底层自动应答,这里收到也忽略。
-async fn handle_client_message(sender: &mut BrowserSink, message: Message) -> anyhow::Result<bool> {
+/// 客户端入站消息的处理决策,由 [`classify_client_message`] 纯函数推导。
+#[derive(Debug, PartialEq, Eq)]
+enum ClientAction {
+    /// 应用层 `Ping` → 回 `Pong`。
+    ReplyPong,
+    /// 客户端发起关闭 → 结束会话。
+    End,
+    /// 其它消息一律忽略(协议向前兼容;协议级 Ping/Pong 帧由底层自动应答)。
+    Ignore,
+}
+
+fn classify_client_message(message: &Message) -> ClientAction {
     match message {
         Message::Text(text) => {
-            if let Ok(BrowserMessage::Ping) = serde_json::from_str::<BrowserMessage>(&text) {
-                send_browser_message(sender, &BrowserMessage::Pong).await?;
+            if matches!(
+                serde_json::from_str::<BrowserMessage>(text.as_str()),
+                Ok(BrowserMessage::Ping)
+            ) {
+                ClientAction::ReplyPong
+            } else {
+                ClientAction::Ignore
             }
+        }
+        Message::Close(_) => ClientAction::End,
+        _ => ClientAction::Ignore,
+    }
+}
+
+/// 处理客户端发来的消息。返回 `true` 表示应结束会话。
+async fn handle_client_message(sender: &mut BrowserSink, message: Message) -> anyhow::Result<bool> {
+    match classify_client_message(&message) {
+        ClientAction::ReplyPong => {
+            send_browser_message(sender, &BrowserMessage::Pong).await?;
             Ok(false)
         }
-        Message::Close(_) => Ok(true),
-        _ => Ok(false),
+        ClientAction::End => Ok(true),
+        ClientAction::Ignore => Ok(false),
     }
 }
 
@@ -148,6 +171,34 @@ async fn send_initial_state(
     Ok(index_by_node_id(nodes))
 }
 
+/// 一次重算相对上次发送快照的增量:新增/变更的行 + 消失的行 id。
+struct NodeListDiff<'a> {
+    upserts: Vec<&'a NodeListItem>,
+    removed: Vec<String>,
+}
+
+/// 与上次发送的快照逐行对比:内容不同(或新出现)的行进 `upserts`,
+/// 上次有、这次没有的 id 进 `removed`。行内容未变时不产生任何输出。
+fn diff_node_lists<'a>(
+    last_nodes: &HashMap<String, NodeListItem>,
+    current: &'a [NodeListItem],
+) -> NodeListDiff<'a> {
+    let mut seen: HashSet<&str> = HashSet::with_capacity(current.len());
+    let mut upserts = Vec::new();
+    for node in current {
+        seen.insert(node.identity.node_id.as_str());
+        if last_nodes.get(&node.identity.node_id) != Some(node) {
+            upserts.push(node);
+        }
+    }
+    let removed = last_nodes
+        .keys()
+        .filter(|id| !seen.contains(id.as_str()))
+        .cloned()
+        .collect();
+    NodeListDiff { upserts, removed }
+}
+
 /// 重算当前节点列表,与上次发送的快照 diff,发出增量 + 概览更新。
 async fn push_incremental_updates(
     shared: &SharedState,
@@ -157,28 +208,17 @@ async fn push_incremental_updates(
     let current = shared.list_node_summaries().await;
     let generated_at = Utc::now();
 
-    // 新增 / 变更的行 → NodeUpsert。
-    let mut seen: HashSet<String> = HashSet::with_capacity(current.len());
-    for node in &current {
-        seen.insert(node.identity.node_id.clone());
-        if last_nodes.get(&node.identity.node_id) != Some(node) {
-            send_browser_message(
-                sender,
-                &BrowserMessage::NodeUpsert {
-                    generated_at,
-                    node: Box::new(node.clone()),
-                },
-            )
-            .await?;
-        }
+    let NodeListDiff { upserts, removed } = diff_node_lists(last_nodes, &current);
+    for node in upserts {
+        send_browser_message(
+            sender,
+            &BrowserMessage::NodeUpsert {
+                generated_at,
+                node: Box::new(node.clone()),
+            },
+        )
+        .await?;
     }
-
-    // 上次有、这次没有的行 → NodeRemoved。
-    let removed: Vec<String> = last_nodes
-        .keys()
-        .filter(|id| !seen.contains(*id))
-        .cloned()
-        .collect();
     for node_id in removed {
         send_browser_message(
             sender,

--- a/nodelite-server/tests/integration/browser_websocket.rs
+++ b/nodelite-server/tests/integration/browser_websocket.rs
@@ -69,6 +69,120 @@ async fn browser_ws_pushes_node_upsert_when_agent_registers() -> Result<()> {
     server.shutdown().await
 }
 
+/// 节点内容变化后,浏览器应收到同一节点的第二条 `NodeUpsert`(增量更新,而非只推一次)。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn browser_ws_pushes_second_upsert_when_node_changes() -> Result<()> {
+    let server = TestServer::start().await?;
+    let mut browser = TestBrowserClient::connect(&server).await?;
+    let initial = browser.next_message(TEST_TIMEOUT).await?;
+    assert!(matches!(initial, BrowserMessage::InitialState { .. }));
+
+    let node = server
+        .issue_node("itest-browser-change", "Integration Browser Change")
+        .await?;
+    let mut agent = TestAgent::connect(&server, &node).await?;
+
+    // 第一次上报 → 第一条 NodeUpsert。先等到它,确保 uptime=2 的上报落在下一个 diff 周期。
+    // fake_snapshot(n) 的 cpu_usage_percent = 12.5 + n%7,可精确区分两次上报。
+    agent.send_fake_metrics(1).await?;
+    browser
+        .next_matching(TEST_TIMEOUT, |message| {
+            matches!(
+                message,
+                BrowserMessage::NodeUpsert { node, .. }
+                    if node.identity.node_id == "itest-browser-change"
+                        && node.snapshot.as_ref().is_some_and(|s| s.cpu_usage_percent == Some(13.5))
+            )
+        })
+        .await?;
+
+    // 内容变化的第二次上报 → 必须再次收到该节点的 NodeUpsert,携带新快照。
+    agent.send_fake_metrics(2).await?;
+    let upsert = browser
+        .next_matching(TEST_TIMEOUT, |message| {
+            matches!(
+                message,
+                BrowserMessage::NodeUpsert { node, .. }
+                    if node.identity.node_id == "itest-browser-change"
+            )
+        })
+        .await?;
+    match upsert {
+        BrowserMessage::NodeUpsert { node, .. } => {
+            assert_eq!(
+                node.snapshot.as_ref().and_then(|s| s.cpu_usage_percent),
+                Some(14.5),
+                "second upsert should carry the updated snapshot"
+            );
+        }
+        other => panic!("expected NodeUpsert, got {other:?}"),
+    }
+
+    agent.disconnect().await?;
+    browser.close().await?;
+    server.shutdown().await
+}
+
+/// agent 断开后,浏览器应收到该节点 `online == false` 的增量 `NodeUpsert`。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn browser_ws_pushes_offline_upsert_when_agent_disconnects() -> Result<()> {
+    let server = TestServer::start().await?;
+    let mut browser = TestBrowserClient::connect(&server).await?;
+    let initial = browser.next_message(TEST_TIMEOUT).await?;
+    assert!(matches!(initial, BrowserMessage::InitialState { .. }));
+
+    let node = server
+        .issue_node("itest-browser-offline", "Integration Browser Offline")
+        .await?;
+    let mut agent = TestAgent::connect(&server, &node).await?;
+    agent.send_fake_metrics(1).await?;
+    browser
+        .next_matching(TEST_TIMEOUT, |message| {
+            matches!(
+                message,
+                BrowserMessage::NodeUpsert { node, .. }
+                    if node.identity.node_id == "itest-browser-offline" && node.online
+            )
+        })
+        .await?;
+
+    agent.disconnect().await?;
+    server
+        .wait_for_node_offline("itest-browser-offline", LIVE_REFRESH_TIMEOUT)
+        .await?;
+
+    let offline = browser
+        .next_matching(LIVE_REFRESH_TIMEOUT, |message| {
+            matches!(
+                message,
+                BrowserMessage::NodeUpsert { node, .. }
+                    if node.identity.node_id == "itest-browser-offline" && !node.online
+            )
+        })
+        .await?;
+    assert!(matches!(offline, BrowserMessage::NodeUpsert { .. }));
+
+    browser.close().await?;
+    server.shutdown().await
+}
+
+/// 没有任何节点变化时,去抖 tick 不应产生消息:InitialState 之后保持静默。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn browser_ws_stays_silent_without_node_changes() -> Result<()> {
+    let server = TestServer::start().await?;
+    let mut browser = TestBrowserClient::connect(&server).await?;
+    let initial = browser.next_message(TEST_TIMEOUT).await?;
+    assert!(matches!(initial, BrowserMessage::InitialState { .. }));
+
+    // 覆盖至少两个去抖周期(1s/次):dirty=false 的 tick 不得发任何增量或概览。
+    browser
+        .expect_no_message(std::time::Duration::from_millis(2500))
+        .await?;
+
+    browser.close().await?;
+    server.shutdown().await
+}
+
 /// 客户端发送应用层 `Ping`,服务端必须回 `Pong`。
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn browser_ws_replies_pong_to_ping() -> Result<()> {


### PR DESCRIPTION
## Summary

性能优化 #1(浏览器 diff 集中广播)动手前的测试安全网:先把 `ws/browser.rs` 的核心逻辑锁进可直接断言的测试,重写时行为契约不漂移。

- **refactor(d43e767)**:从会话 IO 路径中机械提取两个纯函数,行为不变
  - `diff_node_lists`:上次发送快照 vs 当前列表 → `NodeListDiff { upserts, removed }`
  - `classify_client_message`:入站帧 → `ReplyPong / End / Ignore`
- **unit tests(4bf3528)**:12 条直接单测覆盖 diff(新增/变更/不变/移除/混合/双空)、`index_by_node_id`、消息分类(Ping/其它消息/非法 JSON/二进制帧/Close)
  - 其中 `NodeRemoved` 路径目前没有任何生产删除入口能从集成层触达,单测是它唯一的行为锚点
- **integration tests(8db5624)**:3 条端到端契约
  - 节点内容变化 → 同一节点收到第二条 `NodeUpsert`(携带新快照)
  - agent 断开 → 收到 `online=false` 的增量 `NodeUpsert`
  - 无任何变化 → 跨多个去抖周期保持静默(不发增量/概览)
  - 配套在 `TestBrowserClient` 上新增 `expect_no_message` 辅助

## Test plan

- [x] `cargo test -p nodelite-server --lib browser` — 单测 12 条 + 集成 7 条全过
- [x] `cargo test --workspace` — 全量通过(一次并行运行中 `spawn_server_update_uses_systemd_when_available` 偶发失败,隔离重跑与全量重跑均通过,系既有偶发,与本分支无关)
- [x] `cargo clippy --workspace --all-targets` 无告警;`cargo fmt --all` 无变更

🤖 Generated with [Claude Code](https://claude.com/claude-code)