### PR TITLE
Ops CI issue sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,10 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh
+
+      - name: Test installer summaries
+        run: sh scripts/test-install-server-summary.sh
 
       - name: Audit dependency advisories
         # 发布前之外,日常 CI 也要尽早暴露已知 RUSTSEC / yanked 依赖问题。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,49 @@ jobs:
           NODELITE_SKIP_WEB_BUILD: 1
         run: cargo test --workspace --locked
 
+  web-e2e:
+    name: Web E2E
+    runs-on: ubuntu-latest
+    needs: [web-lint-and-test]
+    defaults:
+      run:
+        working-directory: nodelite-server/web
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: nodelite-server/web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright E2E
+        run: pnpm e2e:ci
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            nodelite-server/web/playwright-report/
+            nodelite-server/web/test-results/
+          retention-days: 7
+
   web-lint-and-test:
     # 前端 Stage 0 守门:lint / typecheck / 单测 / 构建,以及 CSP 内联脚本守卫。
     # Stage 1 接入 build.rs 后,Rust 侧会通过 NODELITE_SKIP_WEB_BUILD=1 复用这里的 dist/。

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -79,6 +79,12 @@ jobs:
           NODELITE_SKIP_WEB_BUILD: 1
         run: cargo tarpaulin --config tarpaulin.toml
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: target/tarpaulin/cobertura.xml
+          fail_ci_if_error: false
+
       - name: Upload HTML report as artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh
 
       - name: Audit dependency advisories
         run: cargo audit --deny warnings

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![CI](https://github.com/XiNian-dada/NodeLite/actions/workflows/ci.yml/badge.svg)](https://github.com/XiNian-dada/NodeLite/actions/workflows/ci.yml)
 [![Coverage](https://github.com/XiNian-dada/NodeLite/actions/workflows/coverage.yml/badge.svg)](https://github.com/XiNian-dada/NodeLite/actions/workflows/coverage.yml)
+[![codecov](https://codecov.io/gh/XiNian-dada/NodeLite/branch/main/graph/badge.svg)](https://codecov.io/gh/XiNian-dada/NodeLite)
 
 # NodeLite
 
@@ -122,6 +123,8 @@ Prometheus 快速验证：
 ```bash
 curl -u viewer:secret https://monitor.example.com/metrics
 ```
+
+Prometheus 抓取示例和 Grafana Dashboard 见 `ops/prometheus/prometheus.yml` 与 `ops/grafana/nodelite-dashboard.json`。
 
 ## 当前能力
 

--- a/nodelite-server/web/package.json
+++ b/nodelite-server/web/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "e2e": "playwright test",
+    "e2e:ci": "playwright test e2e/auto-logout-24h.spec.ts",
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {

--- a/nodelite-server/web/playwright.config.ts
+++ b/nodelite-server/web/playwright.config.ts
@@ -4,14 +4,14 @@ import { defineConfig, devices } from '@playwright/test';
 // NODELITE_E2E_BASE_URL=http://localhost:8080 (legacy backend) for the
 // Stage 2/3 flows that need the real Rust API. Either backend handles
 // Basic Auth via NODELITE_E2E_USER/PASS below.
-const DEFAULT_BASE_URL = process.env.NODELITE_E2E_BASE_URL ?? 'http://localhost:5173';
+const DEFAULT_BASE_URL = process.env.NODELITE_E2E_BASE_URL ?? 'http://127.0.0.1:5173';
 
 export default defineConfig({
   testDir: './e2e',
   webServer: process.env.NODELITE_E2E_BASE_URL
     ? undefined
     : {
-        command: 'pnpm dev -- --host 127.0.0.1',
+        command: 'pnpm dev --host 127.0.0.1',
         url: DEFAULT_BASE_URL,
         reuseExistingServer: !process.env.CI,
         timeout: 120_000,

--- a/nodelite-server/web/playwright.config.ts
+++ b/nodelite-server/web/playwright.config.ts
@@ -8,6 +8,14 @@ const DEFAULT_BASE_URL = process.env.NODELITE_E2E_BASE_URL ?? 'http://localhost:
 
 export default defineConfig({
   testDir: './e2e',
+  webServer: process.env.NODELITE_E2E_BASE_URL
+    ? undefined
+    : {
+        command: 'pnpm dev -- --host 127.0.0.1',
+        url: DEFAULT_BASE_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/ops/grafana/nodelite-dashboard.json
+++ b/ops/grafana/nodelite-dashboard.json
@@ -1,0 +1,149 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "nodelite_nodes_total",
+          "refId": "A"
+        },
+        {
+          "expr": "nodelite_nodes_online",
+          "refId": "B"
+        },
+        {
+          "expr": "nodelite_nodes_offline",
+          "refId": "C"
+        }
+      ],
+      "title": "Nodes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "rate(nodelite_ws_messages_total{type=\"metrics\"}[5m])",
+          "refId": "A"
+        }
+      ],
+      "title": "Metrics Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "nodelite_history_queue_depth",
+          "refId": "A"
+        },
+        {
+          "expr": "nodelite_audit_queue_depth",
+          "refId": "B"
+        }
+      ],
+      "title": "Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "nodelite_sqlite_wal_checkpoint_pages{state=\"backlog\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "SQLite WAL Backlog",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "label": "Prometheus",
+        "name": "DS_PROMETHEUS",
+        "query": "prometheus",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "NodeLite",
+  "uid": "nodelite",
+  "version": 1
+}

--- a/ops/prometheus/prometheus.yml
+++ b/ops/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: nodelite
+    metrics_path: /metrics
+    scheme: https
+    basic_auth:
+      username: viewer
+      password: change-me
+    static_configs:
+      - targets:
+          - monitor.example.com

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -104,6 +104,15 @@ tty_println() {
   fi
 }
 
+print_readonly_credentials_summary() {
+  tty_println "Readonly username: $READONLY_USERNAME"
+  if has_tty; then
+    tty_println "Readonly password: $READONLY_PASSWORD"
+  else
+    tty_println "Readonly password: written to $CONFIG_PATH"
+  fi
+}
+
 # 清屏:优先使用 `clear`,否则发送 ANSI 序列。
 clear_screen() {
   if ! has_tty; then
@@ -1010,8 +1019,7 @@ if [ "$MODE" = "upgrade" ]; then
     tty_println "Config supplemented: added $CONFIG_DEFAULTS_ADDED missing default setting(s)."
   fi
 else
-  tty_println "Readonly username: $READONLY_USERNAME"
-  tty_println "Readonly password: $READONLY_PASSWORD"
+  print_readonly_credentials_summary
   tty_println "Public base URL: ${PUBLIC_SCHEME}://${PUBLIC_HOST}"
 fi
 tty_println ""

--- a/scripts/test-install-server-summary.sh
+++ b/scripts/test-install-server-summary.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+INSTALLER="$SCRIPT_DIR/install-server.sh"
+HAS_TTY_MODE="non-tty"
+
+extract_summary_function() {
+  awk '
+    /^print_readonly_credentials_summary\(\) \{/ { printing = 1 }
+    printing { print }
+    printing && /^\}/ { exit }
+  ' "$INSTALLER"
+}
+
+run_summary() {
+  HAS_TTY_MODE="$1"
+
+  READONLY_USERNAME="viewer"
+  READONLY_PASSWORD="secret-from-test"
+  CONFIG_PATH="/opt/nodelite/config/server.toml"
+  export READONLY_USERNAME READONLY_PASSWORD CONFIG_PATH HAS_TTY_MODE
+
+  eval "$(extract_summary_function)"
+  print_readonly_credentials_summary
+}
+
+has_tty() {
+  [ "$HAS_TTY_MODE" = "tty" ]
+}
+
+tty_println() {
+  printf '%s\n' "$*"
+}
+
+non_tty_output="$(run_summary non-tty)"
+case "$non_tty_output" in
+  *secret-from-test*)
+    printf '%s\n' "non-tty summary leaked readonly password" >&2
+    exit 1
+    ;;
+esac
+printf '%s\n' "$non_tty_output" | grep -F "Readonly password: written to /opt/nodelite/config/server.toml" >/dev/null
+
+tty_output="$(run_summary tty)"
+printf '%s\n' "$tty_output" | grep -F "Readonly password: secret-from-test" >/dev/null


### PR DESCRIPTION
## Summary
- add Prometheus and Grafana observability examples plus Codecov upload wiring
- add a minimal Playwright E2E CI canary using the existing auto-logout browser test
- avoid printing generated readonly passwords in non-TTY install summaries

## Verification
- shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh
- sh scripts/test-install-server-summary.sh
- pnpm --dir nodelite-server/web lint
- pnpm --dir nodelite-server/web typecheck
- pnpm --dir nodelite-server/web e2e:ci
- cargo +stable fmt --all --check
- workflow YAML parse, Grafana JSON parse, Prometheus YAML parse

Closes #214
Closes #205
Closes #247