### PR TITLE
refactor(ui): split node detail models and harden runtime guards

### DIFF
--- a/nodelite-server/web/e2e/auto-logout-24h.spec.ts
+++ b/nodelite-server/web/e2e/auto-logout-24h.spec.ts
@@ -17,3 +17,19 @@ test('client triggers logout-and-reauth after 24h', async ({ page }) => {
   await page.waitForURL('**/logout-and-reauth', { timeout: 5000 });
   await expect(page).toHaveURL(/\/logout-and-reauth$/);
 });
+
+test('client triggers logout-and-reauth when auth storage is unavailable', async ({ page }) => {
+  await page.addInitScript(() => {
+    const storageBlocked = () => {
+      throw new Error('storage blocked');
+    };
+
+    Storage.prototype.getItem = storageBlocked;
+    Storage.prototype.setItem = storageBlocked;
+    Storage.prototype.removeItem = storageBlocked;
+  });
+
+  await page.goto('/', { waitUntil: 'commit' });
+  await page.waitForURL('**/logout-and-reauth', { timeout: 5000 });
+  await expect(page).toHaveURL(/\/logout-and-reauth$/);
+});

--- a/nodelite-server/web/index.html
+++ b/nodelite-server/web/index.html
@@ -6,7 +6,7 @@
     <link rel="preload" as="image" href="/assets/brand-logo-dark.png" />
     <link rel="preload" as="image" href="/assets/brand-logo-light.png" />
     <title>NodeLite</title>
-    <script>(function(){try{var t=localStorage.getItem('nodelite.ui.theme');document.documentElement.dataset.theme=t==='light'?'light':'dark'}catch(e){document.documentElement.dataset.theme='dark'}try{var k='nodelite.auth.timestamp',r=localStorage.getItem(k),n=Date.now();if(r!==null){var s=parseInt(r,10);if(isFinite(s)&&n-s>86400000){localStorage.removeItem(k);location.assign('/logout-and-reauth');return}}localStorage.setItem(k,n.toString())}catch(e){}})();</script>
+    <script>(function(){try{var t=localStorage.getItem('nodelite.ui.theme');document.documentElement.dataset.theme=t==='light'?'light':'dark'}catch(e){document.documentElement.dataset.theme='dark'}try{var k='nodelite.auth.timestamp',r=localStorage.getItem(k),n=Date.now();if(r!==null){var s=parseInt(r,10);if(isFinite(s)&&n-s>86400000){localStorage.removeItem(k);location.assign('/logout-and-reauth');return}}localStorage.setItem(k,n.toString())}catch(e){location.assign('/logout-and-reauth');return}})();</script>
   </head>
   <body>
     <div id="app"></div>

--- a/nodelite-server/web/src/auth/expiry.spec.ts
+++ b/nodelite-server/web/src/auth/expiry.spec.ts
@@ -1,10 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  AUTH_EXPIRY_MS,
-  AUTH_TIMESTAMP_KEY,
-  LOGOUT_PATH,
-  checkAuthExpiry,
-} from './expiry';
+import { AUTH_EXPIRY_MS, AUTH_TIMESTAMP_KEY, LOGOUT_PATH, checkAuthExpiry } from './expiry';
 
 describe('checkAuthExpiry', () => {
   let assignSpy: ReturnType<typeof vi.fn>;
@@ -22,6 +17,7 @@ describe('checkAuthExpiry', () => {
 
   afterEach(() => {
     window.localStorage.clear();
+    vi.restoreAllMocks();
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: originalLocation,
@@ -70,5 +66,23 @@ describe('checkAuthExpiry', () => {
     expect(checkAuthExpiry()).toBe(true);
     expect(window.localStorage.getItem(AUTH_TIMESTAMP_KEY)).toBe('1700000000000');
     expect(assignSpy).not.toHaveBeenCalled();
+  });
+
+  it('redirects when localStorage cannot be read', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage blocked');
+    });
+
+    expect(checkAuthExpiry()).toBe(false);
+    expect(assignSpy).toHaveBeenCalledWith(LOGOUT_PATH);
+  });
+
+  it('redirects when localStorage cannot be updated', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage blocked');
+    });
+
+    expect(checkAuthExpiry()).toBe(false);
+    expect(assignSpy).toHaveBeenCalledWith(LOGOUT_PATH);
   });
 });

--- a/nodelite-server/web/src/auth/expiry.ts
+++ b/nodelite-server/web/src/auth/expiry.ts
@@ -31,8 +31,7 @@ export function checkAuthExpiry(): boolean {
     window.localStorage.setItem(AUTH_TIMESTAMP_KEY, now.toString());
     return true;
   } catch {
-    // localStorage unavailable — fail open (don't lock the user out of a
-    // working session because of private-browsing mode).
-    return true;
+    window.location.assign(LOGOUT_PATH);
+    return false;
   }
 }

--- a/nodelite-server/web/src/components/NodeHardwarePanel.vue
+++ b/nodelite-server/web/src/components/NodeHardwarePanel.vue
@@ -1,189 +1,14 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import type { DiskUsage, NodeStatus } from '@/api';
-import { totalDiskBytes, uniqueDisks, usedDiskBytes } from '@/lib/disks';
-import { fmtBytes, fmtLatency, uptimeParts } from '@/lib/format';
+import type { NodeStatus } from '@/api';
+import { buildNodeHardwareModel } from '@/lib/nodeHardwareModel';
 
 const props = defineProps<{ node: NodeStatus | null }>();
 
 const { t } = useI18n();
 
-function fallback(value: string | null | undefined): string {
-  return value || t('common.not_available');
-}
-
-function percentText(value: number | null | undefined): string {
-  if (value == null || !Number.isFinite(Number(value))) return '—';
-  return `${Math.round(Number(value))}%`;
-}
-
-function clampPercent(value: number | null | undefined): number {
-  if (value == null || !Number.isFinite(Number(value))) return 0;
-  return Math.max(0, Math.min(100, Number(value)));
-}
-
-function uptimeText(seconds: number | null | undefined): string {
-  const parts = uptimeParts(seconds);
-  if (!parts) return t('common.not_available');
-  const named = { days: parts.days, hours: parts.hours, minutes: parts.minutes };
-  if (parts.days > 0) return t('node.uptime.days_hours', named);
-  if (parts.hours > 0) return t('node.uptime.hours_minutes', named);
-  return t('node.uptime.minutes', named);
-}
-
-function severity(value: number | null | undefined): 'ok' | 'warn' | 'bad' {
-  if (value == null || !Number.isFinite(Number(value))) return 'ok';
-  if (value >= 90) return 'bad';
-  if (value >= 75) return 'warn';
-  return 'ok';
-}
-
-function diskCapacity(disk: DiskUsage): string {
-  return `${fmtBytes(disk.used_bytes) ?? '—'} / ${fmtBytes(disk.total_bytes) ?? '—'}`;
-}
-
-const snapshot = computed(() => props.node?.snapshot ?? null);
-const identity = computed(() => props.node?.identity ?? null);
-const disks = computed(() => uniqueDisks(snapshot.value?.disks));
-const totalDisk = computed(() => totalDiskBytes(disks.value));
-const usedDisk = computed(() => usedDiskBytes(disks.value));
-const availableDisk = computed(() => Math.max(0, totalDisk.value - usedDisk.value));
-const diskPercent = computed(() => (totalDisk.value ? (usedDisk.value / totalDisk.value) * 100 : null));
-const memoryPercent = computed(() => {
-  const memory = snapshot.value?.memory;
-  return memory?.total_bytes ? (memory.used_bytes / memory.total_bytes) * 100 : null;
-});
-const swapPercent = computed(() => {
-  const memory = snapshot.value?.memory;
-  return memory?.swap_total_bytes ? (memory.swap_used_bytes / memory.swap_total_bytes) * 100 : null;
-});
-
-const filesystemRows = computed(() => {
-  const totals = new Map<string, { total: number; used: number; count: number }>();
-  for (const disk of disks.value) {
-    const key = disk.fs_type || t('common.unknown');
-    const current = totals.get(key) ?? { total: 0, used: 0, count: 0 };
-    current.total += disk.total_bytes || 0;
-    current.used += disk.used_bytes || 0;
-    current.count += 1;
-    totals.set(key, current);
-  }
-  return [...totals.entries()].map(([name, row]) => ({
-    name,
-    count: row.count,
-    total: fmtBytes(row.total) ?? '—',
-    pct: totalDisk.value ? (row.total / totalDisk.value) * 100 : 0,
-  }));
-});
-
-const specRows = computed(() => [
-  { label: t('node.info.os'), value: identity.value?.os || t('common.unknown_os') },
-  { label: t('node.info.kernel'), value: fallback(identity.value?.kernel_version) },
-  {
-    label: t('node.info.cpu'),
-    value: identity.value?.cpu_model
-      ? `${identity.value.cpu_cores} ${t('node.hardware.cores')} · ${identity.value.cpu_model}`
-      : t('common.unknown'),
-  },
-  {
-    label: t('node.info.memory'),
-    value: fmtBytes(snapshot.value?.memory.total_bytes) ?? t('common.not_available'),
-  },
-  { label: t('node.info.virtualization'), value: fallback(identity.value?.agent_version) },
-  { label: t('node.info.uptime'), value: uptimeText(snapshot.value?.uptime_secs) },
-]);
-
-const summaryCards = computed(() => [
-  {
-    key: 'cpu',
-    label: t('node.stats.cpu'),
-    value: identity.value?.cpu_model ?? t('common.unknown'),
-    sub: `${identity.value?.cpu_cores ?? 0} ${t('node.hardware.cores')} · ${percentText(snapshot.value?.cpu_usage_percent)}`,
-    tone: 'blue',
-    bar: clampPercent(snapshot.value?.cpu_usage_percent),
-  },
-  {
-    key: 'memory',
-    label: t('node.stats.memory'),
-    value: fmtBytes(snapshot.value?.memory.total_bytes) ?? '—',
-    sub: `${fmtBytes(snapshot.value?.memory.used_bytes) ?? '—'} ${t('node.hardware.used')} · ${percentText(memoryPercent.value)}`,
-    tone: 'green',
-    bar: clampPercent(memoryPercent.value),
-  },
-  {
-    key: 'swap',
-    label: t('node.stats.swap'),
-    value: fmtBytes(snapshot.value?.memory.swap_total_bytes) ?? '—',
-    sub: snapshot.value?.memory.swap_total_bytes
-      ? `${fmtBytes(snapshot.value.memory.swap_used_bytes) ?? '—'} ${t('node.hardware.used')} · ${percentText(swapPercent.value)}`
-      : t('common.not_available'),
-    tone: 'neutral',
-    bar: clampPercent(swapPercent.value),
-  },
-  {
-    key: 'load',
-    label: t('node.stats.load'),
-    value: snapshot.value
-      ? `${snapshot.value.load.one.toFixed(2)} / ${snapshot.value.load.five.toFixed(2)} / ${snapshot.value.load.fifteen.toFixed(2)}`
-      : '—',
-    sub: t('node.hardware.load_hint'),
-    tone: 'neutral',
-    bar: null,
-  },
-  {
-    key: 'latency',
-    label: t('node.stats.latency'),
-    value: fmtLatency(props.node?.latency_ms) ?? '—',
-    sub: props.node?.online ? t('common.online') : t('common.offline'),
-    tone: props.node?.online ? 'green' : 'red',
-    bar: null,
-  },
-]);
-
-const diskRows = computed(() =>
-  disks.value.map((disk) => ({
-    device: disk.device,
-    mount: disk.mount_point || '—',
-    fs: disk.fs_type || '—',
-    pct: disk.used_percent ?? 0,
-    capacity: diskCapacity(disk),
-    severity: severity(disk.used_percent),
-  })),
-);
-
-const healthRows = computed(() => [
-  {
-    label: t('node.hardware.health.status'),
-    value: props.node?.online ? t('common.online') : t('common.offline'),
-    state: props.node?.online ? 'ok' : 'bad',
-  },
-  {
-    label: t('node.cpu_usage'),
-    value: percentText(snapshot.value?.cpu_usage_percent),
-    state: severity(snapshot.value?.cpu_usage_percent),
-  },
-  {
-    label: t('node.memory_usage'),
-    value: percentText(memoryPercent.value),
-    state: severity(memoryPercent.value),
-  },
-  {
-    label: t('node.disk_usage'),
-    value: percentText(diskPercent.value),
-    state: severity(diskPercent.value),
-  },
-  {
-    label: t('node.stats.latency'),
-    value: fmtLatency(props.node?.latency_ms) ?? '—',
-    state: props.node?.latency_ms != null && props.node.latency_ms > 200 ? 'warn' : 'ok',
-  },
-  {
-    label: t('node.hardware.partitions'),
-    value: `${disks.value.length}`,
-    state: 'ok',
-  },
-]);
+const model = computed(() => buildNodeHardwareModel(props.node, t));
 </script>
 
 <template>
