### PR TITLE
Finish registry, alerts, and ws follow-up issues

### DIFF
--- a/nodelite-server/src/alerts/evaluator.rs
+++ b/nodelite-server/src/alerts/evaluator.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use nodelite_proto::{
-    AlertComparator, AlertMetric, AlertRuleConfig, AlertScopeMode, InspectionConfig, NodeStatus,
+    AlertComparator, AlertMetric, AlertRuleConfig, AlertScopeMode, InspectionConfig, NodeSnapshot,
+    NodeStatus,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,35 +36,84 @@ pub(crate) struct InspectionHighlight {
     pub(crate) reasons: Vec<String>,
 }
 
-pub(crate) fn evaluate_rules(
+pub(crate) trait AlertStatusView {
+    fn node_id(&self) -> &str;
+    fn node_label(&self) -> &str;
+    fn tags(&self) -> &[String];
+    fn snapshot(&self) -> Option<&NodeSnapshot>;
+    fn last_seen(&self) -> Option<DateTime<Utc>>;
+    fn latency_ms(&self) -> Option<u64>;
+    fn online(&self) -> bool;
+}
+
+impl AlertStatusView for NodeStatus {
+    fn node_id(&self) -> &str {
+        &self.identity.node_id
+    }
+
+    fn node_label(&self) -> &str {
+        &self.identity.node_label
+    }
+
+    fn tags(&self) -> &[String] {
+        &self.identity.tags
+    }
+
+    fn snapshot(&self) -> Option<&NodeSnapshot> {
+        self.snapshot.as_ref()
+    }
+
+    fn last_seen(&self) -> Option<DateTime<Utc>> {
+        self.last_seen
+    }
+
+    fn latency_ms(&self) -> Option<u64> {
+        self.latency_ms
+    }
+
+    fn online(&self) -> bool {
+        self.online
+    }
+}
+
+pub(crate) fn evaluate_rules<'a, I, S>(
     rules: &[AlertRuleConfig],
-    statuses: &[NodeStatus],
+    statuses: I,
     now: DateTime<Utc>,
-) -> Vec<EvaluatedRule> {
+) -> Vec<EvaluatedRule>
+where
+    I: IntoIterator<Item = &'a S>,
+    S: AlertStatusView + 'a,
+{
+    let statuses: Vec<&S> = statuses.into_iter().collect();
     let mut matches = Vec::new();
     for rule in rules.iter().filter(|rule| rule.enabled) {
         matches.extend(
             statuses
                 .iter()
+                .copied()
                 .filter_map(|status| evaluate_rule(rule, status, now)),
         );
     }
     matches
 }
 
-pub(crate) fn evaluate_rule(
+pub(crate) fn evaluate_rule<S>(
     rule: &AlertRuleConfig,
-    status: &NodeStatus,
+    status: &S,
     now: DateTime<Utc>,
-) -> Option<EvaluatedRule> {
+) -> Option<EvaluatedRule>
+where
+    S: AlertStatusView + ?Sized,
+{
     let value = rule_metric_value(rule, status, now)?;
     if !comparator_matches(rule.comparator.clone(), value, rule.threshold) {
         return None;
     }
     Some(EvaluatedRule {
         rule_id: rule.id.clone(),
-        node_id: status.identity.node_id.clone(),
-        node_label: status.identity.node_label.clone(),
+        node_id: status.node_id().to_string(),
+        node_label: status.node_label().to_string(),
         reading: AlertMetricReading {
             metric: rule.metric.clone(),
             value,
@@ -72,11 +122,16 @@ pub(crate) fn evaluate_rule(
     })
 }
 
-pub(crate) fn build_inspection_report(
+pub(crate) fn build_inspection_report<'a, I, S>(
     inspection: &InspectionConfig,
-    statuses: &[NodeStatus],
+    statuses: I,
     now: DateTime<Utc>,
-) -> InspectionReport {
+) -> InspectionReport
+where
+    I: IntoIterator<Item = &'a S>,
+    S: AlertStatusView + 'a,
+{
+    let mut total_nodes = 0;
     let mut offline_nodes = 0;
     let mut latency_nodes = 0;
     let mut cpu_hot_nodes = 0;
@@ -84,6 +139,7 @@ pub(crate) fn build_inspection_report(
     let mut highlights = Vec::new();
 
     for status in statuses {
+        total_nodes += 1;
         let mut reasons = Vec::new();
         if offline_minutes(status, now)
             .is_some_and(|minutes| minutes >= inspection.offline_grace_minutes)
@@ -92,15 +148,14 @@ pub(crate) fn build_inspection_report(
             reasons.push("offline".to_string());
         }
         if status
-            .latency_ms
+            .latency_ms()
             .is_some_and(|latency| latency >= inspection.latency_warn_ms)
         {
             latency_nodes += 1;
             reasons.push("latency".to_string());
         }
         if status
-            .snapshot
-            .as_ref()
+            .snapshot()
             .and_then(|snapshot| snapshot.cpu_usage_percent)
             .is_some_and(|cpu| cpu >= inspection.cpu_warn_percent as f64)
         {
@@ -116,14 +171,14 @@ pub(crate) fn build_inspection_report(
             continue;
         }
         highlights.push(InspectionHighlight {
-            node_id: status.identity.node_id.clone(),
-            node_label: status.identity.node_label.clone(),
+            node_id: status.node_id().to_string(),
+            node_label: status.node_label().to_string(),
             reasons,
         });
     }
 
     InspectionReport {
-        total_nodes: statuses.len(),
+        total_nodes,
         offline_nodes,
         latency_nodes,
         cpu_hot_nodes,
@@ -132,41 +187,44 @@ pub(crate) fn build_inspection_report(
     }
 }
 
-fn rule_metric_value(
-    rule: &AlertRuleConfig,
-    status: &NodeStatus,
-    now: DateTime<Utc>,
-) -> Option<u64> {
+fn rule_metric_value<S>(rule: &AlertRuleConfig, status: &S, now: DateTime<Utc>) -> Option<u64>
+where
+    S: AlertStatusView + ?Sized,
+{
     if !rule_matches_scope(rule, status) {
         return None;
     }
     metric_value(rule.metric.clone(), status, now)
 }
 
-fn rule_matches_scope(rule: &AlertRuleConfig, status: &NodeStatus) -> bool {
+fn rule_matches_scope<S>(rule: &AlertRuleConfig, status: &S) -> bool
+where
+    S: AlertStatusView + ?Sized,
+{
     match rule.scope_mode {
         AlertScopeMode::All => true,
         AlertScopeMode::NodeIds => rule
             .node_ids
             .iter()
-            .any(|node_id| node_id == &status.identity.node_id),
+            .any(|node_id| node_id == status.node_id()),
         AlertScopeMode::Tags => status
-            .identity
-            .tags
+            .tags()
             .iter()
             .any(|tag| rule.tags.iter().any(|rule_tag| rule_tag == tag)),
     }
 }
 
-fn metric_value(metric: AlertMetric, status: &NodeStatus, now: DateTime<Utc>) -> Option<u64> {
+fn metric_value<S>(metric: AlertMetric, status: &S, now: DateTime<Utc>) -> Option<u64>
+where
+    S: AlertStatusView + ?Sized,
+{
     match metric {
         AlertMetric::CpuUsagePercent => status
-            .snapshot
-            .as_ref()
+            .snapshot()
             .and_then(|snapshot| snapshot.cpu_usage_percent.map(|value| value.round() as u64)),
         AlertMetric::MemoryUsagePercent => memory_percent(status),
         AlertMetric::DiskUsagePercent => max_disk_percent(status),
-        AlertMetric::LatencyMs => status.latency_ms,
+        AlertMetric::LatencyMs => status.latency_ms(),
         AlertMetric::OfflineMinutes => offline_minutes(status, now),
     }
 }
@@ -178,18 +236,23 @@ fn comparator_matches(comparator: AlertComparator, left: u64, right: u64) -> boo
     }
 }
 
-fn memory_percent(status: &NodeStatus) -> Option<u64> {
-    let memory = &status.snapshot.as_ref()?.memory;
+fn memory_percent<S>(status: &S) -> Option<u64>
+where
+    S: AlertStatusView + ?Sized,
+{
+    let memory = &status.snapshot()?.memory;
     if memory.total_bytes == 0 {
         return None;
     }
     Some(((memory.used_bytes.saturating_mul(100)) / memory.total_bytes).min(100))
 }
 
-fn max_disk_percent(status: &NodeStatus) -> Option<u64> {
+fn max_disk_percent<S>(status: &S) -> Option<u64>
+where
+    S: AlertStatusView + ?Sized,
+{
     status
-        .snapshot
-        .as_ref()?
+        .snapshot()?
         .disks
         .iter()
         .filter(|disk| disk.total_bytes > 0)
@@ -197,11 +260,14 @@ fn max_disk_percent(status: &NodeStatus) -> Option<u64> {
         .max()
 }
 
-fn offline_minutes(status: &NodeStatus, now: DateTime<Utc>) -> Option<u64> {
-    if status.online {
+fn offline_minutes<S>(status: &S, now: DateTime<Utc>) -> Option<u64>
+where
+    S: AlertStatusView + ?Sized,
+{
+    if status.online() {
         return None;
     }
-    let minutes = (now - status.last_seen?).num_minutes();
+    let minutes = (now - status.last_seen()?).num_minutes();
     Some(minutes.max(0) as u64)
 }
 

--- a/nodelite-server/src/alerts/mod.rs
+++ b/nodelite-server/src/alerts/mod.rs
@@ -10,7 +10,8 @@ pub(crate) use delivery::{
     webhook_endpoint_label,
 };
 pub(crate) use evaluator::{
-    AlertMetricReading, EvaluatedRule, InspectionReport, build_inspection_report, evaluate_rules,
+    AlertMetricReading, AlertStatusView, EvaluatedRule, InspectionReport, build_inspection_report,
+    evaluate_rules,
 };
 pub(crate) use runtime::spawn_alert_runtime;
 pub(crate) use tracker::{AlertEvent, AlertEventKind, AlertStateTracker};

--- a/nodelite-server/src/alerts/runtime.rs
+++ b/nodelite-server/src/alerts/runtime.rs
@@ -15,8 +15,7 @@ use crate::state::SharedState;
 use super::delivery::AlertDeliveryError;
 use super::{
     AlertEvent, AlertEventKind, AlertStateTracker, InspectionReport, InspectionSummary,
-    build_inspection_report, deliver_alert_event, deliver_inspection_summary, evaluate_rules,
-    smtp_endpoint_label, webhook_endpoint_label,
+    deliver_alert_event, deliver_inspection_summary, smtp_endpoint_label, webhook_endpoint_label,
 };
 
 const ALERT_EVALUATION_INTERVAL_SECS: u64 = 30;
@@ -98,11 +97,10 @@ async fn run_alert_runtime(
                 }
 
                 let now = Utc::now();
-                let statuses = shared.list_statuses().await;
                 if config.rules.is_empty() {
                     tracker.clear();
                 } else {
-                    let matches = evaluate_rules(&config.rules, &statuses, now);
+                    let matches = shared.evaluate_alert_rules(&config.rules, now).await;
                     for event in tracker.update(&config.rules, &matches, now) {
                         log_alert_event(&event);
                         enqueue_alert_delivery(&delivery_tx, &mut tracker, &config, &event, now);
@@ -113,7 +111,9 @@ async fn run_alert_runtime(
                     && let Some(local_date) =
                         inspection_dispatch.due_date(&config.inspection.local_time, Local::now(), now)
                 {
-                    let report = build_inspection_report(&config.inspection, &statuses, now);
+                    let report = shared
+                        .build_alert_inspection_report(&config.inspection, now)
+                        .await;
                     enqueue_inspection_delivery(
                         &delivery_tx,
                         &mut inspection_dispatch,

--- a/nodelite-server/src/state.rs
+++ b/nodelite-server/src/state.rs
@@ -281,8 +281,9 @@ impl SharedState {
     /// revision 用于让浏览器端识别后续增量是否基于同一代节点视图。
     pub(crate) async fn browser_snapshot(&self) -> BrowserSnapshot {
         let generated_at = Utc::now();
-        let (nodes, overview) = self.registry.browser_view();
-        let revision = self.nodes_revision.load(Ordering::Acquire);
+        let (nodes, overview, revision) = self
+            .registry
+            .browser_view_with_revision(|| self.nodes_revision.load(Ordering::Acquire));
         BrowserSnapshot {
             revision,
             generated_at,

--- a/nodelite-server/src/state.rs
+++ b/nodelite-server/src/state.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 use axum::body::Bytes;
 use chrono::{DateTime, Utc};
 use nodelite_proto::{
-    BrowserMessage, GeoIpLocation, NodeIdentity, NodeListItem, NodeSnapshot, NodeStatus,
-    OverviewData, ServerConfig,
+    AlertRuleConfig, BrowserMessage, GeoIpLocation, InspectionConfig, NodeIdentity, NodeListItem,
+    NodeSnapshot, NodeStatus, OverviewData, ServerConfig,
 };
 use tokio::sync::{Mutex, RwLock, broadcast, oneshot};
 use tokio_util::sync::CancellationToken;
@@ -46,6 +46,7 @@ enum ApiBodyKind {
 /// 的 revision 影响范围收窄到 nodes,避免聚合数据无限期不刷新。
 const OVERVIEW_CACHE_MAX_STALE: Duration = Duration::from_secs(1);
 use crate::ServerReadiness;
+use crate::alerts::{EvaluatedRule, InspectionReport};
 use crate::handlers::metrics_exporter::{
     ApiCacheMetrics, SqliteWalCheckpointMetrics, WsMessageMetrics,
 };
@@ -262,6 +263,24 @@ impl SharedState {
     pub async fn list_node_summaries(&self) -> Vec<NodeListItem> {
         let registry = self.registry.read().await;
         registry.list_node_summaries()
+    }
+
+    pub(crate) async fn evaluate_alert_rules(
+        &self,
+        rules: &[AlertRuleConfig],
+        now: DateTime<Utc>,
+    ) -> Vec<EvaluatedRule> {
+        let registry = self.registry.read().await;
+        registry.evaluate_alert_rules(rules, now)
+    }
+
+    pub(crate) async fn build_alert_inspection_report(
+        &self,
+        inspection: &InspectionConfig,
+        now: DateTime<Utc>,
+    ) -> InspectionReport {
+        let registry = self.registry.read().await;
+        registry.build_alert_inspection_report(inspection, now)
     }
 
     /// 返回浏览器全量视图和对应 revision。revision 在持有 registry 读锁时读取:

--- a/nodelite-server/src/state.rs
+++ b/nodelite-server/src/state.rs
@@ -25,7 +25,7 @@ use nodelite_proto::{
     AlertRuleConfig, BrowserMessage, GeoIpLocation, InspectionConfig, NodeIdentity, NodeListItem,
     NodeSnapshot, NodeStatus, OverviewData, ServerConfig,
 };
-use tokio::sync::{Mutex, RwLock, broadcast, oneshot};
+use tokio::sync::{Mutex, broadcast, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use self::registry::Registry;
@@ -84,7 +84,7 @@ const BROWSER_INCREMENTAL_CHANNEL_CAPACITY: usize = 256;
 #[derive(Clone)]
 pub struct SharedState {
     config: Arc<ServerConfig>,
-    registry: Arc<RwLock<Registry>>,
+    registry: Arc<Registry>,
     next_session_id: Arc<AtomicU64>,
     overview_revision: Arc<AtomicU64>,
     nodes_revision: Arc<AtomicU64>,
@@ -122,7 +122,7 @@ impl SharedState {
     pub fn new(config: Arc<ServerConfig>) -> Self {
         Self {
             config: Arc::clone(&config),
-            registry: Arc::new(RwLock::new(Registry::default())),
+            registry: Arc::new(Registry::default()),
             next_session_id: Arc::new(AtomicU64::new(1)),
             overview_revision: Arc::new(AtomicU64::new(1)),
             nodes_revision: Arc::new(AtomicU64::new(1)),
@@ -174,8 +174,7 @@ impl SharedState {
     ) -> u64 {
         let session_id = self.next_session_id.fetch_add(1, Ordering::Relaxed);
         let now = Utc::now();
-        let mut registry = self.registry.write().await;
-        registry.register_node(
+        self.registry.register_node(
             session_id,
             identity,
             remote_ip,
@@ -198,8 +197,9 @@ impl SharedState {
         session_id: u64,
         snapshot: NodeSnapshot,
     ) -> Option<NodeStatus> {
-        let mut registry = self.registry.write().await;
-        let status = registry.update_snapshot(node_id, session_id, snapshot, Utc::now());
+        let status = self
+            .registry
+            .update_snapshot(node_id, session_id, snapshot, Utc::now());
         if status.is_some() {
             self.bump_nodes_revision_only();
         }
@@ -208,8 +208,9 @@ impl SharedState {
 
     /// 更新某节点的最新延迟值,语义同 `update_snapshot`(只 bump nodes_revision)。
     pub async fn update_latency(&self, node_id: &str, session_id: u64, latency_ms: u64) -> bool {
-        let mut registry = self.registry.write().await;
-        let updated = registry.update_latency(node_id, session_id, latency_ms, Utc::now());
+        let updated = self
+            .registry
+            .update_latency(node_id, session_id, latency_ms, Utc::now());
         if updated {
             self.bump_nodes_revision_only();
         }
@@ -218,8 +219,7 @@ impl SharedState {
 
     /// 标记某会话的连接已断开。如果当前活跃 ID 不再等于该会话,则什么也不做。
     pub async fn mark_disconnected(&self, node_id: &str, session_id: u64) {
-        let mut registry = self.registry.write().await;
-        if registry.mark_disconnected(node_id, session_id) {
+        if self.registry.mark_disconnected(node_id, session_id) {
             self.bump_view_revision();
         }
     }
@@ -231,14 +231,13 @@ impl SharedState {
         session_id: u64,
         control: SessionControlHandle,
     ) -> bool {
-        let mut registry = self.registry.write().await;
-        registry.attach_session_control(node_id, session_id, control)
+        self.registry
+            .attach_session_control(node_id, session_id, control)
     }
 
     /// 把超时(超过 `stale_after_secs`)的节点统一标记为离线,返回受影响节点数。
     pub async fn mark_stale(&self) -> usize {
-        let mut registry = self.registry.write().await;
-        let marked = registry.mark_stale(
+        let marked = self.registry.mark_stale(
             Duration::from_secs(self.config.stale_after_secs),
             Utc::now(),
         );
@@ -250,19 +249,16 @@ impl SharedState {
 
     /// 判断给定 `session_id` 是否仍是该节点的当前会话。
     pub async fn is_current_session(&self, node_id: &str, session_id: u64) -> bool {
-        let registry = self.registry.read().await;
-        registry.is_current_session(node_id, session_id)
+        self.registry.is_current_session(node_id, session_id)
     }
 
     /// 列出所有节点的状态(按 `node_label`、`node_id` 升序)。
     pub async fn list_statuses(&self) -> Vec<NodeStatus> {
-        let registry = self.registry.read().await;
-        registry.list_statuses()
+        self.registry.list_statuses()
     }
 
     pub async fn list_node_summaries(&self) -> Vec<NodeListItem> {
-        let registry = self.registry.read().await;
-        registry.list_node_summaries()
+        self.registry.list_node_summaries()
     }
 
     pub(crate) async fn evaluate_alert_rules(
@@ -270,8 +266,7 @@ impl SharedState {
         rules: &[AlertRuleConfig],
         now: DateTime<Utc>,
     ) -> Vec<EvaluatedRule> {
-        let registry = self.registry.read().await;
-        registry.evaluate_alert_rules(rules, now)
+        self.registry.evaluate_alert_rules(rules, now)
     }
 
     pub(crate) async fn build_alert_inspection_report(
@@ -279,17 +274,14 @@ impl SharedState {
         inspection: &InspectionConfig,
         now: DateTime<Utc>,
     ) -> InspectionReport {
-        let registry = self.registry.read().await;
-        registry.build_alert_inspection_report(inspection, now)
+        self.registry.build_alert_inspection_report(inspection, now)
     }
 
-    /// 返回浏览器全量视图和对应 revision。revision 在持有 registry 读锁时读取:
-    /// 若某次写入尚未进入快照,它也不可能已经 bump revision。
+    /// 返回浏览器全量视图和对应 revision。nodes/overview 来自同一组 registry 分片读视图,
+    /// revision 用于让浏览器端识别后续增量是否基于同一代节点视图。
     pub(crate) async fn browser_snapshot(&self) -> BrowserSnapshot {
         let generated_at = Utc::now();
-        let registry = self.registry.read().await;
-        let nodes = registry.list_node_summaries();
-        let overview = registry.overview();
+        let (nodes, overview) = self.registry.browser_view();
         let revision = self.nodes_revision.load(Ordering::Acquire);
         BrowserSnapshot {
             revision,
@@ -300,23 +292,20 @@ impl SharedState {
     }
 
     pub async fn get_status(&self, node_id: &str) -> Option<NodeStatus> {
-        let registry = self.registry.read().await;
-        registry.get_status(node_id)
+        self.registry.get_status(node_id)
     }
 
     pub(crate) async fn geoip_refresh_candidates(&self) -> Vec<(String, String)> {
-        let registry = self.registry.read().await;
-        registry.geoip_refresh_candidates()
+        self.registry.geoip_refresh_candidates()
     }
 
     pub(crate) async fn refresh_geoip_locations(
         &self,
         updates: Vec<(String, String, GeoIpLocation)>,
     ) -> usize {
-        let mut registry = self.registry.write().await;
         let mut updated = 0;
         for (node_id, remote_ip, geoip) in updates {
-            if registry.update_geoip(&node_id, &remote_ip, geoip) {
+            if self.registry.update_geoip(&node_id, &remote_ip, geoip) {
                 updated += 1;
             }
         }
@@ -331,8 +320,9 @@ impl SharedState {
         node_id: &str,
         location_override: Option<GeoIpLocation>,
     ) -> bool {
-        let mut registry = self.registry.write().await;
-        let updated = registry.update_location_override(node_id, location_override);
+        let updated = self
+            .registry
+            .update_location_override(node_id, location_override);
         if updated {
             self.bump_view_revision();
         }
@@ -344,9 +334,11 @@ impl SharedState {
         overrides: Vec<(String, Option<GeoIpLocation>)>,
     ) -> usize {
         let mut updated = 0;
-        let mut registry = self.registry.write().await;
         for (node_id, location_override) in overrides {
-            if registry.update_location_override(&node_id, location_override) {
+            if self
+                .registry
+                .update_location_override(&node_id, location_override)
+            {
                 updated += 1;
             }
         }
@@ -361,12 +353,10 @@ impl SharedState {
         &self,
         node_id: &str,
     ) -> Result<oneshot::Receiver<Result<SessionRefreshReply, String>>, SessionCommandError> {
-        let control_tx = {
-            let registry = self.registry.read().await;
-            registry
-                .session_control(node_id)
-                .ok_or(SessionCommandError::NodeOffline)?
-        };
+        let control_tx = self
+            .registry
+            .session_control(node_id)
+            .ok_or(SessionCommandError::NodeOffline)?;
 
         let (response_tx, response_rx) = oneshot::channel();
         if let Err(error) = control_tx.try_enqueue_refresh(response_tx) {
@@ -445,8 +435,7 @@ impl SharedState {
     }
 
     pub(crate) async fn registry_disk_entries_total(&self) -> u64 {
-        let registry = self.registry.read().await;
-        registry.disk_entries_total()
+        self.registry.disk_entries_total()
     }
 
     /// 返回缓存后的 `/metrics` 响应体。
@@ -481,8 +470,10 @@ impl SharedState {
         self.metrics_cache_builds.fetch_add(1, Ordering::Relaxed);
 
         let body = {
-            let registry = self.registry.read().await;
-            Bytes::from(registry.render_metrics_body(readiness, self.config.metrics))
+            Bytes::from(
+                self.registry
+                    .render_metrics_body(readiness, self.config.metrics),
+            )
         };
         self.metrics_body_bytes
             .store(body.len() as u64, Ordering::Relaxed);
@@ -496,8 +487,7 @@ impl SharedState {
     }
 
     async fn overview_data(&self) -> OverviewData {
-        let registry = self.registry.read().await;
-        registry.overview()
+        self.registry.overview()
     }
 
     /// 订阅浏览器视图脏信号。集中 diff 任务持有 receiver,在信号到达后
@@ -521,8 +511,7 @@ impl SharedState {
 
     /// 启动时从磁盘快照恢复状态,所有节点都视为离线直至首次心跳到达。
     pub async fn restore_statuses(&self, statuses: Vec<NodeStatus>) {
-        let mut registry = self.registry.write().await;
-        registry.restore_statuses(statuses);
+        self.registry.restore_statuses(statuses);
         self.bump_view_revision();
     }
 

--- a/nodelite-server/src/state/registry.rs
+++ b/nodelite-server/src/state/registry.rs
@@ -7,13 +7,17 @@ use chrono::{DateTime, Utc};
 #[cfg(test)]
 use nodelite_proto::DiskUsage;
 use nodelite_proto::{
-    GeoIpLocation, MetricsConfig, NodeIdentity, NodeListIdentity, NodeListItem, NodeListSnapshot,
-    NodeSnapshot, NodeStatus, OverviewData,
+    AlertRuleConfig, GeoIpLocation, InspectionConfig, MetricsConfig, NodeIdentity,
+    NodeListIdentity, NodeListItem, NodeListSnapshot, NodeSnapshot, NodeStatus, OverviewData,
 };
 
 use super::overview::{OverviewNode, build_overview_from_iter};
 use super::session_control::SessionControlHandle;
 use crate::ServerReadiness;
+use crate::alerts::{
+    AlertStatusView, EvaluatedRule, InspectionReport,
+    build_inspection_report as build_alert_inspection_report, evaluate_rules,
+};
 use crate::handlers::metrics_exporter::{PrometheusNode, render_prometheus_metrics_from_iter};
 
 #[derive(Debug, Default)]
@@ -191,6 +195,36 @@ impl NodeEntry {
     }
 }
 
+impl AlertStatusView for NodeEntry {
+    fn node_id(&self) -> &str {
+        &self.identity.node_id
+    }
+
+    fn node_label(&self) -> &str {
+        &self.identity.node_label
+    }
+
+    fn tags(&self) -> &[String] {
+        &self.identity.tags
+    }
+
+    fn snapshot(&self) -> Option<&NodeSnapshot> {
+        self.snapshot.as_ref()
+    }
+
+    fn last_seen(&self) -> Option<DateTime<Utc>> {
+        self.last_seen
+    }
+
+    fn latency_ms(&self) -> Option<u64> {
+        self.latency_ms
+    }
+
+    fn online(&self) -> bool {
+        self.online
+    }
+}
+
 fn geoip_fields_from_location(
     geoip: Option<&GeoIpLocation>,
 ) -> (Option<String>, Option<String>, Option<f64>, Option<f64>) {
@@ -336,19 +370,27 @@ impl Registry {
     }
 
     pub(super) fn list_statuses(&self) -> Vec<NodeStatus> {
-        self.sorted_node_ids
-            .iter()
-            .filter_map(|node_id| self.nodes.get(node_id))
-            .map(NodeEntry::to_status)
-            .collect()
+        self.sorted_entries().map(NodeEntry::to_status).collect()
     }
 
     pub(super) fn list_node_summaries(&self) -> Vec<NodeListItem> {
-        self.sorted_node_ids
-            .iter()
-            .filter_map(|node_id| self.nodes.get(node_id))
-            .map(NodeEntry::to_summary)
-            .collect()
+        self.sorted_entries().map(NodeEntry::to_summary).collect()
+    }
+
+    pub(super) fn evaluate_alert_rules(
+        &self,
+        rules: &[AlertRuleConfig],
+        now: DateTime<Utc>,
+    ) -> Vec<EvaluatedRule> {
+        evaluate_rules(rules, self.sorted_entries(), now)
+    }
+
+    pub(super) fn build_alert_inspection_report(
+        &self,
+        inspection: &InspectionConfig,
+        now: DateTime<Utc>,
+    ) -> InspectionReport {
+        build_alert_inspection_report(inspection, self.sorted_entries(), now)
     }
 
     pub(super) fn get_status(&self, node_id: &str) -> Option<NodeStatus> {
@@ -516,6 +558,12 @@ impl Registry {
                 .cmp(&right.identity.node_label)
                 .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
         });
+    }
+
+    fn sorted_entries(&self) -> impl Iterator<Item = &NodeEntry> {
+        self.sorted_node_ids
+            .iter()
+            .filter_map(|node_id| self.nodes.get(node_id))
     }
 }
 

--- a/nodelite-server/src/state/registry.rs
+++ b/nodelite-server/src/state/registry.rs
@@ -412,14 +412,18 @@ impl Registry {
             .collect()
     }
 
-    pub(super) fn browser_view(&self) -> (Vec<NodeListItem>, OverviewData) {
+    pub(super) fn browser_view_with_revision<R>(
+        &self,
+        load_revision: impl FnOnce() -> R,
+    ) -> (Vec<NodeListItem>, OverviewData, R) {
         let shards = self.read_all_shards();
         let nodes = sorted_entries(&shards)
             .into_iter()
             .map(NodeEntry::to_summary)
             .collect();
         let overview = overview_from_shards(&shards);
-        (nodes, overview)
+        let revision = load_revision();
+        (nodes, overview, revision)
     }
 
     pub(super) fn evaluate_alert_rules(
@@ -606,6 +610,11 @@ impl Registry {
             .iter()
             .map(|shard| read_lock(shard).nodes.len())
             .collect()
+    }
+
+    #[cfg(test)]
+    pub(super) fn shard_is_read_locked_for_test(&self, node_id: &str) -> bool {
+        self.shard_for(node_id).try_write().is_err()
     }
 
     #[cfg(test)]

--- a/nodelite-server/src/state/registry.rs
+++ b/nodelite-server/src/state/registry.rs
@@ -1,6 +1,10 @@
 //! 节点运行态注册表与会话生命周期。
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -20,10 +24,26 @@ use crate::alerts::{
 };
 use crate::handlers::metrics_exporter::{PrometheusNode, render_prometheus_metrics_from_iter};
 
-#[derive(Debug, Default)]
+const REGISTRY_SHARD_COUNT: usize = 32;
+
+#[derive(Debug)]
 pub(super) struct Registry {
+    shards: Vec<RwLock<RegistryShard>>,
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Self {
+            shards: (0..REGISTRY_SHARD_COUNT)
+                .map(|_| RwLock::new(RegistryShard::default()))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct RegistryShard {
     nodes: HashMap<String, NodeEntry>,
-    sorted_node_ids: Vec<String>,
 }
 
 /// 单节点的运行态条目。外部响应模型只在 API / snapshot 边界按需组装。
@@ -238,7 +258,7 @@ fn geoip_fields_from_location(
 
 impl Registry {
     pub(super) fn register_node(
-        &mut self,
+        &self,
         session_id: u64,
         identity: NodeIdentity,
         remote_ip: Option<String>,
@@ -247,7 +267,8 @@ impl Registry {
         now: DateTime<Utc>,
     ) {
         let node_id = identity.node_id.clone();
-        if let Some(entry) = self.nodes.get_mut(&node_id) {
+        let mut shard = write_lock(self.shard_for(&node_id));
+        if let Some(entry) = shard.nodes.get_mut(&node_id) {
             entry.register_session(
                 session_id,
                 identity,
@@ -257,8 +278,8 @@ impl Registry {
                 now,
             );
         } else {
-            self.nodes.insert(
-                node_id.clone(),
+            shard.nodes.insert(
+                node_id,
                 NodeEntry::new(
                     session_id,
                     identity,
@@ -268,19 +289,18 @@ impl Registry {
                     now,
                 ),
             );
-            self.sorted_node_ids.push(node_id);
         }
-        self.resort_node_ids();
     }
 
     pub(super) fn update_snapshot(
-        &mut self,
+        &self,
         node_id: &str,
         session_id: u64,
         snapshot: NodeSnapshot,
         now: DateTime<Utc>,
     ) -> Option<NodeStatus> {
-        let entry = self.nodes.get_mut(node_id)?;
+        let mut shard = write_lock(self.shard_for(node_id));
+        let entry = shard.nodes.get_mut(node_id)?;
         if entry.active_session_id != Some(session_id) {
             return None;
         }
@@ -292,13 +312,14 @@ impl Registry {
     }
 
     pub(super) fn update_latency(
-        &mut self,
+        &self,
         node_id: &str,
         session_id: u64,
         latency_ms: u64,
         now: DateTime<Utc>,
     ) -> bool {
-        let Some(entry) = self.nodes.get_mut(node_id) else {
+        let mut shard = write_lock(self.shard_for(node_id));
+        let Some(entry) = shard.nodes.get_mut(node_id) else {
             return false;
         };
         if entry.active_session_id != Some(session_id) {
@@ -311,8 +332,9 @@ impl Registry {
         true
     }
 
-    pub(super) fn mark_disconnected(&mut self, node_id: &str, session_id: u64) -> bool {
-        let Some(entry) = self.nodes.get_mut(node_id) else {
+    pub(super) fn mark_disconnected(&self, node_id: &str, session_id: u64) -> bool {
+        let mut shard = write_lock(self.shard_for(node_id));
+        let Some(entry) = shard.nodes.get_mut(node_id) else {
             return false;
         };
         if entry.active_session_id == Some(session_id) {
@@ -325,12 +347,13 @@ impl Registry {
     }
 
     pub(super) fn attach_session_control(
-        &mut self,
+        &self,
         node_id: &str,
         session_id: u64,
         control: SessionControlHandle,
     ) -> bool {
-        let Some(entry) = self.nodes.get_mut(node_id) else {
+        let mut shard = write_lock(self.shard_for(node_id));
+        let Some(entry) = shard.nodes.get_mut(node_id) else {
             return false;
         };
         if entry.active_session_id != Some(session_id) {
@@ -341,21 +364,24 @@ impl Registry {
         true
     }
 
-    pub(super) fn mark_stale(&mut self, threshold: Duration, now: DateTime<Utc>) -> usize {
+    pub(super) fn mark_stale(&self, threshold: Duration, now: DateTime<Utc>) -> usize {
         let mut marked = 0;
 
-        for entry in self.nodes.values_mut() {
-            let Some(last_seen) = entry.last_seen else {
-                continue;
-            };
-            let Ok(elapsed) = (now - last_seen).to_std() else {
-                continue;
-            };
-            if elapsed >= threshold && entry.online {
-                entry.online = false;
-                entry.active_session_id = None;
-                entry.control = None;
-                marked += 1;
+        for shard in &self.shards {
+            let mut shard = write_lock(shard);
+            for entry in shard.nodes.values_mut() {
+                let Some(last_seen) = entry.last_seen else {
+                    continue;
+                };
+                let Ok(elapsed) = (now - last_seen).to_std() else {
+                    continue;
+                };
+                if elapsed >= threshold && entry.online {
+                    entry.online = false;
+                    entry.active_session_id = None;
+                    entry.control = None;
+                    marked += 1;
+                }
             }
         }
 
@@ -363,18 +389,37 @@ impl Registry {
     }
 
     pub(super) fn is_current_session(&self, node_id: &str, session_id: u64) -> bool {
-        self.nodes
+        read_lock(self.shard_for(node_id))
+            .nodes
             .get(node_id)
             .and_then(|entry| entry.active_session_id)
             == Some(session_id)
     }
 
     pub(super) fn list_statuses(&self) -> Vec<NodeStatus> {
-        self.sorted_entries().map(NodeEntry::to_status).collect()
+        let shards = self.read_all_shards();
+        sorted_entries(&shards)
+            .into_iter()
+            .map(NodeEntry::to_status)
+            .collect()
     }
 
     pub(super) fn list_node_summaries(&self) -> Vec<NodeListItem> {
-        self.sorted_entries().map(NodeEntry::to_summary).collect()
+        let shards = self.read_all_shards();
+        sorted_entries(&shards)
+            .into_iter()
+            .map(NodeEntry::to_summary)
+            .collect()
+    }
+
+    pub(super) fn browser_view(&self) -> (Vec<NodeListItem>, OverviewData) {
+        let shards = self.read_all_shards();
+        let nodes = sorted_entries(&shards)
+            .into_iter()
+            .map(NodeEntry::to_summary)
+            .collect();
+        let overview = overview_from_shards(&shards);
+        (nodes, overview)
     }
 
     pub(super) fn evaluate_alert_rules(
@@ -382,7 +427,8 @@ impl Registry {
         rules: &[AlertRuleConfig],
         now: DateTime<Utc>,
     ) -> Vec<EvaluatedRule> {
-        evaluate_rules(rules, self.sorted_entries(), now)
+        let shards = self.read_all_shards();
+        evaluate_rules(rules, sorted_entries(&shards), now)
     }
 
     pub(super) fn build_alert_inspection_report(
@@ -390,36 +436,41 @@ impl Registry {
         inspection: &InspectionConfig,
         now: DateTime<Utc>,
     ) -> InspectionReport {
-        build_alert_inspection_report(inspection, self.sorted_entries(), now)
+        let shards = self.read_all_shards();
+        build_alert_inspection_report(inspection, sorted_entries(&shards), now)
     }
 
     pub(super) fn get_status(&self, node_id: &str) -> Option<NodeStatus> {
-        self.nodes.get(node_id).map(NodeEntry::to_status)
+        read_lock(self.shard_for(node_id))
+            .nodes
+            .get(node_id)
+            .map(NodeEntry::to_status)
     }
 
     pub(super) fn geoip_refresh_candidates(&self) -> Vec<(String, String)> {
-        self.sorted_node_ids
-            .iter()
-            .filter_map(|node_id| {
-                let entry = self.nodes.get(node_id)?;
+        let shards = self.read_all_shards();
+        sorted_entries(&shards)
+            .into_iter()
+            .filter_map(|entry| {
                 if !entry.online || entry.active_session_id.is_none() {
                     return None;
                 }
                 entry
                     .remote_ip
                     .as_ref()
-                    .map(|remote_ip| (node_id.clone(), remote_ip.clone()))
+                    .map(|remote_ip| (entry.identity.node_id.clone(), remote_ip.clone()))
             })
             .collect()
     }
 
     pub(super) fn update_geoip(
-        &mut self,
+        &self,
         node_id: &str,
         expected_remote_ip: &str,
         geoip: GeoIpLocation,
     ) -> bool {
-        let Some(entry) = self.nodes.get_mut(node_id) else {
+        let mut shard = write_lock(self.shard_for(node_id));
+        let Some(entry) = shard.nodes.get_mut(node_id) else {
             return false;
         };
         if entry.remote_ip.as_deref() != Some(expected_remote_ip) {
@@ -446,11 +497,12 @@ impl Registry {
     }
 
     pub(super) fn update_location_override(
-        &mut self,
+        &self,
         node_id: &str,
         location_override: Option<GeoIpLocation>,
     ) -> bool {
-        let Some(entry) = self.nodes.get_mut(node_id) else {
+        let mut shard = write_lock(self.shard_for(node_id));
+        let Some(entry) = shard.nodes.get_mut(node_id) else {
             return false;
         };
         let (
@@ -475,7 +527,8 @@ impl Registry {
     }
 
     pub(super) fn session_control(&self, node_id: &str) -> Option<SessionControlHandle> {
-        let entry = self.nodes.get(node_id)?;
+        let shard = read_lock(self.shard_for(node_id));
+        let entry = shard.nodes.get(node_id)?;
         if entry.active_session_id.is_none() || !entry.online {
             return None;
         }
@@ -483,7 +536,8 @@ impl Registry {
     }
 
     pub(super) fn overview(&self) -> OverviewData {
-        build_overview_from_iter(self.nodes.values().map(NodeEntry::overview_node))
+        let shards = self.read_all_shards();
+        overview_from_shards(&shards)
     }
 
     pub(super) fn render_metrics_body(
@@ -491,36 +545,67 @@ impl Registry {
         readiness: &ServerReadiness,
         metrics_config: MetricsConfig,
     ) -> String {
-        let overview = self.overview();
+        let shards = self.read_all_shards();
+        let overview = overview_from_shards(&shards);
+        let entries = sorted_entries(&shards);
         render_prometheus_metrics_from_iter(
             readiness,
-            self.sorted_node_ids
-                .iter()
-                .filter_map(|node_id| self.nodes.get(node_id))
-                .map(NodeEntry::prometheus_node),
+            entries.into_iter().map(NodeEntry::prometheus_node),
             &overview,
             metrics_config,
         )
     }
 
     pub(super) fn disk_entries_total(&self) -> u64 {
-        self.nodes
-            .values()
-            .filter_map(|entry| entry.snapshot.as_ref())
-            .map(|snapshot| snapshot.disks.len() as u64)
+        self.shards
+            .iter()
+            .map(|shard| {
+                read_lock(shard)
+                    .nodes
+                    .values()
+                    .filter_map(|entry| entry.snapshot.as_ref())
+                    .map(|snapshot| snapshot.disks.len() as u64)
+                    .sum::<u64>()
+            })
             .sum()
     }
 
-    pub(super) fn restore_statuses(&mut self, statuses: Vec<NodeStatus>) {
-        self.nodes.clear();
-        self.sorted_node_ids.clear();
+    pub(super) fn restore_statuses(&self, statuses: Vec<NodeStatus>) {
+        for shard in &self.shards {
+            write_lock(shard).nodes.clear();
+        }
         for status in statuses {
             let node_id = status.identity.node_id.clone();
-            self.nodes
-                .insert(node_id.clone(), NodeEntry::from_restored_status(status));
-            self.sorted_node_ids.push(node_id);
+            write_lock(self.shard_for(&node_id))
+                .nodes
+                .insert(node_id, NodeEntry::from_restored_status(status));
         }
-        self.resort_node_ids();
+    }
+
+    fn read_all_shards(&self) -> Vec<RwLockReadGuard<'_, RegistryShard>> {
+        self.shards.iter().map(read_lock).collect()
+    }
+
+    fn shard_for(&self, node_id: &str) -> &RwLock<RegistryShard> {
+        &self.shards[shard_index(node_id)]
+    }
+
+    #[cfg(test)]
+    pub(super) fn shard_index_for_test(node_id: &str) -> usize {
+        shard_index(node_id)
+    }
+
+    #[cfg(test)]
+    pub(super) fn shard_count_for_test() -> usize {
+        REGISTRY_SHARD_COUNT
+    }
+
+    #[cfg(test)]
+    pub(super) fn nodes_per_shard_for_test(&self) -> Vec<usize> {
+        self.shards
+            .iter()
+            .map(|shard| read_lock(shard).nodes.len())
+            .collect()
     }
 
     #[cfg(test)]
@@ -546,25 +631,45 @@ impl Registry {
         let runtime = node_entry_heap_estimate(&NodeEntry::from_restored_status(status));
         (runtime, previous)
     }
+}
 
-    fn resort_node_ids(&mut self) {
-        self.sorted_node_ids.sort_by(|left_id, right_id| {
-            let (Some(left), Some(right)) = (self.nodes.get(left_id), self.nodes.get(right_id))
-            else {
-                return left_id.cmp(right_id);
-            };
-            left.identity
-                .node_label
-                .cmp(&right.identity.node_label)
-                .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
-        });
-    }
+fn sorted_entries<'a>(shards: &'a [RwLockReadGuard<'_, RegistryShard>]) -> Vec<&'a NodeEntry> {
+    let mut entries = shards
+        .iter()
+        .flat_map(|shard| shard.nodes.values())
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| compare_node_entries(left, right));
+    entries
+}
 
-    fn sorted_entries(&self) -> impl Iterator<Item = &NodeEntry> {
-        self.sorted_node_ids
+fn compare_node_entries(left: &NodeEntry, right: &NodeEntry) -> Ordering {
+    left.identity
+        .node_label
+        .cmp(&right.identity.node_label)
+        .then_with(|| left.identity.node_id.cmp(&right.identity.node_id))
+}
+
+fn overview_from_shards(shards: &[RwLockReadGuard<'_, RegistryShard>]) -> OverviewData {
+    build_overview_from_iter(
+        shards
             .iter()
-            .filter_map(|node_id| self.nodes.get(node_id))
-    }
+            .flat_map(|shard| shard.nodes.values().map(NodeEntry::overview_node)),
+    )
+}
+
+fn shard_index(node_id: &str) -> usize {
+    let mut hasher = DefaultHasher::new();
+    node_id.hash(&mut hasher);
+    (hasher.finish() as usize) % REGISTRY_SHARD_COUNT
+}
+
+fn read_lock<T>(lock: &RwLock<T>) -> RwLockReadGuard<'_, T> {
+    lock.read().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn write_lock<T>(lock: &RwLock<T>) -> RwLockWriteGuard<'_, T> {
+    lock.write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 #[cfg(test)]

--- a/nodelite-server/src/state/tests/overview_tests.rs
+++ b/nodelite-server/src/state/tests/overview_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn overview_saturates_totals_and_skips_invalid_rates() {
-    let mut registry = Registry::default();
+    let registry = Registry::default();
     let now = Utc
         .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
         .single()
@@ -52,7 +52,7 @@ fn overview_saturates_totals_and_skips_invalid_rates() {
 
 #[test]
 fn overview_avoids_overflow_when_summing_latency() {
-    let mut registry = Registry::default();
+    let registry = Registry::default();
     let now = Utc
         .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
         .single()

--- a/nodelite-server/src/state/tests/registry_tests.rs
+++ b/nodelite-server/src/state/tests/registry_tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use nodelite_proto::NodeStatus;
+use nodelite_proto::{
+    AlertChannel, AlertComparator, AlertMetric, AlertRuleConfig, AlertScopeMode, AlertSeverity,
+    InspectionConfig, NodeStatus,
+};
 
 #[test]
 fn newer_session_replaces_older_one() {
@@ -356,6 +359,62 @@ async fn registry_disk_entries_total_counts_snapshot_disks() {
     );
 
     assert_eq!(shared.registry_disk_entries_total().await, 5);
+}
+
+#[test]
+fn alert_evaluation_borrows_runtime_entries() {
+    let mut registry = Registry::default();
+    let now = Utc
+        .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
+        .single()
+        .expect("valid test datetime");
+    let mut identity = sample_identity();
+    identity.tags = vec!["edge".to_string()];
+    registry.register_node(
+        1,
+        identity,
+        Some("198.51.100.10".to_string()),
+        None,
+        None,
+        now,
+    );
+    let mut snapshot = sample_snapshot(now);
+    snapshot.cpu_usage_percent = Some(95.0);
+    assert!(
+        registry
+            .update_snapshot("hk-01", 1, snapshot, now)
+            .is_some()
+    );
+
+    let rule = AlertRuleConfig {
+        id: "cpu-hot".to_string(),
+        name: "CPU".to_string(),
+        enabled: true,
+        metric: AlertMetric::CpuUsagePercent,
+        comparator: AlertComparator::Gt,
+        threshold: 90,
+        window_minutes: 5,
+        severity: AlertSeverity::Critical,
+        scope_mode: AlertScopeMode::Tags,
+        node_ids: Vec::new(),
+        tags: vec!["edge".to_string()],
+        delivery: vec![AlertChannel::Smtp],
+        cooldown_minutes: 30,
+        send_resolved: true,
+    };
+
+    let matches = registry.evaluate_alert_rules(&[rule], now);
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].node_id, "hk-01");
+
+    let inspection = InspectionConfig {
+        cpu_warn_percent: 90,
+        ..InspectionConfig::default()
+    };
+    let report = registry.build_alert_inspection_report(&inspection, now);
+    assert_eq!(report.total_nodes, 1);
+    assert_eq!(report.cpu_hot_nodes, 1);
+    assert_eq!(report.highlights[0].node_id, "hk-01");
 }
 
 #[tokio::test]

--- a/nodelite-server/src/state/tests/registry_tests.rs
+++ b/nodelite-server/src/state/tests/registry_tests.rs
@@ -238,6 +238,36 @@ fn registry_spreads_runtime_entries_across_shards() {
 }
 
 #[test]
+fn browser_view_holds_shard_locks_until_revision_capture() {
+    let registry = Registry::default();
+    let now = Utc
+        .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
+        .single()
+        .expect("valid test datetime");
+
+    registry.register_node(
+        1,
+        sample_identity(),
+        Some("198.51.100.10".to_string()),
+        None,
+        None,
+        now,
+    );
+
+    let (nodes, overview, revision) = registry.browser_view_with_revision(|| {
+        assert!(
+            registry.shard_is_read_locked_for_test("hk-01"),
+            "revision must be captured while the browser view still holds shard read locks"
+        );
+        7
+    });
+
+    assert_eq!(revision, 7);
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(overview.total_nodes, 1);
+}
+
+#[test]
 fn runtime_entry_is_smaller_than_cached_external_models() {
     assert!(
         Registry::runtime_entry_inline_bytes_for_test()

--- a/nodelite-server/src/state/tests/registry_tests.rs
+++ b/nodelite-server/src/state/tests/registry_tests.rs
@@ -6,7 +6,7 @@ use nodelite_proto::{
 
 #[test]
 fn newer_session_replaces_older_one() {
-    let mut registry = Registry::default();
+    let registry = Registry::default();
     let now = Utc
         .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
         .single()
@@ -60,7 +60,7 @@ fn newer_session_replaces_older_one() {
 
 #[test]
 fn newer_session_refreshes_remote_ip_and_geoip() {
-    let mut registry = Registry::default();
+    let registry = Registry::default();
     let now = Utc
         .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
         .single()
@@ -114,7 +114,7 @@ fn newer_session_refreshes_remote_ip_and_geoip() {
 
 #[test]
 fn stale_nodes_are_marked_offline() {
-    let mut registry = Registry::default();
+    let registry = Registry::default();
     let now = Utc
         .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
         .single()
@@ -143,7 +143,7 @@ fn stale_nodes_are_marked_offline() {
 
 #[test]
 fn session_control_is_only_available_for_current_online_session() {
-    let mut registry = Registry::default();
+    let registry = Registry::default();
     let now = Utc
         .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
         .single()
@@ -177,7 +177,7 @@ fn session_control_is_only_available_for_current_online_session() {
 
 #[test]
 fn mark_disconnected_clears_session_control() {
-    let mut registry = Registry::default();
+    let registry = Registry::default();
     let now = Utc
         .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
         .single()
@@ -196,6 +196,45 @@ fn mark_disconnected_clears_session_control() {
     registry.mark_disconnected("hk-01", 9);
 
     assert!(registry.session_control("hk-01").is_none());
+}
+
+#[test]
+fn registry_spreads_runtime_entries_across_shards() {
+    let registry = Registry::default();
+    let now = Utc
+        .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
+        .single()
+        .expect("valid test datetime");
+
+    for index in 0..64 {
+        let node_id = format!("node-{index:03}");
+        registry.register_node(
+            index,
+            NodeIdentity {
+                node_id: node_id.clone(),
+                node_label: node_id,
+                ..sample_identity()
+            },
+            Some("198.51.100.10".to_string()),
+            None,
+            None,
+            now,
+        );
+    }
+
+    let nodes_per_shard = registry.nodes_per_shard_for_test();
+    let populated_shards = nodes_per_shard.iter().filter(|count| **count > 0).count();
+    let first_shard = Registry::shard_index_for_test("node-000");
+    let has_different_shard = (1..64)
+        .any(|index| Registry::shard_index_for_test(&format!("node-{index:03}")) != first_shard);
+
+    assert_eq!(Registry::shard_count_for_test(), 32);
+    assert!(
+        populated_shards > 1,
+        "runtime entries should not all share one registry shard"
+    );
+    assert!(has_different_shard);
+    assert_eq!(nodes_per_shard.iter().sum::<usize>(), 64);
 }
 
 #[test]
@@ -363,7 +402,7 @@ async fn registry_disk_entries_total_counts_snapshot_disks() {
 
 #[test]
 fn alert_evaluation_borrows_runtime_entries() {
-    let mut registry = Registry::default();
+    let registry = Registry::default();
     let now = Utc
         .with_ymd_and_hms(2026, 5, 7, 0, 0, 0)
         .single()

--- a/nodelite-server/src/ws/handshake.rs
+++ b/nodelite-server/src/ws/handshake.rs
@@ -112,22 +112,14 @@ async fn authorize_hello(
     hello: &HelloMessage,
     audit_user_agent: Option<String>,
 ) -> Result<AuthorizedNode, super::ProtocolError> {
-    if hello.protocol_version < MIN_SUPPORTED_WIRE_PROTOCOL_VERSION
-        || hello.protocol_version > WIRE_PROTOCOL_VERSION
-    {
+    if let Some(rejection) = protocol_version_rejection(hello.protocol_version) {
         state.ws_admission.record_auth_failure(client_ip);
         let notice = WireMessage::ServerNotice(ServerNoticeMessage {
             level: nodelite_proto::NoticeLevel::Error,
-            message: format!(
-                "unsupported protocol version {}; server supports {}..={}",
-                hello.protocol_version, MIN_SUPPORTED_WIRE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION
-            ),
+            message: rejection.notice_message,
         });
         let _ = send_wire_message(socket, &notice).await;
-        return Err(super::ProtocolError::Client(format!(
-            "unsupported protocol version {}; supported range {}..={}",
-            hello.protocol_version, MIN_SUPPORTED_WIRE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION
-        )));
+        return Err(super::ProtocolError::Client(rejection.error_message));
     }
 
     match state
@@ -155,20 +147,10 @@ async fn authorize_hello(
                 "websocket authentication rejected",
             );
             state.ws_admission.record_auth_failure(client_ip);
-            let (notice_message, error_label): (&str, &str) = match &error {
-                RegistryError::TokenExpired { node_id } => {
-                    warn!(expired_node_id = %node_id, "websocket token expired");
-                    (
-                        "token expired; run `nodelite-server install-agent --rotate-token` and reinstall this node",
-                        "token expired",
-                    )
-                }
-                RegistryError::Unauthorized => ("unauthorized", "unauthorized"),
-                _ => ("unauthorized", "unauthorized"),
-            };
+            let rejection = auth_failure_rejection(&error);
             let notice = WireMessage::ServerNotice(ServerNoticeMessage {
                 level: nodelite_proto::NoticeLevel::Error,
-                message: notice_message.to_string(),
+                message: rejection.notice_message.to_string(),
             });
             let _ = send_wire_message(socket, &notice).await;
             let mut event =
@@ -176,10 +158,114 @@ async fn authorize_hello(
             event.node_id = Some(hello.identity.node_id.clone());
             event.user_agent = audit_user_agent;
             event.details = json!({
-                "reason": error_label,
+                "reason": rejection.error_label,
             });
             state.audit_log.record_best_effort(event).await;
-            Err(super::ProtocolError::Client(error_label.to_string()))
+            Err(super::ProtocolError::Client(
+                rejection.error_label.to_string(),
+            ))
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ProtocolVersionRejection {
+    notice_message: String,
+    error_message: String,
+}
+
+fn protocol_version_rejection(protocol_version: u16) -> Option<ProtocolVersionRejection> {
+    if protocol_version >= MIN_SUPPORTED_WIRE_PROTOCOL_VERSION
+        && protocol_version <= WIRE_PROTOCOL_VERSION
+    {
+        return None;
+    }
+
+    Some(ProtocolVersionRejection {
+        notice_message: format!(
+            "unsupported protocol version {}; server supports {}..={}",
+            protocol_version, MIN_SUPPORTED_WIRE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION
+        ),
+        error_message: format!(
+            "unsupported protocol version {}; supported range {}..={}",
+            protocol_version, MIN_SUPPORTED_WIRE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION
+        ),
+    })
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AuthFailureRejection {
+    notice_message: &'static str,
+    error_label: &'static str,
+}
+
+fn auth_failure_rejection(error: &RegistryError) -> AuthFailureRejection {
+    match error {
+        RegistryError::TokenExpired { node_id } => {
+            warn!(expired_node_id = %node_id, "websocket token expired");
+            AuthFailureRejection {
+                notice_message: "token expired; run `nodelite-server install-agent --rotate-token` and reinstall this node",
+                error_label: "token expired",
+            }
+        }
+        RegistryError::Unauthorized => AuthFailureRejection {
+            notice_message: "unauthorized",
+            error_label: "unauthorized",
+        },
+        _ => AuthFailureRejection {
+            notice_message: "unauthorized",
+            error_label: "unauthorized",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nodelite_proto::{MIN_SUPPORTED_WIRE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION};
+
+    use super::{RegistryError, auth_failure_rejection, protocol_version_rejection};
+
+    #[test]
+    fn supported_protocol_versions_are_accepted() {
+        assert!(protocol_version_rejection(MIN_SUPPORTED_WIRE_PROTOCOL_VERSION).is_none());
+        assert!(protocol_version_rejection(WIRE_PROTOCOL_VERSION).is_none());
+    }
+
+    #[test]
+    fn unsupported_protocol_versions_get_notice_and_error_messages() {
+        let rejection = protocol_version_rejection(MIN_SUPPORTED_WIRE_PROTOCOL_VERSION - 1)
+            .expect("old protocol should be rejected");
+
+        assert!(rejection.notice_message.contains("server supports"));
+        assert!(rejection.error_message.contains("supported range"));
+    }
+
+    #[test]
+    fn token_expired_rejection_uses_actionable_notice() {
+        let rejection = auth_failure_rejection(&RegistryError::TokenExpired {
+            node_id: "hk-01".to_string(),
+        });
+
+        assert_eq!(rejection.error_label, "token expired");
+        assert!(rejection.notice_message.contains("--rotate-token"));
+    }
+
+    #[test]
+    fn unauthorized_rejection_does_not_leak_details() {
+        let rejection = auth_failure_rejection(&RegistryError::Unauthorized);
+
+        assert_eq!(rejection.error_label, "unauthorized");
+        assert_eq!(rejection.notice_message, "unauthorized");
+    }
+
+    #[test]
+    fn internal_registry_errors_are_reported_as_unauthorized_to_clients() {
+        let rejection = auth_failure_rejection(&RegistryError::invalid_config(
+            "server.public_base_url",
+            "bad scheme",
+        ));
+
+        assert_eq!(rejection.error_label, "unauthorized");
+        assert_eq!(rejection.notice_message, "unauthorized");
     }
 }

--- a/nodelite-server/src/ws/handshake.rs
+++ b/nodelite-server/src/ws/handshake.rs
@@ -175,9 +175,7 @@ struct ProtocolVersionRejection {
 }
 
 fn protocol_version_rejection(protocol_version: u16) -> Option<ProtocolVersionRejection> {
-    if protocol_version >= MIN_SUPPORTED_WIRE_PROTOCOL_VERSION
-        && protocol_version <= WIRE_PROTOCOL_VERSION
-    {
+    if (MIN_SUPPORTED_WIRE_PROTOCOL_VERSION..=WIRE_PROTOCOL_VERSION).contains(&protocol_version) {
         return None;
     }
 

--- a/nodelite-server/src/ws/refresh.rs
+++ b/nodelite-server/src/ws/refresh.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 
 use super::ActiveSession;
 use crate::AppState;
-use crate::registry::NodeRegistry;
+use crate::registry::{NodeRegistry, RegistryTokenStatus};
 
 /// Token 距离过期不足该天数时,服务端在已认证会话内主动续期并下发新 token。
 pub(crate) const AGENT_TOKEN_REFRESH_BEFORE_EXPIRY_DAYS: i64 = 7;
@@ -91,14 +91,11 @@ pub(crate) async fn ensure_current_token(
         warn!(node_id = %session.node_id, "{log_message}");
         return false;
     };
-    if status.generation == session.session_generation {
-        session.token_expires_at = status.token_expires_at;
-        session.registry_revision = status.registry_revision;
-        return true;
+    if !apply_current_token_status(session, status) {
+        warn!(node_id = %session.node_id, "{log_message}");
+        return false;
     }
-
-    warn!(node_id = %session.node_id, "{log_message}");
-    false
+    true
 }
 
 pub(crate) async fn should_refresh_agent_token(
@@ -107,25 +104,35 @@ pub(crate) async fn should_refresh_agent_token(
 ) -> Result<bool> {
     let refresh_after = Utc::now() + ChronoDuration::days(AGENT_TOKEN_REFRESH_BEFORE_EXPIRY_DAYS);
     if session.registry_revision == registry.registry_revision() {
-        return Ok(session
-            .token_expires_at
-            .map(|expires_at| expires_at <= refresh_after)
-            .unwrap_or(true));
+        return Ok(token_needs_refresh(session.token_expires_at, refresh_after));
     }
 
     let Some(status) = registry.token_status(&session.node_id).await else {
         return Ok(true);
     };
-    if status.generation != session.session_generation {
+    if !apply_current_token_status(session, status) {
         return Ok(false);
     }
 
+    Ok(token_needs_refresh(session.token_expires_at, refresh_after))
+}
+
+fn apply_current_token_status(session: &mut ActiveSession, status: RegistryTokenStatus) -> bool {
+    if status.generation != session.session_generation {
+        return false;
+    }
     session.token_expires_at = status.token_expires_at;
     session.registry_revision = status.registry_revision;
-    Ok(session
-        .token_expires_at
+    true
+}
+
+fn token_needs_refresh(
+    token_expires_at: Option<DateTime<Utc>>,
+    refresh_after: DateTime<Utc>,
+) -> bool {
+    token_expires_at
         .map(|expires_at| expires_at <= refresh_after)
-        .unwrap_or(true))
+        .unwrap_or(true)
 }
 
 /// 通过当前在线会话把新 token 下发给 Agent。
@@ -168,4 +175,85 @@ pub(crate) async fn refresh_session_token(
     session.token_expires_at = Some(expires_at);
     session.registry_revision = registry.registry_revision();
     Ok(expires_at)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::{
+        AGENT_TOKEN_REFRESH_BEFORE_EXPIRY_DAYS, ActiveSession, RegistryTokenStatus,
+        apply_current_token_status, token_needs_refresh,
+    };
+
+    fn session() -> ActiveSession {
+        ActiveSession {
+            node_id: "hk-01".to_string(),
+            node_label: "Hong Kong 01".to_string(),
+            session_id: 7,
+            session_token: "secret".to_string(),
+            session_generation: 3,
+            token_expires_at: None,
+            registry_revision: 11,
+        }
+    }
+
+    #[test]
+    fn token_without_expiry_is_refreshed() {
+        let refresh_after =
+            Utc::now() + chrono::Duration::days(AGENT_TOKEN_REFRESH_BEFORE_EXPIRY_DAYS);
+
+        assert!(token_needs_refresh(None, refresh_after));
+    }
+
+    #[test]
+    fn token_expiring_inside_refresh_window_is_refreshed() {
+        let refresh_after =
+            Utc::now() + chrono::Duration::days(AGENT_TOKEN_REFRESH_BEFORE_EXPIRY_DAYS);
+
+        assert!(token_needs_refresh(
+            Some(refresh_after - chrono::Duration::minutes(1)),
+            refresh_after,
+        ));
+    }
+
+    #[test]
+    fn token_expiring_after_refresh_window_is_not_refreshed() {
+        let refresh_after =
+            Utc::now() + chrono::Duration::days(AGENT_TOKEN_REFRESH_BEFORE_EXPIRY_DAYS);
+
+        assert!(!token_needs_refresh(
+            Some(refresh_after + chrono::Duration::minutes(1)),
+            refresh_after,
+        ));
+    }
+
+    #[test]
+    fn current_token_status_updates_session_cache() {
+        let mut session = session();
+        let expires_at = Utc::now() + chrono::Duration::days(30);
+        let status = RegistryTokenStatus {
+            generation: 3,
+            token_expires_at: Some(expires_at),
+            registry_revision: 12,
+        };
+
+        assert!(apply_current_token_status(&mut session, status));
+        assert_eq!(session.token_expires_at, Some(expires_at));
+        assert_eq!(session.registry_revision, 12);
+    }
+
+    #[test]
+    fn stale_token_status_does_not_update_session_cache() {
+        let mut session = session();
+        let status = RegistryTokenStatus {
+            generation: 4,
+            token_expires_at: Some(Utc::now() + chrono::Duration::days(30)),
+            registry_revision: 12,
+        };
+
+        assert!(!apply_current_token_status(&mut session, status));
+        assert_eq!(session.token_expires_at, None);
+        assert_eq!(session.registry_revision, 11);
+    }
 }

--- a/nodelite-server/src/ws/session.rs
+++ b/nodelite-server/src/ws/session.rs
@@ -7,7 +7,8 @@ use anyhow::{Result, anyhow};
 use axum::extract::ws::{CloseFrame, Message, WebSocket, close_code};
 use futures::{SinkExt, StreamExt};
 use nodelite_proto::{
-    AgentLogsMessage, MetricsMessage, PongMessage, ServerNoticeMessage, WireMessage,
+    AgentLogEntry, AgentLogsMessage, MetricsMessage, NodeSnapshot, PongMessage,
+    RefreshTokenRequestMessage, ServerNoticeMessage, WireMessage,
 };
 use tokio::time::{MissedTickBehavior, interval};
 use tracing::{info, warn};
@@ -155,35 +156,50 @@ async fn handle_wire_message(
     loop_state: &mut SessionLoopState,
     message: WireMessage,
 ) -> Result<LoopAction, super::ProtocolError> {
-    match message {
-        WireMessage::Metrics(MetricsMessage { snapshot }) => {
+    match classify_agent_wire_message(message) {
+        AgentWireAction::Metrics(snapshot) => {
             shared.record_ws_metrics_message();
             handle_metrics_message(state, shared, session, loop_state, snapshot).await
         }
-        WireMessage::AgentLogs(AgentLogsMessage { entries }) => {
+        AgentWireAction::AgentLogs(entries) => {
             shared.record_ws_agent_logs_message();
             handle_agent_logs_message(state, session, entries).await
         }
-        WireMessage::Pong(PongMessage { nonce }) => {
+        AgentWireAction::Pong(nonce) => {
             shared.record_ws_pong_message();
             handle_pong_message(shared, state, session, loop_state, nonce).await
         }
-        WireMessage::RefreshTokenRequest(request) => {
+        AgentWireAction::RefreshTokenRequest(request) => {
             shared.record_ws_refresh_token_request_message();
             handle_refresh_request(state, session, sender, request).await
         }
-        WireMessage::Hello(_) => Err(super::ProtocolError::Client(
-            "duplicate hello message".to_string(),
-        )),
-        WireMessage::Ping(_) => Err(super::ProtocolError::Client(
-            "agent must not send ping messages".to_string(),
-        )),
-        WireMessage::ServerNotice(_) => Err(super::ProtocolError::Client(
-            "agent must not send server_notice messages".to_string(),
-        )),
-        WireMessage::RefreshTokenResponse(_) => Err(super::ProtocolError::Client(
-            "agent must not send refresh_token_response messages".to_string(),
-        )),
+        AgentWireAction::Reject(message) => Err(super::ProtocolError::Client(message.to_string())),
+    }
+}
+
+#[derive(Debug)]
+enum AgentWireAction {
+    Metrics(NodeSnapshot),
+    AgentLogs(Vec<AgentLogEntry>),
+    Pong(u64),
+    RefreshTokenRequest(RefreshTokenRequestMessage),
+    Reject(&'static str),
+}
+
+fn classify_agent_wire_message(message: WireMessage) -> AgentWireAction {
+    match message {
+        WireMessage::Metrics(MetricsMessage { snapshot }) => AgentWireAction::Metrics(snapshot),
+        WireMessage::AgentLogs(AgentLogsMessage { entries }) => AgentWireAction::AgentLogs(entries),
+        WireMessage::Pong(PongMessage { nonce }) => AgentWireAction::Pong(nonce),
+        WireMessage::RefreshTokenRequest(request) => AgentWireAction::RefreshTokenRequest(request),
+        WireMessage::Hello(_) => AgentWireAction::Reject("duplicate hello message"),
+        WireMessage::Ping(_) => AgentWireAction::Reject("agent must not send ping messages"),
+        WireMessage::ServerNotice(_) => {
+            AgentWireAction::Reject("agent must not send server_notice messages")
+        }
+        WireMessage::RefreshTokenResponse(_) => {
+            AgentWireAction::Reject("agent must not send refresh_token_response messages")
+        }
     }
 }
 
@@ -293,10 +309,9 @@ async fn handle_pong_message(
     {
         return Ok(LoopAction::Break);
     }
-    let Some(sent_at) = loop_state.outstanding_pings.remove(&nonce) else {
+    let Some(latency_ms) = consume_pong_latency(loop_state, nonce, Instant::now()) else {
         return Ok(LoopAction::Continue);
     };
-    let latency_ms = sent_at.elapsed().as_millis() as u64;
     if !shared
         .update_latency(&session.node_id, session.session_id, latency_ms)
         .await
@@ -309,6 +324,137 @@ async fn handle_pong_message(
         return Ok(LoopAction::Break);
     }
     Ok(LoopAction::Continue)
+}
+
+fn consume_pong_latency(
+    loop_state: &mut SessionLoopState,
+    nonce: u64,
+    now: Instant,
+) -> Option<u64> {
+    loop_state
+        .outstanding_pings
+        .remove(&nonce)
+        .map(|sent_at| now.duration_since(sent_at).as_millis() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use axum::extract::ws::Message;
+    use nodelite_proto::{
+        HelloMessage, NodeIdentity, NoticeLevel, PingMessage, PongMessage,
+        RefreshTokenResponseMessage, ServerNoticeMessage, WIRE_PROTOCOL_VERSION, WireMessage,
+    };
+
+    use super::{
+        AgentWireAction, SessionLoopState, classify_agent_wire_message, consume_pong_latency,
+    };
+
+    fn identity() -> NodeIdentity {
+        NodeIdentity {
+            node_id: "hk-01".to_string(),
+            node_label: "Hong Kong 01".to_string(),
+            hostname: "hk-01.internal".to_string(),
+            os: "Linux".to_string(),
+            kernel_version: None,
+            cpu_model: None,
+            cpu_cores: 2,
+            agent_version: "0.1.0-test".to_string(),
+            boot_time: None,
+            tags: Vec::new(),
+        }
+    }
+
+    fn hello_message() -> HelloMessage {
+        HelloMessage {
+            protocol_version: WIRE_PROTOCOL_VERSION,
+            identity: identity(),
+            token: "secret".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_loop_state_sets_ping_expiry_from_interval() {
+        let state = SessionLoopState::new(7);
+
+        assert_eq!(state.ping_expiry, Duration::from_secs(21));
+        assert_eq!(state.next_ping_nonce, 1);
+        assert!(state.outstanding_pings.is_empty());
+    }
+
+    #[test]
+    fn classify_routes_agent_business_messages() {
+        let pong = classify_agent_wire_message(WireMessage::Pong(PongMessage { nonce: 42 }));
+
+        assert!(matches!(pong, AgentWireAction::Pong(42)));
+    }
+
+    #[test]
+    fn classify_rejects_agent_forbidden_messages() {
+        let cases = [
+            (
+                WireMessage::Hello(hello_message()),
+                "duplicate hello message",
+            ),
+            (
+                WireMessage::Ping(PingMessage { nonce: 1 }),
+                "agent must not send ping messages",
+            ),
+            (
+                WireMessage::ServerNotice(ServerNoticeMessage {
+                    level: NoticeLevel::Info,
+                    message: "server-only".to_string(),
+                }),
+                "agent must not send server_notice messages",
+            ),
+            (
+                WireMessage::RefreshTokenResponse(RefreshTokenResponseMessage {
+                    new_token: "new-token".to_string(),
+                    expires_at: "2026-01-01T00:00:00Z".to_string(),
+                }),
+                "agent must not send refresh_token_response messages",
+            ),
+        ];
+
+        for (message, expected) in cases {
+            let action = classify_agent_wire_message(message);
+            assert!(matches!(action, AgentWireAction::Reject(actual) if actual == expected));
+        }
+    }
+
+    #[tokio::test]
+    async fn consume_pong_latency_removes_known_nonce() {
+        let mut state = SessionLoopState::new(10);
+        let now = Instant::now();
+        state
+            .outstanding_pings
+            .insert(7, now - Duration::from_millis(42));
+
+        let latency = consume_pong_latency(&mut state, 7, now);
+
+        assert_eq!(latency, Some(42));
+        assert!(state.outstanding_pings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn consume_pong_latency_ignores_unknown_nonce() {
+        let mut state = SessionLoopState::new(10);
+        state.outstanding_pings.insert(7, Instant::now());
+
+        let latency = consume_pong_latency(&mut state, 8, Instant::now());
+
+        assert_eq!(latency, None);
+        assert!(state.outstanding_pings.contains_key(&7));
+    }
+
+    #[test]
+    fn close_frames_break_before_wire_classification() {
+        assert!(matches!(
+            super::super::protocol::parse_wire_message(Message::Close(None)),
+            Ok(super::super::protocol::ParsedFrame::Close)
+        ));
+    }
 }
 
 async fn handle_session_command(

--- a/nodelite-server/src/ws/session.rs
+++ b/nodelite-server/src/ws/session.rs
@@ -337,6 +337,79 @@ fn consume_pong_latency(
         .map(|sent_at| now.duration_since(sent_at).as_millis() as u64)
 }
 
+async fn handle_session_command(
+    state: &AppState,
+    session: &mut ActiveSession,
+    sender: &mut futures::stream::SplitSink<WebSocket, Message>,
+    command: SessionCommand,
+) -> Result<LoopAction, super::ProtocolError> {
+    match command {
+        SessionCommand::RefreshToken {
+            response,
+            refresh_permit: _refresh_permit,
+        } => match refresh_session_token(sender, &state.registry, session, "manual").await {
+            Ok(expires_at) => {
+                let _ = response.send(Ok(SessionRefreshReply {
+                    token_expires_at: expires_at,
+                }));
+                Ok(LoopAction::Continue)
+            }
+            Err(error) => {
+                let message = error.to_string();
+                let _ = response.send(Err(message));
+                Err(super::ProtocolError::Server(error))
+            }
+        },
+    }
+}
+
+async fn handle_ping_tick(
+    state: &AppState,
+    shared: &crate::state::SharedState,
+    session: &mut ActiveSession,
+    sender: &mut futures::stream::SplitSink<WebSocket, Message>,
+    loop_state: &mut SessionLoopState,
+) -> Result<LoopAction, super::ProtocolError> {
+    if !shared
+        .is_current_session(&session.node_id, session.session_id)
+        .await
+    {
+        warn!(
+            node_id = %session.node_id,
+            session_id = session.session_id,
+            "closing superseded websocket session"
+        );
+        return Ok(LoopAction::Break);
+    }
+    if !ensure_current_token(
+        state,
+        session,
+        "closing websocket session after registry token change",
+    )
+    .await
+    {
+        return Ok(LoopAction::Break);
+    }
+    if should_refresh_agent_token(&state.registry, session).await? {
+        refresh_session_token(sender, &state.registry, session, "pre-expiry").await?;
+    }
+
+    prune_outstanding_pings(
+        &mut loop_state.outstanding_pings,
+        loop_state.ping_expiry,
+        shared.config().max_outstanding_pings,
+    );
+    let nonce = loop_state.next_ping_nonce;
+    loop_state.next_ping_nonce = loop_state.next_ping_nonce.saturating_add(1);
+    loop_state.outstanding_pings.insert(nonce, Instant::now());
+    let ping = encode_ping_message(nonce)?;
+    sender
+        .send(Message::Text(ping.into()))
+        .await
+        .map_err(|error| anyhow!("failed to send ping: {error}"))?;
+    Ok(LoopAction::Continue)
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::{Duration, Instant};
@@ -455,77 +528,4 @@ mod tests {
             Ok(super::super::protocol::ParsedFrame::Close)
         ));
     }
-}
-
-async fn handle_session_command(
-    state: &AppState,
-    session: &mut ActiveSession,
-    sender: &mut futures::stream::SplitSink<WebSocket, Message>,
-    command: SessionCommand,
-) -> Result<LoopAction, super::ProtocolError> {
-    match command {
-        SessionCommand::RefreshToken {
-            response,
-            refresh_permit: _refresh_permit,
-        } => match refresh_session_token(sender, &state.registry, session, "manual").await {
-            Ok(expires_at) => {
-                let _ = response.send(Ok(SessionRefreshReply {
-                    token_expires_at: expires_at,
-                }));
-                Ok(LoopAction::Continue)
-            }
-            Err(error) => {
-                let message = error.to_string();
-                let _ = response.send(Err(message));
-                Err(super::ProtocolError::Server(error))
-            }
-        },
-    }
-}
-
-async fn handle_ping_tick(
-    state: &AppState,
-    shared: &crate::state::SharedState,
-    session: &mut ActiveSession,
-    sender: &mut futures::stream::SplitSink<WebSocket, Message>,
-    loop_state: &mut SessionLoopState,
-) -> Result<LoopAction, super::ProtocolError> {
-    if !shared
-        .is_current_session(&session.node_id, session.session_id)
-        .await
-    {
-        warn!(
-            node_id = %session.node_id,
-            session_id = session.session_id,
-            "closing superseded websocket session"
-        );
-        return Ok(LoopAction::Break);
-    }
-    if !ensure_current_token(
-        state,
-        session,
-        "closing websocket session after registry token change",
-    )
-    .await
-    {
-        return Ok(LoopAction::Break);
-    }
-    if should_refresh_agent_token(&state.registry, session).await? {
-        refresh_session_token(sender, &state.registry, session, "pre-expiry").await?;
-    }
-
-    prune_outstanding_pings(
-        &mut loop_state.outstanding_pings,
-        loop_state.ping_expiry,
-        shared.config().max_outstanding_pings,
-    );
-    let nonce = loop_state.next_ping_nonce;
-    loop_state.next_ping_nonce = loop_state.next_ping_nonce.saturating_add(1);
-    loop_state.outstanding_pings.insert(nonce, Instant::now());
-    let ping = encode_ping_message(nonce)?;
-    sender
-        .send(Message::Text(ping.into()))
-        .await
-        .map_err(|error| anyhow!("failed to send ping: {error}"))?;
-    Ok(LoopAction::Continue)
 }


### PR DESCRIPTION
## Summary
- add direct ws handshake/session/refresh unit coverage for the previously integration-only state-machine paths
- evaluate alert rules and inspection reports against borrowed runtime registry entries instead of periodic `NodeStatus` deep clones
- shard runtime registry state by node id, keep external API ordering stable, and preserve same-view browser snapshot/metrics generation

## Verification
- cargo fmt --check
- cargo check -p nodelite-server
- cargo test -p nodelite-server state::tests::registry_tests
- cargo test -p nodelite-server state::tests::overview_tests
- cargo test -p nodelite-server state::tests::view_cache_tests
- cargo test -p nodelite-server ws::
- cargo test -p nodelite-server alerts
- cargo clippy -p nodelite-server --all-targets -- -D warnings
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Closes #162
Closes #257
Closes #265