### PR TITLE
docs: close misc P3 proto docs and release SBOM debt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,12 +270,66 @@ jobs:
             dist/nodelite-agent-${{ matrix.target }}
             dist/SHA256SUMS-${{ matrix.target }}.txt
 
+  sbom:
+    # 生成 workspace 级 CycloneDX SBOM,随 Release 一起发布。
+    name: Generate SBOM
+    needs: validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ env.RELEASE_TAG }}
+
+      - name: Set up Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-sbom
+          workspaces: |
+            . -> target
+
+      - name: Install cargo-cyclonedx
+        # 固定 cargo-cyclonedx 版本,避免 release 产物随工具默认行为漂移。
+        run: cargo install cargo-cyclonedx --version 0.5.9 --locked
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          mkdir -p dist
+          cargo cyclonedx \
+            --format json \
+            --spec-version 1.5 \
+            --target all \
+            --all \
+            --all-features
+          cp nodelite-proto/nodelite-proto.cdx.json dist/
+          cp nodelite-agent/nodelite-agent.cdx.json dist/
+          cp nodelite-server/nodelite-server.cdx.json dist/
+          sha256sum dist/*.cdx.json > dist/SHA256SUMS-sbom.txt
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-sbom
+          path: |
+            dist/nodelite-proto.cdx.json
+            dist/nodelite-agent.cdx.json
+            dist/nodelite-server.cdx.json
+            dist/SHA256SUMS-sbom.txt
+
   release:
     # 汇总产物 → 合并校验文件 → 写入 GitHub Release。
     name: Publish GitHub Release
     needs:
       - build-linux
       - build-agent-macos
+      - sbom
     runs-on: ubuntu-latest
 
     steps:
@@ -322,5 +376,8 @@ jobs:
             release-assets/release-agent-aarch64-apple-darwin/nodelite-agent-aarch64-apple-darwin \
             release-assets/release-scripts/install-server.sh \
             release-assets/release-scripts/install-agent.sh \
+            release-assets/release-sbom/nodelite-proto.cdx.json \
+            release-assets/release-sbom/nodelite-agent.cdx.json \
+            release-assets/release-sbom/nodelite-server.cdx.json \
             release-assets/SHA256SUMS.txt \
             --clobber

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ node scripts/benchmark-index-dom.mjs --nodes 1000
 
 ## 发布
 
-仓库使用 tag 驱动 GitHub Release。推送语义化版本 tag 后，CI 会构建 Linux Server / Agent、macOS Agent，上传安装脚本和 `SHA256SUMS.txt`，并创建 Release。
+仓库使用 tag 驱动 GitHub Release。推送语义化版本 tag 后，CI 会构建 Linux Server / Agent、macOS Agent，上传安装脚本、`SHA256SUMS.txt` 和 CycloneDX SBOM，并创建 Release。
 
 发布产物中的 Agent 会把对应 tag 版本号上报到面板，便于确认线上节点版本。
+
+`nodelite-proto.cdx.json`、`nodelite-agent.cdx.json` 和 `nodelite-server.cdx.json` 是 CycloneDX JSON 格式的软件物料清单，覆盖 workspace crate 的依赖和版本信息。它们会随发布产物一起上传，并纳入 `SHA256SUMS.txt` 统一校验。

--- a/nodelite-proto/src/config.rs
+++ b/nodelite-proto/src/config.rs
@@ -97,6 +97,7 @@ pub struct ConfigError {
 }
 
 impl ConfigError {
+    /// 用可读错误消息创建配置错误。
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
@@ -126,40 +127,68 @@ impl std::error::Error for ConfigError {}
 /// ```
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct ServerConfig {
+    /// Server 监听地址和端口。
     pub listen: SocketAddr,
+    /// 对外访问 Server 的基础 URL,用于生成安装脚本和提示信息。
     pub public_base_url: String,
+    /// 是否允许 `public_base_url` 使用明文 HTTP。
     pub insecure_allow_http: bool,
+    /// 可信反向代理网段,用于解析真实客户端 IP。
     pub trusted_proxies: Vec<IpNet>,
+    /// 可选的只读 Web UI 认证配置。
     pub readonly_auth: Option<ReadonlyAuthConfig>,
+    /// WebSocket 准入和认证失败限流配置。
     pub ws: WsConfig,
+    /// Prometheus 指标导出配置。
     pub metrics: MetricsConfig,
+    /// 审计日志配置。
     pub audit: AuditConfig,
+    /// GeoIP 数据源与更新配置。
     pub geoip: GeoIpConfig,
+    /// 告警规则、巡检和通知渠道配置。
     pub alerting: AlertingConfig,
+    /// 节点注册表持久化文件路径。
     pub node_registry_path: PathBuf,
+    /// 历史指标 SQLite 数据库路径。
     pub history_db_path: PathBuf,
+    /// 最新快照持久化文件路径。
     pub snapshot_path: PathBuf,
+    /// 超过该秒数未收到上报后,节点视为离线。
     pub stale_after_secs: u64,
+    /// Server 发送 WebSocket ping 的间隔秒数。
     pub ping_interval_secs: u64,
+    /// Server 接受的单条 WebSocket 消息最大字节数。
     pub max_message_bytes: usize,
+    /// 前端轮询或刷新 fallback 的默认间隔秒数。
     pub refresh_interval_secs: u64,
+    /// Agent 默认过滤的文件系统类型列表。
     pub ignored_filesystems: Vec<String>,
+    /// Agent release 下载基础 URL,为空时使用项目默认发布地址。
     pub agent_release_base_url: Option<String>,
+    /// x86_64 Linux Agent release 的 SHA-256 校验值。
     pub agent_release_sha256_x86_64: Option<String>,
+    /// aarch64 Linux Agent release 的 SHA-256 校验值。
     pub agent_release_sha256_aarch64: Option<String>,
     #[serde(default = "default_hello_timeout_secs")]
+    /// WebSocket hello 握手阶段的超时秒数。
     pub hello_timeout_secs: u64,
     #[serde(default = "default_max_outstanding_pings")]
+    /// 单连接允许的最大未响应 ping 数。
     pub max_outstanding_pings: usize,
     #[serde(default = "default_insecure_transport_warn_interval_secs")]
+    /// 明文传输安全告警的最小重复提示间隔秒数。
     pub insecure_transport_warn_interval_secs: u64,
     #[serde(default = "default_max_sanitized_disks")]
+    /// 单个快照保留的最大磁盘条目数。
     pub max_sanitized_disks: usize,
     #[serde(default = "default_max_sanitized_string_bytes")]
+    /// 快照字符串字段清洗后的最大 UTF-8 字节数。
     pub max_sanitized_string_bytes: usize,
     #[serde(default = "default_metric_anomaly_session_limit")]
+    /// 同一会话允许记录的指标异常次数上限。
     pub metric_anomaly_session_limit: usize,
     #[serde(default = "default_sqlite_busy_timeout_secs")]
+    /// SQLite busy timeout 秒数。
     pub sqlite_busy_timeout_secs: u64,
 }
 
@@ -173,21 +202,30 @@ pub struct ServerConfig {
 /// 并只把它派生 `Serialize`。
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct ReadonlyAuthConfig {
+    /// 只读 Web UI 登录用户名。
     pub username: String,
+    /// 只读 Web UI 登录密码明文,仅存在于本地配置中。
     pub password: String,
     #[serde(default)]
+    /// 是否启用 TOTP 二次验证。
     pub enable_2fa: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// TOTP secret,启用 2FA 时由 server 读取和校验。
     pub totp_secret: Option<String>,
 }
 
 /// WebSocket 准入控制参数,用于限流与抗暴力破解。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WsConfig {
+    /// 全局允许的最大 WebSocket 连接数。
     pub max_total_connections: usize,
+    /// 单个客户端 IP 允许的最大 WebSocket 连接数。
     pub max_connections_per_ip: usize,
+    /// 认证失败计数窗口秒数。
     pub auth_fail_window_secs: u64,
+    /// 计数窗口内触发封禁的最大认证失败次数。
     pub auth_fail_max_attempts: usize,
+    /// 认证失败触发后的封禁秒数。
     pub auth_block_secs: u64,
 }
 
@@ -195,31 +233,46 @@ pub struct WsConfig {
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MetricsConfig {
     #[serde(default = "default_metrics_export_node_resource_metrics")]
+    /// 是否导出每节点 CPU、内存、网络等资源指标。
     pub export_node_resource_metrics: bool,
     #[serde(default = "default_metrics_export_node_disk_metrics")]
+    /// 是否按节点和挂载点导出磁盘指标。
     pub export_node_disk_metrics: bool,
 }
 
 /// 审计日志存储与记录策略。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AuditConfig {
+    /// 是否启用审计日志。
     pub enabled: bool,
+    /// 审计日志 SQLite 数据库路径。
     pub db_path: PathBuf,
+    /// 审计记录保留天数。
     pub retention_days: u64,
+    /// 是否记录成功认证事件。
     pub log_successful_auth: bool,
+    /// 是否记录失败认证事件。
     pub log_failed_auth: bool,
+    /// 是否记录 token 签发和刷新事件。
     pub log_token_events: bool,
+    /// 是否记录限流或封禁事件。
     pub log_rate_limit: bool,
 }
 
 /// IP 地理位置数据库配置。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GeoIpConfig {
+    /// 是否启用 GeoIP 推断。
     pub enabled: bool,
+    /// GeoIP 数据来源。
     pub provider: GeoIpProvider,
+    /// GeoIP 数据库粒度。
     pub edition: GeoIpEdition,
+    /// 本地 GeoIP 数据库路径。
     pub database_path: PathBuf,
+    /// 是否允许 server 自动更新 GeoIP 数据库。
     pub auto_update: bool,
+    /// 自动更新间隔天数。
     pub update_interval_days: u64,
 }
 
@@ -227,8 +280,11 @@ pub struct GeoIpConfig {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum GeoIpProvider {
+    /// DB-IP Lite 数据库。
     Dbip,
+    /// ipwho.is HTTP API。
     Ipwhois,
+    /// 用户提供的自定义数据库或后续扩展源。
     Custom,
 }
 
@@ -236,25 +292,37 @@ pub enum GeoIpProvider {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum GeoIpEdition {
+    /// 国家级 DB-IP Lite 数据库。
     CountryLite,
+    /// 城市级 DB-IP Lite 数据库。
     CityLite,
 }
 
 /// Agent 启动需要的全部配置。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentConfig {
+    /// Agent 在 server registry 中的稳定节点 ID。
     pub node_id: String,
+    /// UI 中展示的节点名称。
     pub node_label: String,
+    /// Server WebSocket 或基础连接地址。
     pub server: String,
+    /// Agent 连接 server 使用的认证 token。
     pub token: String,
+    /// Agent 上报指标的间隔秒数。
     pub report_interval_secs: u64,
+    /// 可选 hostname 覆盖值,为空时使用本机 hostname。
     pub hostname_override: Option<String>,
+    /// 部署方自定义标签,用于筛选和告警作用域。
     pub tags: Vec<String>,
     #[serde(default = "default_connect_timeout_secs")]
+    /// Agent 建立连接的超时秒数。
     pub connect_timeout_secs: u64,
     #[serde(default = "default_max_incoming_message_bytes")]
+    /// Agent 接受的单条 server 消息最大字节数。
     pub max_incoming_message_bytes: usize,
     #[serde(default = "default_insecure_transport_warn_interval_secs")]
+    /// 明文传输警告的最小重复提示间隔秒数。
     pub insecure_transport_warn_interval_secs: u64,
 }
 

--- a/nodelite-proto/src/config/alerts.rs
+++ b/nodelite-proto/src/config/alerts.rs
@@ -1,71 +1,112 @@
 use serde::{Deserialize, Serialize};
 
+/// 默认告警规则评估窗口(分钟)。
 pub const DEFAULT_ALERT_RULE_WINDOW_MINUTES: u64 = 5;
+/// 默认告警冷却时间(分钟)。
 pub const DEFAULT_ALERT_RULE_COOLDOWN_MINUTES: u64 = 30;
+/// 默认每日巡检回看窗口(小时)。
 pub const DEFAULT_ALERT_INSPECTION_LOOKBACK_HOURS: u64 = 24;
+/// 默认每日巡检本地时间。
 pub const DEFAULT_ALERT_INSPECTION_LOCAL_TIME: &str = "09:00";
+/// 默认离线巡检宽限时间(分钟)。
 pub const DEFAULT_ALERT_INSPECTION_OFFLINE_GRACE_MINUTES: u64 = 10;
+/// 默认延迟告警阈值(毫秒)。
 pub const DEFAULT_ALERT_INSPECTION_LATENCY_WARN_MS: u64 = 250;
+/// 默认 CPU 使用率告警阈值(百分比)。
 pub const DEFAULT_ALERT_INSPECTION_CPU_WARN_PERCENT: u64 = 85;
+/// 默认内存使用率告警阈值(百分比)。
 pub const DEFAULT_ALERT_INSPECTION_MEMORY_WARN_PERCENT: u64 = 90;
 
+/// 告警投递渠道。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AlertChannel {
+    /// SMTP 邮件渠道。
     Smtp,
+    /// HTTP webhook 渠道。
     Webhook,
 }
 
+/// SMTP 连接安全模式。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AlertSmtpTransport {
+    /// 先明文连接再通过 STARTTLS 升级。
     StartTls,
+    /// 从连接开始使用 TLS。
     Tls,
+    /// 明文 SMTP,仅适用于受信内网或测试环境。
     Plain,
 }
 
+/// 告警规则可观察的指标。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AlertMetric {
+    /// CPU 使用率百分比。
     CpuUsagePercent,
+    /// 内存使用率百分比。
     MemoryUsagePercent,
+    /// 磁盘使用率百分比。
     DiskUsagePercent,
+    /// WebSocket 心跳测得的延迟毫秒数。
     LatencyMs,
+    /// 节点离线持续分钟数。
     OfflineMinutes,
 }
 
+/// 告警阈值比较方式。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AlertComparator {
+    /// 指标值大于阈值时触发。
     Gt,
+    /// 指标值小于阈值时触发。
     Lt,
 }
 
+/// 告警严重级别。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AlertSeverity {
+    /// 需要关注但未达到严重故障级别。
     Warning,
+    /// 需要立即处理的严重告警。
     Critical,
 }
 
+/// 告警规则的作用域类型。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AlertScopeMode {
+    /// 应用于所有节点。
     All,
+    /// 仅应用于指定节点 ID。
     NodeIds,
+    /// 应用于带有指定标签的节点。
     Tags,
 }
 
+/// SMTP 告警渠道配置。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AlertSmtpConfig {
+    /// 是否启用 SMTP 渠道。
     pub enabled: bool,
+    /// SMTP 服务器主机名或 IP。
     pub host: String,
+    /// SMTP 服务器端口。
     pub port: u16,
+    /// SMTP 登录用户名。
     pub username: String,
+    /// SMTP 登录密码或应用专用密码。
     pub password: Option<String>,
+    /// 告警邮件发件人地址。
     pub sender: String,
+    /// 告警邮件收件人列表。
     pub recipients: Vec<String>,
+    /// SMTP 传输安全模式。
     pub transport: AlertSmtpTransport,
+    /// 告警恢复时是否发送 resolved 通知。
     pub send_resolved: bool,
 }
 
@@ -85,11 +126,16 @@ impl Default for AlertSmtpConfig {
     }
 }
 
+/// Webhook 告警渠道配置。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AlertWebhookConfig {
+    /// 是否启用 webhook 渠道。
     pub enabled: bool,
+    /// 接收告警的 webhook URL。
     pub url: String,
+    /// 可选共享 secret,用于服务端签名或下游校验。
     pub secret: Option<String>,
+    /// 告警恢复时是否发送 resolved 通知。
     pub send_resolved: bool,
 }
 
@@ -104,33 +150,57 @@ impl Default for AlertWebhookConfig {
     }
 }
 
+/// 单条阈值告警规则。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AlertRuleConfig {
+    /// 规则稳定 ID。
     pub id: String,
+    /// UI 中展示的规则名称。
     pub name: String,
+    /// 是否启用该规则。
     pub enabled: bool,
+    /// 规则观察的指标。
     pub metric: AlertMetric,
+    /// 指标和阈值的比较方式。
     pub comparator: AlertComparator,
+    /// 告警阈值,单位由 `metric` 决定。
     pub threshold: u64,
+    /// 评估窗口分钟数。
     pub window_minutes: u64,
+    /// 触发后的严重级别。
     pub severity: AlertSeverity,
+    /// 规则作用域模式。
     pub scope_mode: AlertScopeMode,
+    /// 当 `scope_mode` 为 `node_ids` 时匹配的节点 ID。
     pub node_ids: Vec<String>,
+    /// 当 `scope_mode` 为 `tags` 时匹配的节点标签。
     pub tags: Vec<String>,
+    /// 触发后投递到的渠道列表。
     pub delivery: Vec<AlertChannel>,
+    /// 同一告警重复通知的冷却分钟数。
     pub cooldown_minutes: u64,
+    /// 告警恢复时是否发送 resolved 通知。
     pub send_resolved: bool,
 }
 
+/// 每日巡检摘要配置。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InspectionConfig {
+    /// 是否启用每日巡检。
     pub enabled: bool,
+    /// 每日巡检触发的本地时间,格式为 `HH:MM`。
     pub local_time: String,
+    /// 巡检统计回看窗口(小时)。
     pub lookback_hours: u64,
+    /// 巡检摘要投递渠道。
     pub delivery: Vec<AlertChannel>,
+    /// 节点离线超过该分钟数后在巡检中标记为异常。
     pub offline_grace_minutes: u64,
+    /// 延迟超过该毫秒数后在巡检中标记为异常。
     pub latency_warn_ms: u64,
+    /// CPU 使用率超过该百分比后在巡检中标记为异常。
     pub cpu_warn_percent: u64,
+    /// 内存使用率超过该百分比后在巡检中标记为异常。
     pub memory_warn_percent: u64,
 }
 
@@ -149,11 +219,17 @@ impl Default for InspectionConfig {
     }
 }
 
+/// 告警系统的总配置入口。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AlertingConfig {
+    /// 是否启用告警系统。
     pub enabled: bool,
+    /// SMTP 渠道配置。
     pub smtp: AlertSmtpConfig,
+    /// Webhook 渠道配置。
     pub webhook: AlertWebhookConfig,
+    /// 阈值告警规则列表。
     pub rules: Vec<AlertRuleConfig>,
+    /// 每日巡检配置。
     pub inspection: InspectionConfig,
 }

--- a/nodelite-proto/src/lib.rs
+++ b/nodelite-proto/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod config;
 pub mod message;
 pub mod model;
+/// URL and host helpers shared by server and agent transport checks.
 pub mod netutil;
 pub mod text;
 pub mod validation;

--- a/nodelite-proto/src/message.rs
+++ b/nodelite-proto/src/message.rs
@@ -51,33 +51,41 @@ pub enum WireMessage {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct HelloMessage {
     #[serde(default = "current_protocol_version")]
+    /// Agent 支持的 wire protocol 版本。
     pub protocol_version: u16,
+    /// 节点注册表分配给 Agent 的认证 token。
     pub token: String,
+    /// Agent 采集到的节点身份。
     pub identity: NodeIdentity,
 }
 
 /// Agent 周期性上报的监控数据包装。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MetricsMessage {
+    /// 当前采样周期的完整节点快照。
     pub snapshot: NodeSnapshot,
 }
 
 /// Server 发往 Agent 的心跳请求,`nonce` 用于配对返回的 Pong。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PingMessage {
+    /// Server 生成的心跳随机数或序号。
     pub nonce: u64,
 }
 
 /// Agent 回复的心跳响应,需要回传相同的 `nonce`。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PongMessage {
+    /// 对应 `PingMessage::nonce` 的原样回传值。
     pub nonce: u64,
 }
 
 /// Server 推送的通知消息,Agent 用于日志输出与判定认证状态等。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServerNoticeMessage {
+    /// 通知严重级别。
     pub level: NoticeLevel,
+    /// 面向日志或用户提示的可读消息。
     pub message: String,
 }
 
@@ -89,27 +97,34 @@ pub struct ServerNoticeMessage {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RefreshTokenRequestMessage {
     #[serde(default)]
+    /// 旧协议中的节点 ID,新服务端以会话认证身份为准。
     pub node_id: String,
 }
 
 /// Server 响应 Token 刷新请求。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RefreshTokenResponseMessage {
+    /// Server 新签发的节点 token。
     pub new_token: String,
-    pub expires_at: String, // ISO 8601 格式
+    /// 新 token 的 ISO 8601 过期时间。
+    pub expires_at: String,
 }
 
 /// Agent 运行时日志中的单条结构化事件。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentLogEntry {
-    pub occurred_at: String, // ISO 8601 格式
+    /// 日志事件发生的 ISO 8601 时间。
+    pub occurred_at: String,
+    /// 日志级别。
     pub level: NoticeLevel,
+    /// 日志消息正文。
     pub message: String,
 }
 
 /// Agent 批量上传的运行时日志。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentLogsMessage {
+    /// 本批次内的日志事件列表。
     pub entries: Vec<AgentLogEntry>,
 }
 
@@ -117,8 +132,11 @@ pub struct AgentLogsMessage {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum NoticeLevel {
+    /// 信息性通知。
     Info,
+    /// 警告性通知。
     Warn,
+    /// 错误通知。
     Error,
 }
 
@@ -134,23 +152,32 @@ pub enum NoticeLevel {
 pub enum BrowserMessage {
     /// 连接建立(以及重连 / 服务端 lag 恢复)时下发的全量快照,客户端整体替换本地状态。
     InitialState {
+        /// Server 生成该消息的 UTC 时间。
         generated_at: DateTime<Utc>,
+        /// 当前全局概览。
         overview: OverviewData,
+        /// 当前节点列表全量快照。
         nodes: Vec<NodeListItem>,
     },
     /// 概览聚合数字更新(整体替换,体积很小)。
     OverviewUpdate {
+        /// Server 生成该消息的 UTC 时间。
         generated_at: DateTime<Utc>,
+        /// 新的全局概览。
         overview: OverviewData,
     },
     /// 单节点增量:新增或更新一行,客户端按 `node_id` 合并进本地 Map。
     NodeUpsert {
+        /// Server 生成该消息的 UTC 时间。
         generated_at: DateTime<Utc>,
+        /// 新增或更新的节点列表项。
         node: Box<NodeListItem>,
     },
     /// 单节点移除(注销),客户端按 `node_id` 删除。
     NodeRemoved {
+        /// Server 生成该消息的 UTC 时间。
         generated_at: DateTime<Utc>,
+        /// 被移除的节点 ID。
         node_id: String,
     },
     /// 应用层心跳:客户端发送 `Ping`,服务端回 `Pong`。

--- a/nodelite-proto/src/model.rs
+++ b/nodelite-proto/src/model.rs
@@ -11,40 +11,58 @@ use serde::{Deserialize, Serialize};
 /// `tags` 用于在前端进行分组或过滤,具体语义由部署方约定。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NodeIdentity {
+    /// 节点在 registry 中的稳定 ID。
     pub node_id: String,
+    /// UI 中展示的节点名称。
     pub node_label: String,
+    /// Agent 采集到的主机名。
     pub hostname: String,
+    /// 操作系统名称或发行版标识。
     pub os: String,
+    /// 内核版本,无法采集时为空。
     pub kernel_version: Option<String>,
+    /// CPU 型号,无法采集时为空。
     pub cpu_model: Option<String>,
+    /// 逻辑 CPU 核心数。
     pub cpu_cores: u32,
+    /// Agent 二进制版本。
     pub agent_version: String,
+    /// 主机启动时间,无法采集时为空。
     pub boot_time: Option<DateTime<Utc>>,
     #[serde(default)]
+    /// 部署方自定义标签。
     pub tags: Vec<String>,
 }
 
 /// 首页列表需要的节点身份字段,避免把详情页不需要的静态字段一起下发。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NodeListIdentity {
+    /// 节点在 registry 中的稳定 ID。
     pub node_id: String,
+    /// UI 中展示的节点名称。
     pub node_label: String,
+    /// Agent 采集到的主机名。
     pub hostname: String,
     #[serde(default)]
+    /// 首页列表展示和筛选用标签。
     pub tags: Vec<String>,
 }
 
 /// Linux 三档平均负载,与 `uptime` / `/proc/loadavg` 输出一致。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LoadAverage {
+    /// 1 分钟平均负载。
     pub one: f64,
+    /// 5 分钟平均负载。
     pub five: f64,
+    /// 15 分钟平均负载。
     pub fifteen: f64,
 }
 
 /// 首页列表矩阵只需要 1 分钟负载。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NodeListLoadAverage {
+    /// 1 分钟平均负载。
     pub one: f64,
 }
 
@@ -53,29 +71,43 @@ pub struct NodeListLoadAverage {
 /// `available_bytes` 取自 `MemAvailable`(若不可用则用 `MemFree + Buffers + Cached` 近似)。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MemoryUsage {
+    /// 总物理内存字节数。
     pub total_bytes: u64,
+    /// 已用物理内存字节数。
     pub used_bytes: u64,
+    /// 可用物理内存字节数。
     pub available_bytes: u64,
+    /// 总 swap 字节数。
     pub swap_total_bytes: u64,
+    /// 已用 swap 字节数。
     pub swap_used_bytes: u64,
 }
 
 /// 首页列表矩阵只需要总内存与已用内存。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NodeListMemoryUsage {
+    /// 总物理内存字节数。
     pub total_bytes: u64,
+    /// 已用物理内存字节数。
     pub used_bytes: u64,
 }
 
 /// 单个挂载点的磁盘使用情况。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DiskUsage {
+    /// 设备名或块设备路径。
     pub device: String,
+    /// 挂载点路径。
     pub mount_point: String,
+    /// 文件系统类型。
     pub fs_type: String,
+    /// 文件系统总容量字节数。
     pub total_bytes: u64,
+    /// 文件系统可用容量字节数。
     pub available_bytes: u64,
+    /// 文件系统已用容量字节数。
     pub used_bytes: u64,
+    /// 文件系统已用百分比。
     pub used_percent: f64,
 }
 
@@ -84,38 +116,53 @@ pub struct DiskUsage {
 /// 即时速率在 Agent 启动后第一次采样时不可用,因此为 `Option`。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NetworkCounters {
+    /// Agent 启动后或系统计数器当前的累计接收字节数。
     pub total_rx_bytes: u64,
+    /// Agent 启动后或系统计数器当前的累计发送字节数。
     pub total_tx_bytes: u64,
+    /// 接收速率,首帧无前值时为空。
     pub rx_bytes_per_sec: Option<f64>,
+    /// 发送速率,首帧无前值时为空。
     pub tx_bytes_per_sec: Option<f64>,
     #[serde(default)]
+    /// 可选丢包率百分比,平台无法采集时为空。
     pub packet_loss_percent: Option<f64>,
 }
 
 /// Server 端推断出的 IP 地理位置。手动 tag 仍然可以在 UI 中覆盖/回退。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GeoIpLocation {
+    /// 国家或地区名称。
     pub country: String,
     #[serde(default)]
+    /// 城市名称,仅城市级数据可用时存在。
     pub city: Option<String>,
     #[serde(default)]
+    /// 纬度,仅城市级数据可用时存在。
     pub latitude: Option<f64>,
     #[serde(default)]
+    /// 经度,仅城市级数据可用时存在。
     pub longitude: Option<f64>,
 }
 
 /// 单次采样得到的完整节点快照。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NodeSnapshot {
+    /// Agent 采集该快照的 UTC 时间。
     pub collected_at: DateTime<Utc>,
     /// CPU 使用率在 Agent 首次采样时没有前值可做差分,因此可能为空。
     #[serde(default)]
     pub cpu_usage_percent: Option<f64>,
+    /// 三档平均负载。
     pub load: LoadAverage,
+    /// 内存与 swap 使用情况。
     pub memory: MemoryUsage,
+    /// 主机运行时间秒数。
     pub uptime_secs: u64,
     #[serde(default)]
+    /// 磁盘挂载点使用情况。
     pub disks: Vec<DiskUsage>,
+    /// 网络累计计数器与即时速率。
     pub network: NetworkCounters,
 }
 
@@ -123,8 +170,11 @@ pub struct NodeSnapshot {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NodeListSnapshot {
     #[serde(default)]
+    /// CPU 使用率百分比,首帧无前值时为空。
     pub cpu_usage_percent: Option<f64>,
+    /// 首页所需的最小负载字段。
     pub load: NodeListLoadAverage,
+    /// 首页所需的最小内存字段。
     pub memory: NodeListMemoryUsage,
 }
 
@@ -133,57 +183,83 @@ pub struct NodeListSnapshot {
 /// `snapshot` 在 Hello 之后、首次 Metrics 之前可能为 `None`。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NodeStatus {
+    /// 节点身份信息。
     pub identity: NodeIdentity,
     #[serde(default)]
+    /// Server 看到的远端 IP。
     pub remote_ip: Option<String>,
     #[serde(default)]
+    /// GeoIP 推断出的国家或地区。
     pub geoip_country: Option<String>,
     #[serde(default)]
+    /// GeoIP 推断出的城市。
     pub geoip_city: Option<String>,
     #[serde(default)]
+    /// GeoIP 推断出的纬度。
     pub geoip_latitude: Option<f64>,
     #[serde(default)]
+    /// GeoIP 推断出的经度。
     pub geoip_longitude: Option<f64>,
     #[serde(default)]
+    /// 运维手动覆盖的国家或地区。
     pub location_override_country: Option<String>,
     #[serde(default)]
+    /// 运维手动覆盖的城市。
     pub location_override_city: Option<String>,
     #[serde(default)]
+    /// 运维手动覆盖的纬度。
     pub location_override_latitude: Option<f64>,
     #[serde(default)]
+    /// 运维手动覆盖的经度。
     pub location_override_longitude: Option<f64>,
+    /// 最新完整快照,首次 metrics 到达前为空。
     pub snapshot: Option<NodeSnapshot>,
+    /// Server 最近一次收到该节点消息的 UTC 时间。
     pub last_seen: Option<DateTime<Utc>>,
+    /// 最近一次心跳测得的延迟毫秒数。
     pub latency_ms: Option<u64>,
+    /// 节点当前是否在线。
     pub online: bool,
 }
 
 /// `/api/nodes` 的轻量列表项,避免把详情字段放进首页全量刷新响应。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NodeListItem {
+    /// 首页列表所需的节点身份字段。
     pub identity: NodeListIdentity,
     #[serde(default)]
+    /// GeoIP 推断出的国家或地区。
     pub geoip_country: Option<String>,
     #[serde(default)]
+    /// GeoIP 推断出的城市。
     pub geoip_city: Option<String>,
     #[serde(default)]
+    /// GeoIP 推断出的纬度。
     pub geoip_latitude: Option<f64>,
     #[serde(default)]
+    /// GeoIP 推断出的经度。
     pub geoip_longitude: Option<f64>,
     #[serde(default)]
+    /// 运维手动覆盖的国家或地区。
     pub location_override_country: Option<String>,
     #[serde(default)]
+    /// 运维手动覆盖的城市。
     pub location_override_city: Option<String>,
     #[serde(default)]
+    /// 运维手动覆盖的纬度。
     pub location_override_latitude: Option<f64>,
     #[serde(default)]
+    /// 运维手动覆盖的经度。
     pub location_override_longitude: Option<f64>,
+    /// 首页列表所需的最新快照子集。
     pub snapshot: Option<NodeListSnapshot>,
+    /// 最近一次心跳测得的延迟毫秒数。
     pub latency_ms: Option<u64>,
+    /// 节点当前是否在线。
     pub online: bool,
 }
 
-/// `/api/nodes` 的零拷贝视图,避免从 Arc<str> 克隆字符串 (Phase 3.2 优化)。
+/// `/api/nodes` 的零拷贝视图,避免从 `Arc<str>` 克隆字符串 (Phase 3.2 优化)。
 ///
 /// 与 `NodeListItem` 的区别:
 /// - GeoIP/location_override 字段使用 `Arc<str>` 而非 `String`
@@ -193,25 +269,37 @@ pub struct NodeListItem {
 /// 性能收益: 1000 节点场景下减少 ~80 KB 字符串克隆,API 响应延迟 -45%。
 #[derive(Debug, Clone, Serialize)]
 pub struct NodeListItemView {
+    /// 首页列表所需的节点身份字段。
     pub identity: NodeListIdentity,
     #[serde(default)]
+    /// GeoIP 推断出的国家或地区。
     pub geoip_country: Option<Arc<str>>,
     #[serde(default)]
+    /// GeoIP 推断出的城市。
     pub geoip_city: Option<Arc<str>>,
     #[serde(default)]
+    /// GeoIP 推断出的纬度。
     pub geoip_latitude: Option<f64>,
     #[serde(default)]
+    /// GeoIP 推断出的经度。
     pub geoip_longitude: Option<f64>,
     #[serde(default)]
+    /// 运维手动覆盖的国家或地区。
     pub location_override_country: Option<Arc<str>>,
     #[serde(default)]
+    /// 运维手动覆盖的城市。
     pub location_override_city: Option<Arc<str>>,
     #[serde(default)]
+    /// 运维手动覆盖的纬度。
     pub location_override_latitude: Option<f64>,
     #[serde(default)]
+    /// 运维手动覆盖的经度。
     pub location_override_longitude: Option<f64>,
+    /// 首页列表所需的最新快照子集。
     pub snapshot: Option<NodeListSnapshot>,
+    /// 最近一次心跳测得的延迟毫秒数。
     pub latency_ms: Option<u64>,
+    /// 节点当前是否在线。
     pub online: bool,
 }
 
@@ -220,35 +308,56 @@ pub struct NodeListItemView {
 /// 与 `NodeSnapshot` 的区别在于仅保留有损但够用的关键指标,降低存储成本。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct HistoryPoint {
+    /// 该采样所属的节点 ID。
     pub node_id: String,
+    /// 采样写入历史库的 UTC 时间。
     pub recorded_at: DateTime<Utc>,
+    /// CPU 使用率百分比。
     pub cpu_usage_percent: Option<f64>,
     #[serde(default)]
+    /// 1 分钟平均负载。
     pub load_one: Option<f64>,
     #[serde(default)]
+    /// 5 分钟平均负载。
     pub load_five: Option<f64>,
     #[serde(default)]
+    /// 15 分钟平均负载。
     pub load_fifteen: Option<f64>,
+    /// 内存使用率百分比。
     pub memory_used_percent: f64,
+    /// 接收速率 bytes/s。
     pub rx_bytes_per_sec: Option<f64>,
+    /// 发送速率 bytes/s。
     pub tx_bytes_per_sec: Option<f64>,
+    /// 心跳延迟毫秒数。
     pub latency_ms: Option<u64>,
     #[serde(default)]
+    /// 丢包率百分比。
     pub packet_loss_percent: Option<f64>,
+    /// 所有磁盘中的最高使用率百分比。
     pub disk_used_percent: Option<f64>,
 }
 
 /// 仪表盘顶部的全局概览数据,由 Server 实时聚合得到。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OverviewData {
+    /// 生成该概览的 UTC 时间。
     pub generated_at: DateTime<Utc>,
+    /// registry 中的节点总数。
     pub total_nodes: usize,
+    /// 当前在线节点数。
     pub online_nodes: usize,
+    /// 当前离线节点数。
     pub offline_nodes: usize,
+    /// 所有节点累计接收字节数之和。
     pub total_rx_bytes: u64,
+    /// 所有节点累计发送字节数之和。
     pub total_tx_bytes: u64,
+    /// 所有在线节点当前接收速率之和。
     pub current_rx_bytes_per_sec: f64,
+    /// 所有在线节点当前发送速率之和。
     pub current_tx_bytes_per_sec: f64,
+    /// 在线节点最近心跳延迟的平均值。
     pub average_latency_ms: Option<f64>,
 }
 

--- a/nodelite-proto/src/validation.rs
+++ b/nodelite-proto/src/validation.rs
@@ -8,12 +8,17 @@
 
 use std::fmt;
 
+/// Validation failure returned by shared config and registry helpers.
+///
+/// The message is intentionally human-readable because callers surface it in
+/// configuration or registration error responses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidationError {
     message: String,
 }
 
 impl ValidationError {
+    /// Create a validation error with a display-ready message.
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
@@ -31,6 +36,10 @@ impl std::error::Error for ValidationError {}
 
 const IDENTIFIER_MAX_CHARS: usize = 128;
 
+/// Reject values that are empty after trimming ASCII or Unicode whitespace.
+///
+/// `field` is included verbatim in the returned error so callers can point to a
+/// TOML key, JSON field, or registry property.
 pub fn validate_non_empty(field: &str, value: &str) -> Result<(), ValidationError> {
     if value.trim().is_empty() {
         return Err(ValidationError::new(format!("{field} must not be empty")));
@@ -38,6 +47,11 @@ pub fn validate_non_empty(field: &str, value: &str) -> Result<(), ValidationErro
     Ok(())
 }
 
+/// Validate a stable NodeLite identifier.
+///
+/// Identifiers must be non-empty, at most 128 bytes long, and limited to ASCII
+/// letters, numbers, dash, underscore, and dot. The same rule is used for node
+/// IDs and other registry keys that need to be safe in logs, paths, and labels.
 pub fn validate_identifier(field: &str, value: &str) -> Result<(), ValidationError> {
     validate_non_empty(field, value)?;
     if value.len() > IDENTIFIER_MAX_CHARS {
@@ -56,6 +70,10 @@ pub fn validate_identifier(field: &str, value: &str) -> Result<(), ValidationErr
     Ok(())
 }
 
+/// Trim, sort, and deduplicate a list of operator-provided strings.
+///
+/// Empty entries are discarded after trimming. The output order is stable and
+/// deterministic, which keeps config round-trips and tests reproducible.
 pub fn normalize_string_list(values: Vec<String>) -> Vec<String> {
     let mut values: Vec<String> = values
         .into_iter()
@@ -67,6 +85,11 @@ pub fn normalize_string_list(values: Vec<String>) -> Vec<String> {
     values
 }
 
+/// Validate normalized node tags against count and byte-size limits.
+///
+/// This function does not trim or deduplicate; call [`normalize_string_list`]
+/// first when values come from free-form user input. `max_tag_bytes` is measured
+/// with `String::len`, so it is a UTF-8 byte limit rather than a character count.
 pub fn validate_tag_list(
     field: &str,
     values: &[String],


### PR DESCRIPTION
## Summary
- document the remaining public `nodelite-proto` API surface so missing-docs rustdoc passes for the crate
- add a release SBOM job that installs pinned `cargo-cyclonedx 0.5.9`, generates CycloneDX JSON for proto/agent/server, uploads it as a release artifact, and includes it in `SHA256SUMS.txt`
- update README release notes to document the SBOM artifacts

## Verification
- `RUSTDOCFLAGS='-D missing_docs' cargo doc -p nodelite-proto --no-deps`
- `cargo test -p nodelite-proto --locked`
- `cargo +stable fmt --all --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `cargo cyclonedx --format json --spec-version 1.5 --target all --all --all-features`
- simulated copying SBOM JSON files and generating `SHA256SUMS-sbom.txt`

References: cargo-cyclonedx documents `cargo cyclonedx`, JSON output, `--target all`, and `--override-filename`/filename behavior in its README: https://github.com/CycloneDX/cyclonedx-rust-cargo/tree/master/cargo-cyclonedx

Closes #240
Closes #238