@@ -195,7 +20,7 @@ const healthRows = computed(() => [
           <strong>{{ t('node.info.title') }}</strong>
         </header>
         <div class="spec-rows">
-          <template v-for="row in specRows" :key="row.label">
+          <template v-for="row in model.specRows" :key="row.label">
             <span class="spec-label">{{ row.label }}</span>
             <strong class="spec-value">{{ row.value }}</strong>
           </template>
@@ -210,21 +35,21 @@ const healthRows = computed(() => [
         <div class="storage-body">
           <div
             class="donut"
-            :style="{ '--pct': `${clampPercent(diskPercent)}%` }"
-            :aria-label="percentText(diskPercent)"
+            :style="{ '--pct': `${model.diskPercentBar}%` }"
+            :aria-label="model.diskPercentText"
           >
             <div class="donut__content">
-              <strong>{{ percentText(diskPercent) }}</strong>
+              <strong>{{ model.diskPercentText }}</strong>
               <span>{{ t('node.hardware.used') }}</span>
             </div>
           </div>
           <div class="storage-stats">
             <span>{{ t('node.hardware.total') }}</span>
-            <strong>{{ fmtBytes(totalDisk) ?? '—' }}</strong>
+            <strong>{{ model.totalDiskText }}</strong>
             <span>{{ t('node.hardware.used') }}</span>
-            <strong>{{ fmtBytes(usedDisk) ?? '—' }}</strong>
+            <strong>{{ model.usedDiskText }}</strong>
             <span>{{ t('node.hardware.available') }}</span>
-            <strong>{{ fmtBytes(availableDisk) ?? '—' }}</strong>
+            <strong>{{ model.availableDiskText }}</strong>
           </div>
         </div>
       </article>
@@ -234,8 +59,8 @@ const healthRows = computed(() => [
           <span class="card-kicker">{{ t('node.hardware.filesystems') }}</span>
           <strong>{{ t('node.disk.filesystem') }}</strong>
         </header>
-        <div v-if="filesystemRows.length" class="filesystem-list">
-          <div v-for="row in filesystemRows" :key="row.name" class="filesystem-row">
+        <div v-if="model.filesystemRows.length" class="filesystem-list">
+          <div v-for="row in model.filesystemRows" :key="row.name" class="filesystem-row">
             <span class="dot" />
             <strong>{{ row.name }}</strong>
             <span>{{ row.total }}</span>
@@ -245,14 +70,14 @@ const healthRows = computed(() => [
         <p v-else class="placeholder">{{ t('node.no_disks') }}</p>
         <div class="partition-count">
           <span>{{ t('node.hardware.partitions') }}</span>
-          <strong>{{ disks.length }}</strong>
+          <strong>{{ model.disks.length }}</strong>
         </div>
       </article>
     </section>
 
     <section class="summary-strip" data-test="hardware-summary-cards">
       <article
-        v-for="card in summaryCards"
+        v-for="card in model.summaryCards"
         :key="card.key"
         class="summary-card"
         :class="`summary-card--${card.tone}`"
@@ -273,9 +98,11 @@ const healthRows = computed(() => [
             <span class="card-kicker">{{ t('node.hardware.partitions') }}</span>
             <strong>{{ t('node.mounted_disks') }}</strong>
           </div>
-          <span class="card-count">{{ t('node.hardware.partition_count', { count: disks.length }) }}</span>
+          <span class="card-count">{{
+            t('node.hardware.partition_count', { count: model.disks.length })
+          }}</span>
         </header>
-        <p v-if="diskRows.length === 0" class="placeholder" data-test="node-disks-empty">
+        <p v-if="model.diskRows.length === 0" class="placeholder" data-test="node-disks-empty">
           {{ t('node.no_disks') }}
         </p>
         <div v-else class="disk-table">
@@ -287,17 +114,19 @@ const healthRows = computed(() => [
             <span>{{ t('node.disk.capacity') }}</span>
           </div>
           <div
-            v-for="row in diskRows"
+            v-for="row in model.diskRows"
             :key="`${row.device}:${row.mount}`"
             class="disk-row"
             data-test="disk-row"
           >
             <span class="device" :data-label="t('node.disk.device')">{{ row.device }}</span>
             <span :data-label="t('node.disk.mount')">{{ row.mount }}</span>
-            <span :data-label="t('node.disk.filesystem')"><em>{{ row.fs }}</em></span>
+            <span :data-label="t('node.disk.filesystem')"
+              ><em>{{ row.fs }}</em></span
+            >
             <span class="usage-cell" :data-label="t('node.disk.usage')">
               <span class="usage-track">
-                <span :class="row.severity" :style="{ width: `${clampPercent(row.pct)}%` }" />
+                <span :class="row.severity" :style="{ width: `${row.bar}%` }" />
               </span>
               <span class="usage-value">{{ Math.round(row.pct) }}%</span>
             </span>
@@ -312,7 +141,7 @@ const healthRows = computed(() => [
           <strong>{{ t('node.hardware.health.summary') }}</strong>
         </header>
         <div class="health-list">
-          <div v-for="row in healthRows" :key="row.label" class="health-row">
+          <div v-for="row in model.healthRows" :key="row.label" class="health-row">
             <span>{{ row.label }}</span>
             <strong :class="row.state">{{ row.value }}</strong>
           </div>
@@ -572,7 +401,10 @@ const healthRows = computed(() => [
 .disk-head,
 .disk-row {
   display: grid;
-  grid-template-columns: minmax(140px, 1.1fr) minmax(80px, 0.7fr) minmax(84px, 0.6fr) minmax(160px, 1fr) minmax(120px, 0.8fr);
+  grid-template-columns: minmax(140px, 1.1fr) minmax(80px, 0.7fr) minmax(84px, 0.6fr) minmax(
+      160px,
+      1fr
+    ) minmax(120px, 0.8fr);
   gap: 12px;
   align-items: center;
   min-width: 720px;

--- a/nodelite-server/web/src/components/NodeOverviewMonitor.vue
+++ b/nodelite-server/web/src/components/NodeOverviewMonitor.vue
@@ -4,14 +4,13 @@ import { useI18n } from 'vue-i18n';
 import type { HistoryPoint, NodeStatus } from '@/api';
 import { provideChartHoverGroup } from '@/composables/useChartHoverGroup';
 import { PRESET_WINDOWS, type PresetKey } from '@/composables/useChartSelection';
-import { buildChartData, averageValue, type ChartPoint } from '@/lib/chart/chartData';
-import { formatChartValue, type ChartValueKind } from '@/lib/chart/format';
-import { loadSeries, networkSeries } from '@/lib/chart/svgModel';
-import { totalDiskBytes, uniqueDisks, usedDiskBytes } from '@/lib/disks';
-import { fmtBytes, fmtRate, uptimeParts } from '@/lib/format';
+import {
+  buildOverviewMonitorModel,
+  type OverviewMonitorMetric,
+} from '@/lib/nodeOverviewMonitorModel';
 import MetricChart from './MetricChart.vue';
 
-export type OverviewMonitorMetric = 'cpu' | 'memory' | 'network' | 'load' | 'disk' | 'latency';
+export type { OverviewMonitorMetric } from '@/lib/nodeOverviewMonitorModel';
 
 const props = defineProps<{
   node: NodeStatus | null;
@@ -28,39 +27,6 @@ const { t } = useI18n();
 
 provideChartHoverGroup();
 
-function currentHistoryPoint(node: NodeStatus | null): HistoryPoint | null {
-  const snapshot = node?.snapshot;
-  if (!node || !snapshot) return null;
-  const disks = uniqueDisks(snapshot.disks);
-  const totalDisk = totalDiskBytes(disks);
-  const usedDisk = usedDiskBytes(disks);
-  const memoryTotal = snapshot.memory.total_bytes;
-  return {
-    node_id: node.identity.node_id,
-    recorded_at: snapshot.collected_at,
-    cpu_usage_percent: snapshot.cpu_usage_percent,
-    load_one: snapshot.load.one,
-    load_five: snapshot.load.five,
-    load_fifteen: snapshot.load.fifteen,
-    memory_used_percent: memoryTotal > 0 ? (snapshot.memory.used_bytes / memoryTotal) * 100 : 0,
-    rx_bytes_per_sec: snapshot.network.rx_bytes_per_sec,
-    tx_bytes_per_sec: snapshot.network.tx_bytes_per_sec,
-    latency_ms: node.latency_ms,
-    packet_loss_percent: snapshot.network.packet_loss_percent,
-    disk_used_percent: totalDisk > 0 ? (usedDisk / totalDisk) * 100 : null,
-  };
-}
-
-const effectiveHistory = computed(() => {
-  const current = currentHistoryPoint(props.node);
-  if (!current) return props.history;
-  if (props.history.some((point) => point.recorded_at === current.recorded_at)) {
-    return props.history;
-  }
-  return [...props.history, current];
-});
-
-const data = computed(() => buildChartData(effectiveHistory.value));
 const clipSpikes = reactive<Record<OverviewMonitorMetric, boolean>>({
   cpu: true,
   memory: true,
@@ -74,213 +40,14 @@ function toggleClip(metric: OverviewMonitorMetric): void {
   clipSpikes[metric] = !clipSpikes[metric];
 }
 
-function uptimeText(seconds: number | null | undefined): string {
-  const parts = uptimeParts(seconds);
-  if (!parts) return t('common.not_available');
-  const named = { days: parts.days, hours: parts.hours, minutes: parts.minutes };
-  if (parts.days > 0) return t('node.uptime.days_hours', named);
-  if (parts.hours > 0) return t('node.uptime.hours_minutes', named);
-  return t('node.uptime.minutes', named);
-}
-
-const infoRows = computed<Array<{ label: string; value: string }>>(() => {
-  const node = props.node;
-  if (!node) return [];
-  const id = node.identity;
-  const snapshot = node.snapshot;
-  const disks = uniqueDisks(snapshot?.disks);
-  const totalDisk = totalDiskBytes(disks);
-  const cpuLine = id.cpu_cores
-    ? `${t('node.info.cores', { count: id.cpu_cores })}${id.cpu_model ? ` · ${id.cpu_model}` : ''}`
-    : (id.cpu_model ?? t('common.unknown'));
-
-  return [
-    { label: t('node.info.os'), value: id.os || t('common.unknown_os') },
-    { label: t('node.info.kernel'), value: id.kernel_version || t('common.unknown') },
-    { label: t('node.info.cpu'), value: cpuLine },
-    {
-      label: t('node.info.memory'),
-      value: snapshot?.memory.total_bytes
-        ? (fmtBytes(snapshot.memory.total_bytes) ?? t('common.not_available'))
-        : t('common.not_available'),
-    },
-    {
-      label: t('node.info.disk'),
-      value: totalDisk
-        ? (fmtBytes(totalDisk) ?? t('common.not_available'))
-        : t('common.not_available'),
-    },
-    { label: t('node.info.virtualization'), value: id.agent_version || t('common.unknown') },
-    { label: t('node.info.uptime'), value: uptimeText(snapshot?.uptime_secs) },
-  ];
-});
-
-const memoryPercent = computed(() => {
-  const memory = props.node?.snapshot?.memory;
-  return memory?.total_bytes ? (memory.used_bytes / memory.total_bytes) * 100 : null;
-});
-
-const disk = computed(() => {
-  const disks = uniqueDisks(props.node?.snapshot?.disks);
-  const total = totalDiskBytes(disks);
-  const used = usedDiskBytes(disks);
-  const pct = total ? (used / total) * 100 : null;
-  return {
-    pct,
-    used: total ? (fmtBytes(used) ?? '—') : '—',
-    total: total ? (fmtBytes(total) ?? '—') : '—',
-  };
-});
-
-function percentText(value: number | null | undefined): string {
-  return value == null ? '—' : formatChartValue(value, 'percent');
-}
-
-function progress(value: number | null | undefined): number | null {
-  if (value == null || !Number.isFinite(Number(value))) return null;
-  return Math.max(0, Math.min(100, Number(value)));
-}
-
-function avgText(points: ChartPoint[], kind: ChartValueKind): string {
-  const avg = averageValue(points);
-  return t('node.chart.average', {
-    value: avg == null ? '—' : formatChartValue(avg, kind),
-  });
-}
-
-const cpuValue = computed(() => props.node?.snapshot?.cpu_usage_percent ?? null);
-const loadValue = computed(() => props.node?.snapshot?.load ?? null);
-const latencyValue = computed(() => props.node?.latency_ms ?? null);
-const networkValue = computed(() => props.node?.snapshot?.network ?? null);
-
-const summaryCards = computed(() => {
-  const memory = props.node?.snapshot?.memory;
-  return [
-    {
-      key: 'cpu',
-      label: t('node.cpu_usage'),
-      value: percentText(cpuValue.value),
-      sub: avgText(data.value.cpuPts, 'percent'),
-      progress: progress(cpuValue.value),
-      tone: 'green',
-    },
-    {
-      key: 'memory',
-      label: t('node.memory_usage'),
-      value: percentText(memoryPercent.value),
-      sub: memory?.total_bytes
-        ? `${fmtBytes(memory.used_bytes) ?? '—'} / ${fmtBytes(memory.total_bytes) ?? '—'}`
-        : '—',
-      progress: progress(memoryPercent.value),
-      tone: 'blue',
-    },
-    {
-      key: 'disk',
-      label: t('node.disk_usage'),
-      value: percentText(disk.value.pct),
-      sub: `${disk.value.used} / ${disk.value.total}`,
-      progress: progress(disk.value.pct),
-      tone: 'teal',
-    },
-    {
-      key: 'load',
-      label: t('node.load'),
-      value: loadValue.value ? loadValue.value.one.toFixed(2) : '—',
-      sub: loadValue.value
-        ? `${loadValue.value.one.toFixed(2)} / ${loadValue.value.five.toFixed(2)} / ${loadValue.value.fifteen.toFixed(2)}`
-        : '—',
-      progress: null,
-      tone: 'neutral',
-    },
-    {
-      key: 'latency',
-      label: t('node.latency_history'),
-      value: latencyValue.value == null ? '—' : formatChartValue(latencyValue.value, 'latency'),
-      sub: avgText(data.value.rttPts, 'latency'),
-      progress: null,
-      tone: 'yellow',
-    },
-  ];
-});
-
-const charts = computed(() => [
-  {
-    metric: 'cpu' as const,
-    title: t('node.cpu_usage'),
-    meta: percentText(cpuValue.value),
-    sub: avgText(data.value.cpuPts, 'percent'),
-    chartProps: {
-      points: data.value.cpuPts,
-      valueKind: 'percent' as const,
-      color: 'var(--chart-cpu)',
-      label: t('node.cpu_usage'),
-      clipSpikes: clipSpikes.cpu,
-    },
-  },
-  {
-    metric: 'memory' as const,
-    title: t('node.memory_usage'),
-    meta: percentText(memoryPercent.value),
-    sub: avgText(data.value.memPts, 'percent'),
-    chartProps: {
-      points: data.value.memPts,
-      valueKind: 'percent' as const,
-      color: 'var(--chart-memory)',
-      label: t('node.memory_usage'),
-      maxValue: 100,
-      clipSpikes: clipSpikes.memory,
-    },
-  },
-  {
-    metric: 'network' as const,
-    title: t('node.network_traffic'),
-    meta: fmtRate(networkValue.value?.rx_bytes_per_sec) ?? '—',
-    sub: fmtRate(networkValue.value?.tx_bytes_per_sec) ?? '—',
-    chartProps: {
-      series: networkSeries(data.value, t('index.node.download'), t('index.node.upload')),
-      valueKind: 'rate' as const,
-      clipSpikes: clipSpikes.network,
-    },
-  },
-  {
-    metric: 'load' as const,
-    title: t('node.load'),
-    meta: loadValue.value ? loadValue.value.one.toFixed(2) : '—',
-    sub: avgText(data.value.loadOnePts, 'number'),
-    chartProps: {
-      series: loadSeries(data.value),
-      valueKind: 'number' as const,
-      clipSpikes: clipSpikes.load,
-    },
-  },
-  {
-    metric: 'disk' as const,
-    title: t('node.disk_usage'),
-    meta: percentText(disk.value.pct),
-    sub: avgText(data.value.diskPts, 'percent'),
-    chartProps: {
-      points: data.value.diskPts,
-      valueKind: 'percent' as const,
-      color: 'var(--chart-disk)',
-      label: t('node.disk_usage'),
-      maxValue: 100,
-      clipSpikes: clipSpikes.disk,
-    },
-  },
-  {
-    metric: 'latency' as const,
-    title: t('node.latency_history'),
-    meta: latencyValue.value == null ? '—' : formatChartValue(latencyValue.value, 'latency'),
-    sub: avgText(data.value.rttPts, 'latency'),
-    chartProps: {
-      points: data.value.rttPts,
-      valueKind: 'latency' as const,
-      color: 'var(--chart-latency)',
-      label: t('node.latency_history'),
-      clipSpikes: clipSpikes.latency,
-    },
-  },
-]);
+const model = computed(() =>
+  buildOverviewMonitorModel({
+    node: props.node,
+    history: props.history,
+    clipSpikes,
+    t,
+  }),
+);
 </script>
 
 <template>
@@ -288,7 +55,7 @@ const charts = computed(() => [
     <section class="info-band" data-test="overview-info-band">
       <div class="info-band__title">{{ t('node.info.title') }}</div>
       <div class="info-band__grid">
-        <div v-for="row in infoRows" :key="row.label" class="info-pill">
+        <div v-for="row in model.infoRows" :key="row.label" class="info-pill">
           <span class="info-pill__label">{{ row.label }}</span>
           <strong class="info-pill__value">{{ row.value }}</strong>
         </div>
@@ -314,7 +81,7 @@ const charts = computed(() => [
 
     <div class="summary-grid" data-test="overview-summary-cards">
       <article
-        v-for="card in summaryCards"
+        v-for="card in model.summaryCards"
         :key="card.key"
         class="summary-card"
         :class="`summary-card--${card.tone}`"
@@ -330,7 +97,7 @@ const charts = computed(() => [
     </div>
 
     <div class="chart-grid" data-test="overview-monitor-charts">
-      <article v-for="chart in charts" :key="chart.metric" class="chart-card">
+      <article v-for="chart in model.charts" :key="chart.metric" class="chart-card">
         <header class="chart-card__head">
           <div class="chart-card__title-wrap">
             <span class="chart-card__title">{{ chart.title }}</span>

--- a/nodelite-server/web/src/components/NodeSettingsPanel.vue
+++ b/nodelite-server/web/src/components/NodeSettingsPanel.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, watch } from 'vue';
+import { toRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import ReauthFields from '@/components/ReauthFields.vue';
 import SettingsMessage from '@/components/SettingsMessage.vue';
-import { apiClient } from '@/api';
-import { ApiAbortError } from '@/api/client';
-import { messageFromError } from '@/lib/apiError';
-import { useSettingsStore } from '@/stores/settings';
-import { fmtDateTime } from '@/lib/format';
+import { useNodeSettingsDraft } from '@/composables/useNodeSettingsDraft';
 
 /**
  * Per-node settings tab: shows the current node's token info (from the global
@@ -18,187 +14,24 @@ import { fmtDateTime } from '@/lib/format';
 const props = defineProps<{ nodeId: string }>();
 
 const { t } = useI18n();
-const settingsStore = useSettingsStore();
-
-const reauth = reactive({ current_password: '', code: '' });
-const message = reactive<{ state: 'ok' | 'error' | null; text: string }>({ state: null, text: '' });
-const saving = reactive({ value: false });
-const serviceDraft = reactive({ serviceDate: '', serviceUnlimited: false, renewalPrice: '' });
-const serviceMessage = reactive<{ state: 'ok' | 'error' | null; text: string }>({
-  state: null,
-  text: '',
-});
-const serviceSaving = reactive({ value: false });
-const locationDraft = reactive({ country: '', city: '', latitude: '', longitude: '' });
-const locationMessage = reactive<{ state: 'ok' | 'error' | null; text: string }>({
-  state: null,
-  text: '',
-});
-const locationSaving = reactive({ value: false });
-
-const agent = computed(() =>
-  settingsStore.data?.agents.find((a) => a.node_id === props.nodeId),
-);
-
-onMounted(() => {
-  if (!settingsStore.data && !settingsStore.loading) {
-    void settingsStore.load();
-  }
-});
-
-const expiryLabel = computed(() => {
-  const a = agent.value;
-  if (!a) return '—';
-  if (!a.token_expires_at) return t('node.settings.token_never_expires');
-  const secs = a.token_expires_in_secs;
-  if (secs == null || secs < 0) return t('node.settings.token_expired');
-  const days = Math.floor(secs / 86400);
-  if (days > 0) return t('node.settings.token_expires_in_days', { days });
-  const hours = Math.floor(secs / 3600);
-  return t('node.settings.token_expires_in_hours', { hours });
-});
-
-const expiryDate = computed(() => {
-  const a = agent.value;
-  return a?.token_expires_at ? fmtDateTime(a.token_expires_at) : null;
-});
-
-const automaticLocation = computed(() => {
-  const a = agent.value;
-  if (!a) return '—';
-  const parts = [a.geoip_city, a.geoip_country].filter(Boolean);
-  if (parts.length > 0) return parts.join(', ');
-  if (a.geoip_latitude != null && a.geoip_longitude != null) {
-    return `${a.geoip_latitude.toFixed(4)}, ${a.geoip_longitude.toFixed(4)}`;
-  }
-  return '—';
-});
-
-function dateInputValue(value: string | null | undefined): string {
-  if (!value) return '';
-  const ms = Date.parse(value);
-  if (Number.isFinite(ms)) return new Date(ms).toISOString().slice(0, 10);
-  return /^\d{4}-\d{2}-\d{2}/.test(value) ? value.slice(0, 10) : '';
-}
-
-function serviceExpiresAt(value: string): string | null {
-  return value ? `${value}T00:00:00Z` : null;
-}
-
-watch(
+const {
   agent,
-  (value) => {
-    serviceDraft.serviceDate = dateInputValue(value?.service_expires_at);
-    serviceDraft.serviceUnlimited = value?.service_unlimited ?? false;
-    serviceDraft.renewalPrice = value?.renewal_price ?? '';
-    locationDraft.country = value?.location_override_country ?? '';
-    locationDraft.city = value?.location_override_city ?? '';
-    locationDraft.latitude =
-      value?.location_override_latitude == null ? '' : String(value.location_override_latitude);
-    locationDraft.longitude =
-      value?.location_override_longitude == null ? '' : String(value.location_override_longitude);
-  },
-  { immediate: true },
-);
-
-function optionalNumber(value: string | number): number | null | undefined {
-  const trimmed = String(value).trim();
-  if (!trimmed) return null;
-  const parsed = Number(trimmed);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-async function saveServiceMetadata(): Promise<void> {
-  serviceMessage.state = null;
-  serviceMessage.text = '';
-  serviceSaving.value = true;
-  try {
-    const renewalPrice = serviceDraft.renewalPrice.trim();
-    const resp = await apiClient.updateNodeServiceMetadata(props.nodeId, {
-      service_expires_at: serviceDraft.serviceUnlimited
-        ? null
-        : serviceExpiresAt(serviceDraft.serviceDate),
-      service_unlimited: serviceDraft.serviceUnlimited,
-      renewal_price: renewalPrice || null,
-    });
-    await settingsStore.refresh();
-    serviceDraft.renewalPrice = renewalPrice;
-    serviceMessage.state = 'ok';
-    serviceMessage.text = resp.message || t('node.settings.service_meta_saved');
-  } catch (e) {
-    if (e instanceof ApiAbortError) return;
-    serviceMessage.state = 'error';
-    serviceMessage.text = t('node.settings.service_meta_failed', {
-      error: messageFromError(e, 'unknown'),
-    });
-  } finally {
-    serviceSaving.value = false;
-  }
-}
-
-async function saveLocationOverride(clear = false): Promise<void> {
-  locationMessage.state = null;
-  locationMessage.text = '';
-  const latitude = clear ? null : optionalNumber(locationDraft.latitude);
-  const longitude = clear ? null : optionalNumber(locationDraft.longitude);
-  if (latitude === undefined || longitude === undefined) {
-    locationMessage.state = 'error';
-    locationMessage.text = t('node.settings.location_invalid_number');
-    return;
-  }
-
-  locationSaving.value = true;
-  try {
-    const country = clear ? '' : locationDraft.country.trim();
-    const city = clear ? '' : locationDraft.city.trim();
-    const resp = await apiClient.updateNodeLocationOverride(props.nodeId, {
-      country: country || null,
-      city: city || null,
-      latitude,
-      longitude,
-    });
-    await settingsStore.refresh();
-    locationDraft.country = country;
-    locationDraft.city = city;
-    if (clear) {
-      locationDraft.latitude = '';
-      locationDraft.longitude = '';
-    }
-    locationMessage.state = 'ok';
-    locationMessage.text = resp.message || t('node.settings.location_saved');
-  } catch (e) {
-    if (e instanceof ApiAbortError) return;
-    locationMessage.state = 'error';
-    locationMessage.text = t('node.settings.location_failed', {
-      error: messageFromError(e, 'unknown'),
-    });
-  } finally {
-    locationSaving.value = false;
-  }
-}
-
-async function refresh(): Promise<void> {
-  message.state = null;
-  message.text = t('node.settings.refreshing');
-  saving.value = true;
-  try {
-    const body: { current_password?: string; code?: string } = {};
-    if (reauth.current_password) body.current_password = reauth.current_password;
-    if (reauth.code) body.code = reauth.code;
-    const resp = await apiClient.refreshNodeToken(props.nodeId, body);
-    await settingsStore.refresh();
-    reauth.current_password = '';
-    reauth.code = '';
-    message.state = 'ok';
-    message.text = resp.message || t('node.settings.token_refreshed');
-  } catch (e) {
-    if (e instanceof ApiAbortError) return;
-    message.state = 'error';
-    message.text = t('node.settings.refresh_failed', { error: messageFromError(e, 'unknown') });
-  } finally {
-    saving.value = false;
-  }
-}
+  automaticLocation,
+  expiryDate,
+  expiryLabel,
+  locationDraft,
+  locationMessage,
+  locationSaving,
+  reauth,
+  message,
+  refresh,
+  saveLocationOverride,
+  saveServiceMetadata,
+  saving,
+  serviceDraft,
+  serviceMessage,
+  serviceSaving,
+} = useNodeSettingsDraft(toRef(props, 'nodeId'), t);
 </script>
 
 <template>

--- a/nodelite-server/web/src/composables/useNodeSettingsDraft.spec.ts
+++ b/nodelite-server/web/src/composables/useNodeSettingsDraft.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { makeSettings } from '@/api/__fixtures__/nodes';
+import {
+  dateInputValue,
+  optionalNumber,
+  reauthBody,
+  serviceExpiresAt,
+  syncDraftsFromAgent,
+  type LocationDraft,
+  type ServiceDraft,
+} from './useNodeSettingsDraft';
+
+describe('useNodeSettingsDraft helpers', () => {
+  it('normalizes service dates for date inputs and API payloads', () => {
+    expect(dateInputValue(null)).toBe('');
+    expect(dateInputValue('2026-12-31T00:00:00Z')).toBe('2026-12-31');
+    expect(dateInputValue('2026-12-31 manually entered')).toBe('2026-12-31');
+    expect(dateInputValue('not a date')).toBe('');
+    expect(serviceExpiresAt('')).toBeNull();
+    expect(serviceExpiresAt('2027-01-15')).toBe('2027-01-15T00:00:00Z');
+  });
+
+  it('parses optional numeric location fields', () => {
+    expect(optionalNumber('')).toBeNull();
+    expect(optionalNumber(' 22.3193 ')).toBe(22.3193);
+    expect(optionalNumber('abc')).toBeUndefined();
+  });
+
+  it('omits blank reauth fields from refresh payloads', () => {
+    expect(reauthBody({ current_password: '', code: '' })).toEqual({});
+    expect(reauthBody({ current_password: 'hunter2', code: '' })).toEqual({
+      current_password: 'hunter2',
+    });
+    expect(reauthBody({ current_password: '', code: '123456' })).toEqual({ code: '123456' });
+  });
+
+  it('syncs service and location drafts when the selected agent changes', () => {
+    const agent = makeSettings({
+      agents: [
+        {
+          ...makeSettings().agents[0]!,
+          service_expires_at: '2026-12-31T00:00:00Z',
+          service_unlimited: true,
+          renewal_price: '$9/mo',
+          location_override_country: 'HK',
+          location_override_city: 'Hong Kong',
+          location_override_latitude: 22.3193,
+          location_override_longitude: 114.1694,
+        },
+      ],
+    }).agents[0];
+    const serviceDraft: ServiceDraft = {
+      serviceDate: '',
+      serviceUnlimited: false,
+      renewalPrice: '',
+    };
+    const locationDraft: LocationDraft = {
+      country: '',
+      city: '',
+      latitude: '',
+      longitude: '',
+    };
+
+    syncDraftsFromAgent(agent, serviceDraft, locationDraft);
+
+    expect(serviceDraft).toEqual({
+      serviceDate: '2026-12-31',
+      serviceUnlimited: true,
+      renewalPrice: '$9/mo',
+    });
+    expect(locationDraft).toEqual({
+      country: 'HK',
+      city: 'Hong Kong',
+      latitude: '22.3193',
+      longitude: '114.1694',
+    });
+
+    syncDraftsFromAgent(undefined, serviceDraft, locationDraft);
+    expect(serviceDraft).toEqual({
+      serviceDate: '',
+      serviceUnlimited: false,
+      renewalPrice: '',
+    });
+    expect(locationDraft).toEqual({
+      country: '',
+      city: '',
+      latitude: '',
+      longitude: '',
+    });
+  });
+});

--- a/nodelite-server/web/src/composables/useNodeSettingsDraft.ts
+++ b/nodelite-server/web/src/composables/useNodeSettingsDraft.ts
@@ -1,0 +1,255 @@
+import { computed, onMounted, reactive, watch, type Ref } from 'vue';
+import { apiClient, type SettingsAgentToken } from '@/api';
+import { ApiAbortError } from '@/api/client';
+import { messageFromError } from '@/lib/apiError';
+import { fmtDateTime } from '@/lib/format';
+import { useSettingsStore } from '@/stores/settings';
+
+export type NodeSettingsTranslate = (
+  key: string,
+  named?: Record<string, number | string>,
+) => string;
+
+export interface ReauthDraft {
+  current_password: string;
+  code: string;
+}
+
+export interface ServiceDraft {
+  serviceDate: string;
+  serviceUnlimited: boolean;
+  renewalPrice: string;
+}
+
+export interface LocationDraft {
+  country: string;
+  city: string;
+  latitude: string;
+  longitude: string;
+}
+
+export interface SettingsMessageState {
+  state: 'ok' | 'error' | null;
+  text: string;
+}
+
+export function dateInputValue(value: string | null | undefined): string {
+  if (!value) return '';
+  const ms = Date.parse(value);
+  if (Number.isFinite(ms)) return new Date(ms).toISOString().slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}/.test(value) ? value.slice(0, 10) : '';
+}
+
+export function serviceExpiresAt(value: string): string | null {
+  return value ? `${value}T00:00:00Z` : null;
+}
+
+export function optionalNumber(value: string | number): number | null | undefined {
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function reauthBody(reauth: ReauthDraft): { current_password?: string; code?: string } {
+  const body: { current_password?: string; code?: string } = {};
+  if (reauth.current_password) body.current_password = reauth.current_password;
+  if (reauth.code) body.code = reauth.code;
+  return body;
+}
+
+export function syncDraftsFromAgent(
+  agent: SettingsAgentToken | undefined,
+  serviceDraft: ServiceDraft,
+  locationDraft: LocationDraft,
+): void {
+  serviceDraft.serviceDate = dateInputValue(agent?.service_expires_at);
+  serviceDraft.serviceUnlimited = agent?.service_unlimited ?? false;
+  serviceDraft.renewalPrice = agent?.renewal_price ?? '';
+  locationDraft.country = agent?.location_override_country ?? '';
+  locationDraft.city = agent?.location_override_city ?? '';
+  locationDraft.latitude =
+    agent?.location_override_latitude == null ? '' : String(agent.location_override_latitude);
+  locationDraft.longitude =
+    agent?.location_override_longitude == null ? '' : String(agent.location_override_longitude);
+}
+
+function resetMessage(message: SettingsMessageState): void {
+  message.state = null;
+  message.text = '';
+}
+
+export function useNodeSettingsDraft(nodeId: Ref<string>, t: NodeSettingsTranslate) {
+  const settingsStore = useSettingsStore();
+
+  const reauth = reactive<ReauthDraft>({ current_password: '', code: '' });
+  const message = reactive<SettingsMessageState>({ state: null, text: '' });
+  const saving = reactive({ value: false });
+  const serviceDraft = reactive<ServiceDraft>({
+    serviceDate: '',
+    serviceUnlimited: false,
+    renewalPrice: '',
+  });
+  const serviceMessage = reactive<SettingsMessageState>({
+    state: null,
+    text: '',
+  });
+  const serviceSaving = reactive({ value: false });
+  const locationDraft = reactive<LocationDraft>({
+    country: '',
+    city: '',
+    latitude: '',
+    longitude: '',
+  });
+  const locationMessage = reactive<SettingsMessageState>({
+    state: null,
+    text: '',
+  });
+  const locationSaving = reactive({ value: false });
+
+  const agent = computed(() => settingsStore.data?.agents.find((a) => a.node_id === nodeId.value));
+
+  onMounted(() => {
+    if (!settingsStore.data && !settingsStore.loading) {
+      void settingsStore.load();
+    }
+  });
+
+  const expiryLabel = computed(() => {
+    const a = agent.value;
+    if (!a) return '—';
+    if (!a.token_expires_at) return t('node.settings.token_never_expires');
+    const secs = a.token_expires_in_secs;
+    if (secs == null || secs < 0) return t('node.settings.token_expired');
+    const days = Math.floor(secs / 86400);
+    if (days > 0) return t('node.settings.token_expires_in_days', { days });
+    const hours = Math.floor(secs / 3600);
+    return t('node.settings.token_expires_in_hours', { hours });
+  });
+
+  const expiryDate = computed(() => {
+    const a = agent.value;
+    return a?.token_expires_at ? fmtDateTime(a.token_expires_at) : null;
+  });
+
+  const automaticLocation = computed(() => {
+    const a = agent.value;
+    if (!a) return '—';
+    const parts = [a.geoip_city, a.geoip_country].filter(Boolean);
+    if (parts.length > 0) return parts.join(', ');
+    if (a.geoip_latitude != null && a.geoip_longitude != null) {
+      return `${a.geoip_latitude.toFixed(4)}, ${a.geoip_longitude.toFixed(4)}`;
+    }
+    return '—';
+  });
+
+  watch(agent, (value) => syncDraftsFromAgent(value, serviceDraft, locationDraft), {
+    immediate: true,
+  });
+
+  async function saveServiceMetadata(): Promise<void> {
+    resetMessage(serviceMessage);
+    serviceSaving.value = true;
+    try {
+      const renewalPrice = serviceDraft.renewalPrice.trim();
+      const resp = await apiClient.updateNodeServiceMetadata(nodeId.value, {
+        service_expires_at: serviceDraft.serviceUnlimited
+          ? null
+          : serviceExpiresAt(serviceDraft.serviceDate),
+        service_unlimited: serviceDraft.serviceUnlimited,
+        renewal_price: renewalPrice || null,
+      });
+      await settingsStore.refresh();
+      serviceDraft.renewalPrice = renewalPrice;
+      serviceMessage.state = 'ok';
+      serviceMessage.text = resp.message || t('node.settings.service_meta_saved');
+    } catch (e) {
+      if (e instanceof ApiAbortError) return;
+      serviceMessage.state = 'error';
+      serviceMessage.text = t('node.settings.service_meta_failed', {
+        error: messageFromError(e, 'unknown'),
+      });
+    } finally {
+      serviceSaving.value = false;
+    }
+  }
+
+  async function saveLocationOverride(clear = false): Promise<void> {
+    resetMessage(locationMessage);
+    const latitude = clear ? null : optionalNumber(locationDraft.latitude);
+    const longitude = clear ? null : optionalNumber(locationDraft.longitude);
+    if (latitude === undefined || longitude === undefined) {
+      locationMessage.state = 'error';
+      locationMessage.text = t('node.settings.location_invalid_number');
+      return;
+    }
+
+    locationSaving.value = true;
+    try {
+      const country = clear ? '' : locationDraft.country.trim();
+      const city = clear ? '' : locationDraft.city.trim();
+      const resp = await apiClient.updateNodeLocationOverride(nodeId.value, {
+        country: country || null,
+        city: city || null,
+        latitude,
+        longitude,
+      });
+      await settingsStore.refresh();
+      locationDraft.country = country;
+      locationDraft.city = city;
+      if (clear) {
+        locationDraft.latitude = '';
+        locationDraft.longitude = '';
+      }
+      locationMessage.state = 'ok';
+      locationMessage.text = resp.message || t('node.settings.location_saved');
+    } catch (e) {
+      if (e instanceof ApiAbortError) return;
+      locationMessage.state = 'error';
+      locationMessage.text = t('node.settings.location_failed', {
+        error: messageFromError(e, 'unknown'),
+      });
+    } finally {
+      locationSaving.value = false;
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    message.state = null;
+    message.text = t('node.settings.refreshing');
+    saving.value = true;
+    try {
+      const resp = await apiClient.refreshNodeToken(nodeId.value, reauthBody(reauth));
+      await settingsStore.refresh();
+      reauth.current_password = '';
+      reauth.code = '';
+      message.state = 'ok';
+      message.text = resp.message || t('node.settings.token_refreshed');
+    } catch (e) {
+      if (e instanceof ApiAbortError) return;
+      message.state = 'error';
+      message.text = t('node.settings.refresh_failed', { error: messageFromError(e, 'unknown') });
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  return {
+    agent,
+    automaticLocation,
+    expiryDate,
+    expiryLabel,
+    locationDraft,
+    locationMessage,
+    locationSaving,
+    reauth,
+    message,
+    refresh,
+    saveLocationOverride,
+    saveServiceMetadata,
+    saving,
+    serviceDraft,
+    serviceMessage,
+    serviceSaving,
+  };
+}

--- a/nodelite-server/web/src/lib/nodeHardwareModel.spec.ts
+++ b/nodelite-server/web/src/lib/nodeHardwareModel.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { DiskUsage } from '@/api';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import {
+  buildNodeHardwareModel,
+  clampPercent,
+  percentText,
+  severity,
+  type HardwareTranslate,
+} from './nodeHardwareModel';
+
+const labels: Record<string, string> = {
+  'common.not_available': 'n/a',
+  'common.unknown': 'Unknown',
+  'common.unknown_os': 'unknown os',
+  'common.online': 'Online',
+  'common.offline': 'Offline',
+  'node.info.os': 'OS',
+  'node.info.kernel': 'Kernel',
+  'node.info.cpu': 'CPU',
+  'node.info.memory': 'Memory',
+  'node.info.virtualization': 'Agent',
+  'node.info.uptime': 'Uptime',
+  'node.uptime.days_hours': '{days}d {hours}h {minutes}m',
+  'node.uptime.hours_minutes': '{hours}h {minutes}m',
+  'node.uptime.minutes': '{minutes}m',
+  'node.stats.cpu': 'CPU',
+  'node.stats.memory': 'Memory',
+  'node.stats.swap': 'Swap',
+  'node.stats.load': 'Load 1/5/15',
+  'node.stats.latency': 'Latency',
+  'node.cpu_usage': 'CPU Usage',
+  'node.memory_usage': 'Memory Usage',
+  'node.disk_usage': 'Disk Usage',
+  'node.hardware.used': 'Used',
+  'node.hardware.cores': 'cores',
+  'node.hardware.load_hint': '1 / 5 / 15 minute windows',
+  'node.hardware.health.status': 'Node Status',
+  'node.hardware.partitions': 'Partitions',
+};
+
+const t: HardwareTranslate = (key, named) => {
+  const value = labels[key] ?? key;
+  return value.replace(/\{(\w+)\}/g, (_, name: string) => String(named?.[name] ?? ''));
+};
+
+function disk(over: Partial<DiskUsage>): DiskUsage {
+  return {
+    device: '/dev/sda1',
+    mount_point: '/',
+    fs_type: 'ext4',
+    total_bytes: 100,
+    available_bytes: 60,
+    used_bytes: 40,
+    used_percent: 40,
+    ...over,
+  };
+}
+
+describe('nodeHardwareModel', () => {
+  it('formats and clamps percent values', () => {
+    expect(percentText(null)).toBe('—');
+    expect(percentText(Number.NaN)).toBe('—');
+    expect(percentText(74.6)).toBe('75%');
+    expect(clampPercent(null)).toBe(0);
+    expect(clampPercent(-10)).toBe(0);
+    expect(clampPercent(140)).toBe(100);
+  });
+
+  it('classifies health severity boundaries', () => {
+    expect(severity(null)).toBe('ok');
+    expect(severity(74.9)).toBe('ok');
+    expect(severity(75)).toBe('warn');
+    expect(severity(90)).toBe('bad');
+  });
+
+  it('deduplicates disks and aggregates filesystem rows', () => {
+    const node = makeNodeStatus();
+    node.snapshot!.disks = [
+      disk({ device: '/dev/sda1', total_bytes: 100, used_bytes: 40, used_percent: 40 }),
+      disk({ device: '/dev/sda1', total_bytes: 100, used_bytes: 40, used_percent: 40 }),
+      disk({
+        device: '/dev/sdb1',
+        mount_point: '/data',
+        fs_type: 'xfs',
+        total_bytes: 200,
+        used_bytes: 190,
+        used_percent: 95,
+      }),
+    ];
+
+    const model = buildNodeHardwareModel(node, t);
+
+    expect(model.disks).toHaveLength(2);
+    expect(model.diskPercent).toBeCloseTo(76.666, 2);
+    expect(model.diskPercentBar).toBeCloseTo(76.666, 2);
+    expect(model.filesystemRows.map((row) => row.name)).toEqual(['ext4', 'xfs']);
+    expect(model.filesystemRows.map((row) => row.count)).toEqual([1, 1]);
+    expect(model.diskRows.find((row) => row.device === '/dev/sdb1')?.severity).toBe('bad');
+  });
+
+  it('builds empty hardware rows when the snapshot is missing', () => {
+    const model = buildNodeHardwareModel(makeNodeStatus({ snapshot: null, online: false }), t);
+
+    expect(model.disks).toHaveLength(0);
+    expect(model.diskRows).toHaveLength(0);
+    expect(model.filesystemRows).toHaveLength(0);
+    expect(model.diskPercent).toBeNull();
+    expect(model.diskPercentText).toBe('—');
+    expect(model.specRows.find((row) => row.label === 'Memory')?.value).toBe('n/a');
+    expect(model.healthRows[0]).toEqual({
+      label: 'Node Status',
+      value: 'Offline',
+      state: 'bad',
+    });
+  });
+
+  it('keeps memory and swap percentages bounded for zero totals', () => {
+    const node = makeNodeStatus();
+    node.snapshot!.memory.total_bytes = 0;
+    node.snapshot!.memory.used_bytes = 10;
+    node.snapshot!.memory.swap_total_bytes = 0;
+    node.snapshot!.memory.swap_used_bytes = 10;
+
+    const model = buildNodeHardwareModel(node, t);
+    const memoryCard = model.summaryCards.find((card) => card.key === 'memory');
+    const swapCard = model.summaryCards.find((card) => card.key === 'swap');
+
+    expect(memoryCard?.bar).toBe(0);
+    expect(memoryCard?.sub).toContain('—');
+    expect(swapCard?.bar).toBe(0);
+    expect(swapCard?.sub).toBe('n/a');
+  });
+});

--- a/nodelite-server/web/src/lib/nodeHardwareModel.ts
+++ b/nodelite-server/web/src/lib/nodeHardwareModel.ts
@@ -1,0 +1,246 @@
+import type { DiskUsage, NodeStatus } from '@/api';
+import { totalDiskBytes, uniqueDisks, usedDiskBytes } from '@/lib/disks';
+import { fmtBytes, fmtLatency, uptimeParts } from '@/lib/format';
+
+export type HardwareTranslate = (key: string, named?: Record<string, number | string>) => string;
+export type HardwareSeverity = 'ok' | 'warn' | 'bad';
+
+export interface HardwareSpecRow {
+  label: string;
+  value: string;
+}
+
+export interface HardwareFilesystemRow {
+  name: string;
+  count: number;
+  total: string;
+  pct: number;
+}
+
+export interface HardwareSummaryCard {
+  key: 'cpu' | 'memory' | 'swap' | 'load' | 'latency';
+  label: string;
+  value: string;
+  sub: string;
+  tone: 'blue' | 'green' | 'red' | 'neutral';
+  bar: number | null;
+}
+
+export interface HardwareDiskRow {
+  device: string;
+  mount: string;
+  fs: string;
+  pct: number;
+  bar: number;
+  capacity: string;
+  severity: HardwareSeverity;
+}
+
+export interface HardwareHealthRow {
+  label: string;
+  value: string;
+  state: HardwareSeverity;
+}
+
+export interface NodeHardwareModel {
+  disks: DiskUsage[];
+  totalDiskText: string;
+  usedDiskText: string;
+  availableDiskText: string;
+  diskPercent: number | null;
+  diskPercentText: string;
+  diskPercentBar: number;
+  filesystemRows: HardwareFilesystemRow[];
+  specRows: HardwareSpecRow[];
+  summaryCards: HardwareSummaryCard[];
+  diskRows: HardwareDiskRow[];
+  healthRows: HardwareHealthRow[];
+}
+
+function fallback(value: string | null | undefined, t: HardwareTranslate): string {
+  return value || t('common.not_available');
+}
+
+export function percentText(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(Number(value))) return '—';
+  return `${Math.round(Number(value))}%`;
+}
+
+export function clampPercent(value: number | null | undefined): number {
+  if (value == null || !Number.isFinite(Number(value))) return 0;
+  return Math.max(0, Math.min(100, Number(value)));
+}
+
+function uptimeText(seconds: number | null | undefined, t: HardwareTranslate): string {
+  const parts = uptimeParts(seconds);
+  if (!parts) return t('common.not_available');
+  const named = { days: parts.days, hours: parts.hours, minutes: parts.minutes };
+  if (parts.days > 0) return t('node.uptime.days_hours', named);
+  if (parts.hours > 0) return t('node.uptime.hours_minutes', named);
+  return t('node.uptime.minutes', named);
+}
+
+export function severity(value: number | null | undefined): HardwareSeverity {
+  if (value == null || !Number.isFinite(Number(value))) return 'ok';
+  if (value >= 90) return 'bad';
+  if (value >= 75) return 'warn';
+  return 'ok';
+}
+
+function diskCapacity(disk: DiskUsage): string {
+  return `${fmtBytes(disk.used_bytes) ?? '—'} / ${fmtBytes(disk.total_bytes) ?? '—'}`;
+}
+
+function filesystemRows(
+  disks: DiskUsage[],
+  totalDisk: number,
+  t: HardwareTranslate,
+): HardwareFilesystemRow[] {
+  const totals = new Map<string, { total: number; used: number; count: number }>();
+  for (const disk of disks) {
+    const key = disk.fs_type || t('common.unknown');
+    const current = totals.get(key) ?? { total: 0, used: 0, count: 0 };
+    current.total += disk.total_bytes || 0;
+    current.used += disk.used_bytes || 0;
+    current.count += 1;
+    totals.set(key, current);
+  }
+  return [...totals.entries()].map(([name, row]) => ({
+    name,
+    count: row.count,
+    total: fmtBytes(row.total) ?? '—',
+    pct: totalDisk ? (row.total / totalDisk) * 100 : 0,
+  }));
+}
+
+export function buildNodeHardwareModel(
+  node: NodeStatus | null,
+  t: HardwareTranslate,
+): NodeHardwareModel {
+  const snapshot = node?.snapshot ?? null;
+  const identity = node?.identity ?? null;
+  const disks = uniqueDisks(snapshot?.disks);
+  const totalDisk = totalDiskBytes(disks);
+  const usedDisk = usedDiskBytes(disks);
+  const availableDisk = Math.max(0, totalDisk - usedDisk);
+  const diskPercent = totalDisk ? (usedDisk / totalDisk) * 100 : null;
+  const memory = snapshot?.memory;
+  const memoryPercent = memory?.total_bytes ? (memory.used_bytes / memory.total_bytes) * 100 : null;
+  const swapPercent = memory?.swap_total_bytes
+    ? (memory.swap_used_bytes / memory.swap_total_bytes) * 100
+    : null;
+
+  return {
+    disks,
+    totalDiskText: fmtBytes(totalDisk) ?? '—',
+    usedDiskText: fmtBytes(usedDisk) ?? '—',
+    availableDiskText: fmtBytes(availableDisk) ?? '—',
+    diskPercent,
+    diskPercentText: percentText(diskPercent),
+    diskPercentBar: clampPercent(diskPercent),
+    filesystemRows: filesystemRows(disks, totalDisk, t),
+    specRows: [
+      { label: t('node.info.os'), value: identity?.os || t('common.unknown_os') },
+      { label: t('node.info.kernel'), value: fallback(identity?.kernel_version, t) },
+      {
+        label: t('node.info.cpu'),
+        value: identity?.cpu_model
+          ? `${identity.cpu_cores} ${t('node.hardware.cores')} · ${identity.cpu_model}`
+          : t('common.unknown'),
+      },
+      {
+        label: t('node.info.memory'),
+        value: fmtBytes(memory?.total_bytes) ?? t('common.not_available'),
+      },
+      { label: t('node.info.virtualization'), value: fallback(identity?.agent_version, t) },
+      { label: t('node.info.uptime'), value: uptimeText(snapshot?.uptime_secs, t) },
+    ],
+    summaryCards: [
+      {
+        key: 'cpu',
+        label: t('node.stats.cpu'),
+        value: identity?.cpu_model ?? t('common.unknown'),
+        sub: `${identity?.cpu_cores ?? 0} ${t('node.hardware.cores')} · ${percentText(snapshot?.cpu_usage_percent)}`,
+        tone: 'blue',
+        bar: clampPercent(snapshot?.cpu_usage_percent),
+      },
+      {
+        key: 'memory',
+        label: t('node.stats.memory'),
+        value: fmtBytes(memory?.total_bytes) ?? '—',
+        sub: `${fmtBytes(memory?.used_bytes) ?? '—'} ${t('node.hardware.used')} · ${percentText(memoryPercent)}`,
+        tone: 'green',
+        bar: clampPercent(memoryPercent),
+      },
+      {
+        key: 'swap',
+        label: t('node.stats.swap'),
+        value: fmtBytes(memory?.swap_total_bytes) ?? '—',
+        sub: memory?.swap_total_bytes
+          ? `${fmtBytes(memory.swap_used_bytes) ?? '—'} ${t('node.hardware.used')} · ${percentText(swapPercent)}`
+          : t('common.not_available'),
+        tone: 'neutral',
+        bar: clampPercent(swapPercent),
+      },
+      {
+        key: 'load',
+        label: t('node.stats.load'),
+        value: snapshot
+          ? `${snapshot.load.one.toFixed(2)} / ${snapshot.load.five.toFixed(2)} / ${snapshot.load.fifteen.toFixed(2)}`
+          : '—',
+        sub: t('node.hardware.load_hint'),
+        tone: 'neutral',
+        bar: null,
+      },
+      {
+        key: 'latency',
+        label: t('node.stats.latency'),
+        value: fmtLatency(node?.latency_ms) ?? '—',
+        sub: node?.online ? t('common.online') : t('common.offline'),
+        tone: node?.online ? 'green' : 'red',
+        bar: null,
+      },
+    ],
+    diskRows: disks.map((disk) => ({
+      device: disk.device,
+      mount: disk.mount_point || '—',
+      fs: disk.fs_type || '—',
+      pct: disk.used_percent ?? 0,
+      bar: clampPercent(disk.used_percent),
+      capacity: diskCapacity(disk),
+      severity: severity(disk.used_percent),
+    })),
+    healthRows: [
+      {
+        label: t('node.hardware.health.status'),
+        value: node?.online ? t('common.online') : t('common.offline'),
+        state: node?.online ? 'ok' : 'bad',
+      },
+      {
+        label: t('node.cpu_usage'),
+        value: percentText(snapshot?.cpu_usage_percent),
+        state: severity(snapshot?.cpu_usage_percent),
+      },
+      {
+        label: t('node.memory_usage'),
+        value: percentText(memoryPercent),
+        state: severity(memoryPercent),
+      },
+      {
+        label: t('node.disk_usage'),
+        value: percentText(diskPercent),
+        state: severity(diskPercent),
+      },
+      {
+        label: t('node.stats.latency'),
+        value: fmtLatency(node?.latency_ms) ?? '—',
+        state: node?.latency_ms != null && node.latency_ms > 200 ? 'warn' : 'ok',
+      },
+      {
+        label: t('node.hardware.partitions'),
+        value: `${disks.length}`,
+        state: 'ok',
+      },
+    ],
+  };
+}

--- a/nodelite-server/web/src/lib/nodeOverviewMonitorModel.spec.ts
+++ b/nodelite-server/web/src/lib/nodeOverviewMonitorModel.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { HistoryPoint } from '@/api';
+import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import {
+  buildOverviewMonitorModel,
+  currentHistoryPoint,
+  effectiveHistory,
+  type ClipState,
+  type OverviewMonitorTranslate,
+} from './nodeOverviewMonitorModel';
+
+const t: OverviewMonitorTranslate = (key, named) => {
+  if (key === 'node.info.cores') return `${named?.count} Core(s)`;
+  if (key === 'node.chart.average') return `Avg ${named?.value}`;
+  return key;
+};
+
+const clipSpikes: ClipState = {
+  cpu: true,
+  memory: true,
+  network: true,
+  load: true,
+  disk: true,
+  latency: true,
+};
+
+function hp(recorded_at: string, over: Partial<HistoryPoint> = {}): HistoryPoint {
+  return {
+    node_id: 'node-a',
+    recorded_at,
+    cpu_usage_percent: 10,
+    load_one: 0.1,
+    load_five: 0.2,
+    load_fifteen: 0.3,
+    memory_used_percent: 20,
+    rx_bytes_per_sec: 100,
+    tx_bytes_per_sec: 50,
+    latency_ms: 5,
+    packet_loss_percent: 0.2,
+    disk_used_percent: 40,
+    ...over,
+  };
+}
+
+describe('nodeOverviewMonitorModel', () => {
+  it('creates a current history point from the latest snapshot', () => {
+    const current = currentHistoryPoint(makeNodeStatus());
+
+    expect(current).toMatchObject({
+      node_id: 'node-a',
+      recorded_at: '2026-05-29T00:00:00Z',
+      cpu_usage_percent: 12.5,
+      load_one: 0.3,
+      load_five: 0.4,
+      load_fifteen: 0.5,
+      memory_used_percent: 25,
+      rx_bytes_per_sec: 10,
+      tx_bytes_per_sec: 20,
+      latency_ms: 5,
+      packet_loss_percent: 0.2,
+      disk_used_percent: 40,
+    });
+  });
+
+  it('does not create a current point without a node snapshot', () => {
+    expect(currentHistoryPoint(null)).toBeNull();
+    expect(currentHistoryPoint(makeNodeStatus({ snapshot: null }))).toBeNull();
+  });
+
+  it('appends the current point only when the timestamp is new', () => {
+    const node = makeNodeStatus();
+    const oldPoint = hp('2026-05-28T23:55:00Z');
+    const appended = effectiveHistory([oldPoint], node);
+
+    expect(appended).toHaveLength(2);
+    expect(appended[0]).toBe(oldPoint);
+    expect(appended[1]?.recorded_at).toBe('2026-05-29T00:00:00Z');
+
+    const duplicateHistory = [hp('2026-05-29T00:00:00Z')];
+    expect(effectiveHistory(duplicateHistory, node)).toBe(duplicateHistory);
+  });
+
+  it('builds chart data from the current snapshot when history is empty', () => {
+    const model = buildOverviewMonitorModel({
+      node: makeNodeStatus(),
+      history: [],
+      clipSpikes,
+      t,
+    });
+
+    expect(model.effectiveHistory).toHaveLength(1);
+    expect(model.data.cpuPts).toHaveLength(1);
+    expect(model.infoRows).toHaveLength(7);
+    expect(model.summaryCards.map((card) => card.key)).toEqual([
+      'cpu',
+      'memory',
+      'disk',
+      'load',
+      'latency',
+    ]);
+    expect(model.charts.map((chart) => chart.metric)).toEqual([
+      'cpu',
+      'memory',
+      'network',
+      'load',
+      'disk',
+      'latency',
+    ]);
+  });
+
+  it('keeps null disk usage and zero memory percent bounded for empty hardware data', () => {
+    const node = makeNodeStatus({
+      snapshot: {
+        collected_at: '2026-05-29T00:00:00Z',
+        cpu_usage_percent: null,
+        load: { one: 0, five: 0, fifteen: 0 },
+        memory: {
+          total_bytes: 0,
+          used_bytes: 0,
+          available_bytes: 0,
+          swap_total_bytes: 0,
+          swap_used_bytes: 0,
+        },
+        uptime_secs: 0,
+        disks: [],
+        network: {
+          total_rx_bytes: 0,
+          total_tx_bytes: 0,
+          rx_bytes_per_sec: null,
+          tx_bytes_per_sec: null,
+          packet_loss_percent: null,
+        },
+      },
+    });
+    const current = currentHistoryPoint(node);
+    const model = buildOverviewMonitorModel({ node, history: [], clipSpikes, t });
+
+    expect(current?.memory_used_percent).toBe(0);
+    expect(current?.disk_used_percent).toBeNull();
+    expect(model.summaryCards.find((card) => card.key === 'memory')?.progress).toBeNull();
+    expect(model.summaryCards.find((card) => card.key === 'disk')?.value).toBe('—');
+  });
+});

--- a/nodelite-server/web/src/lib/nodeOverviewMonitorModel.ts
+++ b/nodelite-server/web/src/lib/nodeOverviewMonitorModel.ts
@@ -1,0 +1,335 @@
+import type { HistoryPoint, NodeStatus } from '@/api';
+import {
+  averageValue,
+  buildChartData,
+  type ChartData,
+  type ChartPoint,
+} from '@/lib/chart/chartData';
+import { formatChartValue, type ChartValueKind } from '@/lib/chart/format';
+import { loadSeries, networkSeries, type MultiSeriesInput } from '@/lib/chart/svgModel';
+import { totalDiskBytes, uniqueDisks, usedDiskBytes } from '@/lib/disks';
+import { fmtBytes, fmtRate, uptimeParts } from '@/lib/format';
+
+export type OverviewMonitorMetric = 'cpu' | 'memory' | 'network' | 'load' | 'disk' | 'latency';
+
+export type OverviewMonitorTranslate = (
+  key: string,
+  named?: Record<string, number | string>,
+) => string;
+
+export type ClipState = Record<OverviewMonitorMetric, boolean>;
+
+export interface OverviewInfoRow {
+  label: string;
+  value: string;
+}
+
+export interface OverviewSummaryCard {
+  key: OverviewMonitorMetric;
+  label: string;
+  value: string;
+  sub: string;
+  progress: number | null;
+  tone: 'green' | 'blue' | 'teal' | 'yellow' | 'neutral';
+}
+
+export interface OverviewChartProps {
+  points?: ChartPoint[];
+  series?: MultiSeriesInput[];
+  valueKind: ChartValueKind;
+  color?: string;
+  label?: string;
+  maxValue?: number;
+  clipSpikes: boolean;
+}
+
+export interface OverviewChartModel {
+  metric: OverviewMonitorMetric;
+  title: string;
+  meta: string;
+  sub: string;
+  chartProps: OverviewChartProps;
+}
+
+export interface OverviewMonitorModel {
+  effectiveHistory: HistoryPoint[];
+  data: ChartData;
+  infoRows: OverviewInfoRow[];
+  summaryCards: OverviewSummaryCard[];
+  charts: OverviewChartModel[];
+}
+
+export function currentHistoryPoint(node: NodeStatus | null): HistoryPoint | null {
+  const snapshot = node?.snapshot;
+  if (!node || !snapshot) return null;
+  const disks = uniqueDisks(snapshot.disks);
+  const totalDisk = totalDiskBytes(disks);
+  const usedDisk = usedDiskBytes(disks);
+  const memoryTotal = snapshot.memory.total_bytes;
+  return {
+    node_id: node.identity.node_id,
+    recorded_at: snapshot.collected_at,
+    cpu_usage_percent: snapshot.cpu_usage_percent,
+    load_one: snapshot.load.one,
+    load_five: snapshot.load.five,
+    load_fifteen: snapshot.load.fifteen,
+    memory_used_percent: memoryTotal > 0 ? (snapshot.memory.used_bytes / memoryTotal) * 100 : 0,
+    rx_bytes_per_sec: snapshot.network.rx_bytes_per_sec,
+    tx_bytes_per_sec: snapshot.network.tx_bytes_per_sec,
+    latency_ms: node.latency_ms,
+    packet_loss_percent: snapshot.network.packet_loss_percent,
+    disk_used_percent: totalDisk > 0 ? (usedDisk / totalDisk) * 100 : null,
+  };
+}
+
+export function effectiveHistory(history: HistoryPoint[], node: NodeStatus | null): HistoryPoint[] {
+  const current = currentHistoryPoint(node);
+  if (!current) return history;
+  if (history.some((point) => point.recorded_at === current.recorded_at)) return history;
+  return [...history, current];
+}
+
+function uptimeText(seconds: number | null | undefined, t: OverviewMonitorTranslate): string {
+  const parts = uptimeParts(seconds);
+  if (!parts) return t('common.not_available');
+  const named = { days: parts.days, hours: parts.hours, minutes: parts.minutes };
+  if (parts.days > 0) return t('node.uptime.days_hours', named);
+  if (parts.hours > 0) return t('node.uptime.hours_minutes', named);
+  return t('node.uptime.minutes', named);
+}
+
+export function buildOverviewInfoRows(
+  node: NodeStatus | null,
+  t: OverviewMonitorTranslate,
+): OverviewInfoRow[] {
+  if (!node) return [];
+  const id = node.identity;
+  const snapshot = node.snapshot;
+  const disks = uniqueDisks(snapshot?.disks);
+  const totalDisk = totalDiskBytes(disks);
+  const cpuLine = id.cpu_cores
+    ? `${t('node.info.cores', { count: id.cpu_cores })}${id.cpu_model ? ` · ${id.cpu_model}` : ''}`
+    : (id.cpu_model ?? t('common.unknown'));
+
+  return [
+    { label: t('node.info.os'), value: id.os || t('common.unknown_os') },
+    { label: t('node.info.kernel'), value: id.kernel_version || t('common.unknown') },
+    { label: t('node.info.cpu'), value: cpuLine },
+    {
+      label: t('node.info.memory'),
+      value: snapshot?.memory.total_bytes
+        ? (fmtBytes(snapshot.memory.total_bytes) ?? t('common.not_available'))
+        : t('common.not_available'),
+    },
+    {
+      label: t('node.info.disk'),
+      value: totalDisk
+        ? (fmtBytes(totalDisk) ?? t('common.not_available'))
+        : t('common.not_available'),
+    },
+    { label: t('node.info.virtualization'), value: id.agent_version || t('common.unknown') },
+    { label: t('node.info.uptime'), value: uptimeText(snapshot?.uptime_secs, t) },
+  ];
+}
+
+function memoryPercent(node: NodeStatus | null): number | null {
+  const memory = node?.snapshot?.memory;
+  return memory?.total_bytes ? (memory.used_bytes / memory.total_bytes) * 100 : null;
+}
+
+function diskSummary(node: NodeStatus | null): { pct: number | null; used: string; total: string } {
+  const disks = uniqueDisks(node?.snapshot?.disks);
+  const total = totalDiskBytes(disks);
+  const used = usedDiskBytes(disks);
+  return {
+    pct: total ? (used / total) * 100 : null,
+    used: total ? (fmtBytes(used) ?? '—') : '—',
+    total: total ? (fmtBytes(total) ?? '—') : '—',
+  };
+}
+
+function percentText(value: number | null | undefined): string {
+  return value == null ? '—' : formatChartValue(value, 'percent');
+}
+
+function progress(value: number | null | undefined): number | null {
+  if (value == null || !Number.isFinite(Number(value))) return null;
+  return Math.max(0, Math.min(100, Number(value)));
+}
+
+function avgText(points: ChartPoint[], kind: ChartValueKind, t: OverviewMonitorTranslate): string {
+  const avg = averageValue(points);
+  return t('node.chart.average', {
+    value: avg == null ? '—' : formatChartValue(avg, kind),
+  });
+}
+
+export function buildOverviewSummaryCards(
+  node: NodeStatus | null,
+  data: ChartData,
+  t: OverviewMonitorTranslate,
+): OverviewSummaryCard[] {
+  const memory = node?.snapshot?.memory;
+  const memPct = memoryPercent(node);
+  const disk = diskSummary(node);
+  const cpuValue = node?.snapshot?.cpu_usage_percent ?? null;
+  const loadValue = node?.snapshot?.load ?? null;
+  const latencyValue = node?.latency_ms ?? null;
+
+  return [
+    {
+      key: 'cpu',
+      label: t('node.cpu_usage'),
+      value: percentText(cpuValue),
+      sub: avgText(data.cpuPts, 'percent', t),
+      progress: progress(cpuValue),
+      tone: 'green',
+    },
+    {
+      key: 'memory',
+      label: t('node.memory_usage'),
+      value: percentText(memPct),
+      sub: memory?.total_bytes
+        ? `${fmtBytes(memory.used_bytes) ?? '—'} / ${fmtBytes(memory.total_bytes) ?? '—'}`
+        : '—',
+      progress: progress(memPct),
+      tone: 'blue',
+    },
+    {
+      key: 'disk',
+      label: t('node.disk_usage'),
+      value: percentText(disk.pct),
+      sub: `${disk.used} / ${disk.total}`,
+      progress: progress(disk.pct),
+      tone: 'teal',
+    },
+    {
+      key: 'load',
+      label: t('node.load'),
+      value: loadValue ? loadValue.one.toFixed(2) : '—',
+      sub: loadValue
+        ? `${loadValue.one.toFixed(2)} / ${loadValue.five.toFixed(2)} / ${loadValue.fifteen.toFixed(2)}`
+        : '—',
+      progress: null,
+      tone: 'neutral',
+    },
+    {
+      key: 'latency',
+      label: t('node.latency_history'),
+      value: latencyValue == null ? '—' : formatChartValue(latencyValue, 'latency'),
+      sub: avgText(data.rttPts, 'latency', t),
+      progress: null,
+      tone: 'yellow',
+    },
+  ];
+}
+
+export function buildOverviewCharts(
+  node: NodeStatus | null,
+  data: ChartData,
+  clipSpikes: ClipState,
+  t: OverviewMonitorTranslate,
+): OverviewChartModel[] {
+  const memPct = memoryPercent(node);
+  const disk = diskSummary(node);
+  const cpuValue = node?.snapshot?.cpu_usage_percent ?? null;
+  const loadValue = node?.snapshot?.load ?? null;
+  const latencyValue = node?.latency_ms ?? null;
+  const networkValue = node?.snapshot?.network ?? null;
+
+  return [
+    {
+      metric: 'cpu',
+      title: t('node.cpu_usage'),
+      meta: percentText(cpuValue),
+      sub: avgText(data.cpuPts, 'percent', t),
+      chartProps: {
+        points: data.cpuPts,
+        valueKind: 'percent',
+        color: 'var(--chart-cpu)',
+        label: t('node.cpu_usage'),
+        clipSpikes: clipSpikes.cpu,
+      },
+    },
+    {
+      metric: 'memory',
+      title: t('node.memory_usage'),
+      meta: percentText(memPct),
+      sub: avgText(data.memPts, 'percent', t),
+      chartProps: {
+        points: data.memPts,
+        valueKind: 'percent',
+        color: 'var(--chart-memory)',
+        label: t('node.memory_usage'),
+        maxValue: 100,
+        clipSpikes: clipSpikes.memory,
+      },
+    },
+    {
+      metric: 'network',
+      title: t('node.network_traffic'),
+      meta: fmtRate(networkValue?.rx_bytes_per_sec) ?? '—',
+      sub: fmtRate(networkValue?.tx_bytes_per_sec) ?? '—',
+      chartProps: {
+        series: networkSeries(data, t('index.node.download'), t('index.node.upload')),
+        valueKind: 'rate',
+        clipSpikes: clipSpikes.network,
+      },
+    },
+    {
+      metric: 'load',
+      title: t('node.load'),
+      meta: loadValue ? loadValue.one.toFixed(2) : '—',
+      sub: avgText(data.loadOnePts, 'number', t),
+      chartProps: {
+        series: loadSeries(data),
+        valueKind: 'number',
+        clipSpikes: clipSpikes.load,
+      },
+    },
+    {
+      metric: 'disk',
+      title: t('node.disk_usage'),
+      meta: percentText(disk.pct),
+      sub: avgText(data.diskPts, 'percent', t),
+      chartProps: {
+        points: data.diskPts,
+        valueKind: 'percent',
+        color: 'var(--chart-disk)',
+        label: t('node.disk_usage'),
+        maxValue: 100,
+        clipSpikes: clipSpikes.disk,
+      },
+    },
+    {
+      metric: 'latency',
+      title: t('node.latency_history'),
+      meta: latencyValue == null ? '—' : formatChartValue(latencyValue, 'latency'),
+      sub: avgText(data.rttPts, 'latency', t),
+      chartProps: {
+        points: data.rttPts,
+        valueKind: 'latency',
+        color: 'var(--chart-latency)',
+        label: t('node.latency_history'),
+        clipSpikes: clipSpikes.latency,
+      },
+    },
+  ];
+}
+
+export function buildOverviewMonitorModel(params: {
+  node: NodeStatus | null;
+  history: HistoryPoint[];
+  clipSpikes: ClipState;
+  t: OverviewMonitorTranslate;
+}): OverviewMonitorModel {
+  const history = effectiveHistory(params.history, params.node);
+  const data = buildChartData(history);
+  return {
+    effectiveHistory: history,
+    data,
+    infoRows: buildOverviewInfoRows(params.node, params.t),
+    summaryCards: buildOverviewSummaryCards(params.node, data, params.t),
+    charts: buildOverviewCharts(params.node, data, params.clipSpikes, params.t),
+  };
+}

--- a/nodelite-server/web/src/ws/client.spec.ts
+++ b/nodelite-server/web/src/ws/client.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WS } from 'vitest-websocket-mock';
-import { WsClient } from './client';
+import { parseBrowserMessage, WsClient } from './client';
 import type { BrowserMessage } from '@/api/types';
 
 describe('WsClient', () => {
@@ -157,6 +157,16 @@ describe('WsClient', () => {
   });
 
   describe('message handling', () => {
+    it('parses only known browser message shapes', () => {
+      expect(parseBrowserMessage({ type: 'pong' })).toEqual({ type: 'pong' });
+      expect(
+        parseBrowserMessage({ type: 'node_removed', generated_at: 'now', node_id: 'node-a' }),
+      ).toEqual({ type: 'node_removed', generated_at: 'now', node_id: 'node-a' });
+      expect(parseBrowserMessage({ type: 'node_removed', generated_at: 'now' })).toBeNull();
+      expect(parseBrowserMessage({ type: 'future_message', generated_at: 'now' })).toBeNull();
+      expect(parseBrowserMessage(null)).toBeNull();
+    });
+
     it('delivers InitialState to registered handlers', async () => {
       server = new WS('ws://localhost:1234/ws/browser');
       client = new WsClient('ws://localhost:1234/ws/browser');
@@ -232,6 +242,66 @@ describe('WsClient', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(handler).toHaveBeenCalledWith(msg);
+    });
+
+    it('ignores malformed JSON without dispatching handlers', async () => {
+      server = new WS('ws://localhost:1234/ws/browser');
+      client = new WsClient('ws://localhost:1234/ws/browser');
+
+      const handler = vi.fn();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      client.on('initial_state', handler);
+
+      client.connect();
+      await server.connected;
+
+      server.send('{not-json');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Failed to parse WebSocket message',
+        expect.any(SyntaxError),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('ignores unknown message types without dispatching handlers', async () => {
+      server = new WS('ws://localhost:1234/ws/browser');
+      client = new WsClient('ws://localhost:1234/ws/browser');
+
+      const handler = vi.fn();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      client.on('overview_update', handler);
+
+      client.connect();
+      await server.connected;
+
+      server.send(JSON.stringify({ type: 'future_message', generated_at: '2026-06-01T12:00:00Z' }));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith('Ignoring invalid WebSocket browser message');
+      warnSpy.mockRestore();
+    });
+
+    it('ignores known message types with missing required fields', async () => {
+      server = new WS('ws://localhost:1234/ws/browser');
+      client = new WsClient('ws://localhost:1234/ws/browser');
+
+      const handler = vi.fn();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      client.on('node_removed', handler);
+
+      client.connect();
+      await server.connected;
+
+      server.send(JSON.stringify({ type: 'node_removed', generated_at: '2026-06-01T12:00:00Z' }));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith('Ignoring invalid WebSocket browser message');
+      warnSpy.mockRestore();
     });
 
     it('unsubscribes handlers via returned function', async () => {

--- a/nodelite-server/web/src/ws/client.ts
+++ b/nodelite-server/web/src/ws/client.ts
@@ -13,6 +13,52 @@ type MessageHandler<T extends BrowserMessage['type']> = (
 
 type UnsubscribeFn = () => void;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function hasStringField(value: Record<string, unknown>, key: string): boolean {
+  return typeof value[key] === 'string';
+}
+
+function hasRecordField(value: Record<string, unknown>, key: string): boolean {
+  return isRecord(value[key]);
+}
+
+function hasArrayField(value: Record<string, unknown>, key: string): boolean {
+  return Array.isArray(value[key]);
+}
+
+export function parseBrowserMessage(value: unknown): BrowserMessage | null {
+  if (!isRecord(value) || typeof value.type !== 'string') return null;
+
+  switch (value.type) {
+    case 'initial_state':
+      return hasStringField(value, 'generated_at') &&
+        hasRecordField(value, 'overview') &&
+        hasArrayField(value, 'nodes')
+        ? (value as BrowserMessage)
+        : null;
+    case 'overview_update':
+      return hasStringField(value, 'generated_at') && hasRecordField(value, 'overview')
+        ? (value as BrowserMessage)
+        : null;
+    case 'node_upsert':
+      return hasStringField(value, 'generated_at') && hasRecordField(value, 'node')
+        ? (value as BrowserMessage)
+        : null;
+    case 'node_removed':
+      return hasStringField(value, 'generated_at') && hasStringField(value, 'node_id')
+        ? (value as BrowserMessage)
+        : null;
+    case 'ping':
+    case 'pong':
+      return value as BrowserMessage;
+    default:
+      return null;
+  }
+}
+
 export class WsClient {
   private ws: WebSocket | null = null;
   private state: ConnectionState = { kind: 'idle' };
@@ -61,10 +107,7 @@ export class WsClient {
     }
   }
 
-  on<T extends BrowserMessage['type']>(
-    type: T,
-    handler: MessageHandler<T>,
-  ): UnsubscribeFn {
+  on<T extends BrowserMessage['type']>(type: T, handler: MessageHandler<T>): UnsubscribeFn {
     if (!this.handlers.has(type)) {
       this.handlers.set(type, new Set());
     }
@@ -102,7 +145,11 @@ export class WsClient {
 
   private onMessage(event: MessageEvent): void {
     try {
-      const msg = JSON.parse(event.data) as BrowserMessage;
+      const msg = parseBrowserMessage(JSON.parse(event.data));
+      if (!msg) {
+        console.warn('Ignoring invalid WebSocket browser message');
+        return;
+      }
 
       if (msg.type === 'pong') {
         this.clearPongTimer();
@@ -240,7 +287,11 @@ export class WsClient {
         this.ws.close();
       }
     } else {
-      if (this.state.kind === 'failed' || this.state.kind === 'idle' || this.state.kind === 'reconnecting') {
+      if (
+        this.state.kind === 'failed' ||
+        this.state.kind === 'idle' ||
+        this.state.kind === 'reconnecting'
+      ) {
         console.log('Tab visible, reconnecting');
         this.clearReconnectTimer();
         this.handshakeFailures = 0;


### PR DESCRIPTION
## Summary
- harden auth expiry handling when localStorage is unavailable and validate browser WebSocket messages before dispatch
- extract pure model logic for NodeOverviewMonitor and NodeHardwarePanel
- extract NodeSettingsPanel draft/submit state into a dedicated composable with focused tests

## Issues
Closes #242
Closes #243
Closes #244
Closes #246
Closes #249

## Verification
- pnpm exec vitest run src/auth/expiry.spec.ts src/ws/client.spec.ts
- pnpm exec vitest run src/components/NodeOverviewMonitor.spec.ts src/lib/nodeOverviewMonitorModel.spec.ts
- pnpm exec vitest run src/components/NodeHardwarePanel.spec.ts src/lib/nodeHardwareModel.spec.ts
- pnpm exec vitest run src/components/NodeSettingsPanel.spec.ts src/composables/useNodeSettingsDraft.spec.ts
- pnpm test
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- cargo test --workspace
- cargo clippy --all-targets -- -D warnings