### PR TITLE
security: harden frontend and CI hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check pinned GitHub Actions
+        run: sh scripts/check-actions-pinned.sh
 
       - name: Download web dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: web-dist
           path: nodelite-server/web/dist
@@ -32,7 +35,7 @@ jobs:
           rustup component add clippy rustfmt
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ci-lint-and-test
           workspaces: |
@@ -45,10 +48,10 @@ jobs:
           sudo apt-get install -y shellcheck
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
+        uses: taiki-e/install-action@51b65422b7953c6b71a6f15b2ba16135551ce70a # cargo-audit
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@cargo-deny
+        uses: taiki-e/install-action@dc3d73161fdc9d737a247c07ec4d259142348ee1 # cargo-deny
 
       - name: Check formatting
         # 严格校验 cargo fmt 的格式约定,任何差异都会失败。
@@ -66,7 +69,7 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh scripts/check-demo-credentials.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
 
       - name: Test installer summaries
         run: sh scripts/test-install-server-summary.sh
@@ -88,10 +91,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download web dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: web-dist
           path: nodelite-server/web/dist
@@ -102,7 +105,7 @@ jobs:
           rustup default 1.88.0
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ci-msrv
           workspaces: |
@@ -123,15 +126,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.11.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -148,7 +151,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: |
@@ -167,16 +170,16 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up pnpm
         # 必须先装 pnpm,setup-node 的 cache: pnpm 才能找到它。
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.11.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -215,7 +218,7 @@ jobs:
           fi
 
       - name: Upload web dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: web-dist
           path: nodelite-server/web/dist
@@ -235,10 +238,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download web dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: web-dist
           path: nodelite-server/web/dist
@@ -249,7 +252,7 @@ jobs:
           rustup default stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ci-cross-${{ matrix.target }}
           workspaces: |
@@ -257,7 +260,7 @@ jobs:
 
       - name: Install cross
         # 使用 cross 容器化交叉编译,免去手动准备 musl sysroot。
-        uses: taiki-e/install-action@cross
+        uses: taiki-e/install-action@532bca59bd936483e3ece96e64da0d83ba0f744a # cross
 
       - name: Disable local linker overrides for CI cross build
         # 本地 .cargo/config.toml 里写死了 rust-lld 路径,CI 镜像里没有,所以临时改名。
@@ -290,7 +293,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Rust
         run: |
@@ -299,7 +302,7 @@ jobs:
           rustup target add "${{ matrix.target }}"
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ci-agent-macos-${{ matrix.target }}
           workspaces: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint-and-test:
-    name: Lint and Test
+  workflow-guards:
+    name: Workflow Guards
     runs-on: ubuntu-latest
-    needs: [web-lint-and-test]
 
     steps:
       - name: Check out repository
@@ -20,6 +19,15 @@ jobs:
 
       - name: Check pinned GitHub Actions
         run: sh scripts/check-actions-pinned.sh
+
+  lint-and-test:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+    needs: [workflow-guards, web-lint-and-test]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download web dist
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -87,7 +95,7 @@ jobs:
   msrv:
     name: MSRV Check
     runs-on: ubuntu-latest
-    needs: [web-lint-and-test]
+    needs: [workflow-guards, web-lint-and-test]
 
     steps:
       - name: Check out repository
@@ -119,7 +127,7 @@ jobs:
   web-e2e:
     name: Web E2E
     runs-on: ubuntu-latest
-    needs: [web-lint-and-test]
+    needs: [workflow-guards, web-lint-and-test]
     defaults:
       run:
         working-directory: nodelite-server/web
@@ -164,6 +172,7 @@ jobs:
     # Stage 1 接入 build.rs 后,Rust 侧会通过 NODELITE_SKIP_WEB_BUILD=1 复用这里的 dist/。
     name: Web Lint and Test
     runs-on: ubuntu-latest
+    needs: [workflow-guards]
     defaults:
       run:
         working-directory: nodelite-server/web
@@ -227,7 +236,7 @@ jobs:
   cross-build:
     # 跨平台构建:确保发布前 musl 目标都能编译通过。
     name: Cross Build ${{ matrix.target }}
-    needs: [lint-and-test, msrv, web-lint-and-test]
+    needs: [workflow-guards, lint-and-test, msrv, web-lint-and-test]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -280,7 +289,7 @@ jobs:
   agent-macos-build:
     # 先只验证 Agent 的官方 macOS 构建目标,避免把 server/安装链路一起扩大。
     name: Agent macOS Build ${{ matrix.target }}
-    needs: [lint-and-test, msrv]
+    needs: [workflow-guards, lint-and-test, msrv]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Audit web dependencies
+        run: pnpm audit --audit-level high
+
       - name: Lint
         run: pnpm lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,13 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh scripts/check-demo-credentials.sh
 
       - name: Test installer summaries
         run: sh scripts/test-install-server-summary.sh
+
+      - name: Check demo credentials
+        run: sh scripts/check-demo-credentials.sh
 
       - name: Audit dependency advisories
         # 发布前之外,日常 CI 也要尽早暴露已知 RUSTSEC / yanked 依赖问题。

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.11.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -38,7 +38,7 @@ jobs:
         run: pnpm build
 
       - name: Upload web dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: web-dist-coverage
           path: nodelite-server/web/dist
@@ -51,10 +51,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download web dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: web-dist-coverage
           path: nodelite-server/web/dist
@@ -65,14 +65,14 @@ jobs:
           rustup default stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ci-coverage
           workspaces: |
             . -> target
 
       - name: Install cargo-tarpaulin
-        uses: taiki-e/install-action@cargo-tarpaulin
+        uses: taiki-e/install-action@3b664cf14a5ece2f5ab5d6a546105849b250983c # cargo-tarpaulin
 
       - name: Run coverage
         env:
@@ -80,14 +80,14 @@ jobs:
         run: cargo tarpaulin --config tarpaulin.toml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: target/tarpaulin/cobertura.xml
           fail_ci_if_error: false
 
       - name: Upload HTML report as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report
           path: target/tarpaulin/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh scripts/check-demo-credentials.sh
 
       - name: Audit dependency advisories
         run: cargo audit --deny warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,18 +29,18 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.11.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -60,7 +60,7 @@ jobs:
           rustup component add clippy rustfmt
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-validate
           workspaces: |
@@ -72,10 +72,10 @@ jobs:
           sudo apt-get install -y shellcheck
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
+        uses: taiki-e/install-action@51b65422b7953c6b71a6f15b2ba16135551ce70a # cargo-audit
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@cargo-deny
+        uses: taiki-e/install-action@dc3d73161fdc9d737a247c07ec4d259142348ee1 # cargo-deny
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -91,7 +91,7 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh scripts/check-demo-credentials.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
 
       - name: Audit dependency advisories
         run: cargo audit --deny warnings
@@ -114,18 +114,18 @@ jobs:
     steps:
       - name: Check out repository
         # fetch-depth=0 让 cross 等工具能看到完整历史;ref 强制 checkout 到 release tag。
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.11.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -143,14 +143,14 @@ jobs:
           rustup default stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-${{ matrix.target }}
           workspaces: |
             . -> target
 
       - name: Install cross
-        uses: taiki-e/install-action@cross
+        uses: taiki-e/install-action@532bca59bd936483e3ece96e64da0d83ba0f744a # cross
 
       - name: Warm cross image with retries
         # GHCR 偶发超时会让 cross 首次拉镜像失败;先显式重试拉取,减少 release 偶发红灯。
@@ -203,7 +203,7 @@ jobs:
             > "dist/SHA256SUMS-${{ matrix.target }}.txt"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-${{ matrix.target }}
           path: |
@@ -214,7 +214,7 @@ jobs:
       - name: Upload installer scripts
         # 安装脚本只需要随某一个架构上传一次。
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-scripts
           path: |
@@ -237,7 +237,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: refs/tags/${{ env.RELEASE_TAG }}
@@ -249,7 +249,7 @@ jobs:
           rustup target add "${{ matrix.target }}"
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-agent-macos-${{ matrix.target }}
           workspaces: |
@@ -269,7 +269,7 @@ jobs:
             > "dist/SHA256SUMS-${{ matrix.target }}.txt"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-agent-${{ matrix.target }}
           path: |
@@ -284,7 +284,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: refs/tags/${{ env.RELEASE_TAG }}
@@ -295,7 +295,7 @@ jobs:
           rustup default stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-sbom
           workspaces: |
@@ -320,7 +320,7 @@ jobs:
           sha256sum dist/*.cdx.json > dist/SHA256SUMS-sbom.txt
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-sbom
           path: |
@@ -340,7 +340,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: release-assets
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"

--- a/README.en.md
+++ b/README.en.md
@@ -120,7 +120,7 @@ Browser -> https://monitor.example.com/ -> Nginx/Caddy -> 127.0.0.1:nodelite-ser
 Quick Prometheus check:
 
 ```bash
-curl -u viewer:secret https://monitor.example.com/metrics
+curl -u "$NODELITE_READONLY_USERNAME:$NODELITE_READONLY_PASSWORD" https://monitor.example.com/metrics
 ```
 
 ## Current Capabilities

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Browser -> https://monitor.example.com/ -> Nginx/Caddy -> 127.0.0.1:nodelite-ser
 Prometheus 快速验证：
 
 ```bash
-curl -u viewer:secret https://monitor.example.com/metrics
+curl -u "$NODELITE_READONLY_USERNAME:$NODELITE_READONLY_PASSWORD" https://monitor.example.com/metrics
 ```
 
 Prometheus 抓取示例和 Grafana Dashboard 见 `ops/prometheus/prometheus.yml` 与 `ops/grafana/nodelite-dashboard.json`。

--- a/config/server.example.toml
+++ b/config/server.example.toml
@@ -48,14 +48,14 @@ export_node_resource_metrics = false
 export_node_disk_metrics = false
 
 [auth]
-# 前端只读访问用的基本认证用户名。
-username = "viewer"
-# 对应密码,生产环境务必修改,不要沿用默认值。
-password = "Str0ng#Passphrase!2026"
+# 前端只读访问用的基本认证用户名;生产建议由安装脚本生成或通过受控配置注入。
+# username = "<readonly-username>"
+# 对应密码;不要把实际密码提交到仓库或运维手册。
+# password = "<generated-strong-password>"
 # 可选:开启 TOTP 二次验证。开启后需要先通过 Basic Auth,再输入 6 位动态码。
 enable_2fa = false
 # 可选:TOTP base32 secret。仅在 enable_2fa = true 时必须配置。
-# totp_secret = "JBSWY3DPEHPK3PXP"
+# totp_secret = "<base32-secret-from-setup>"
 
 [audit]
 # 安全审计日志开关。关闭后不再写入 /api/audit-log 也会返回 503。

--- a/nodelite-server/build.rs
+++ b/nodelite-server/build.rs
@@ -43,6 +43,7 @@ fn main() {
     println!("cargo:rerun-if-changed=web/index.html");
     println!("cargo:rerun-if-changed=web/package.json");
     println!("cargo:rerun-if-changed=web/pnpm-lock.yaml");
+    println!("cargo:rerun-if-changed=web/pnpm-workspace.yaml");
     println!("cargo:rerun-if-changed=web/vite.config.ts");
     println!("cargo:rerun-if-changed=web/tsconfig.json");
 

--- a/nodelite-server/web/package.json
+++ b/nodelite-server/web/package.json
@@ -42,10 +42,5 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "packageManager": "pnpm@10.11.0",
-  "pnpm": {
-    "overrides": {
-      "vite": "^6.4.3"
-    }
-  }
+  "packageManager": "pnpm@10.11.0"
 }

--- a/nodelite-server/web/package.json
+++ b/nodelite-server/web/package.json
@@ -31,16 +31,21 @@
     "@vue/test-utils": "^2.4.6",
     "eslint": "^9.16.0",
     "eslint-plugin-vue": "^9.32.0",
-    "jsdom": "^25.0.1",
+    "jsdom": "^26.1.0",
     "prettier": "^3.4.2",
     "typescript": "~5.6.3",
-    "vite": "^5.4.11",
-    "vitest": "^2.1.8",
+    "vite": "^6.4.3",
+    "vitest": "^3.2.6",
     "vitest-websocket-mock": "0.4.0",
     "vue-tsc": "^2.1.10"
   },
   "engines": {
     "node": ">=20.0.0"
   },
-  "packageManager": "pnpm@10.11.0"
+  "packageManager": "pnpm@10.11.0",
+  "pnpm": {
+    "overrides": {
+      "vite": "^6.4.3"
+    }
+  }
 }

--- a/nodelite-server/web/pnpm-lock.yaml
+++ b/nodelite-server/web/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: ^6.4.3
+
 importers:
 
   .:
@@ -29,7 +32,7 @@ importers:
         version: 22.19.19
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.4(vite@5.4.21(@types/node@22.19.19))(vue@3.5.35(typescript@5.6.3))
+        version: 5.2.4(vite@6.4.3(@types/node@22.19.19))(vue@3.5.35(typescript@5.6.3))
       '@vue/eslint-config-prettier':
         specifier: ^10.1.0
         version: 10.2.0(eslint@9.39.4)(prettier@3.8.3)
@@ -46,8 +49,8 @@ importers:
         specifier: ^9.32.0
         version: 9.33.0(eslint@9.39.4)
       jsdom:
-        specifier: ^25.0.1
-        version: 25.0.1
+        specifier: ^26.1.0
+        version: 26.1.0
       prettier:
         specifier: ^3.4.2
         version: 3.8.3
@@ -55,14 +58,14 @@ importers:
         specifier: ~5.6.3
         version: 5.6.3
       vite:
-        specifier: ^5.4.11
-        version: 5.4.21(@types/node@22.19.19)
+        specifier: ^6.4.3
+        version: 6.4.3(@types/node@22.19.19)
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.19.19)(jsdom@26.1.0)
       vitest-websocket-mock:
         specifier: 0.4.0
-        version: 0.4.0(vitest@2.1.9(@types/node@22.19.19)(jsdom@25.0.1))
+        version: 0.4.0(vitest@3.2.6(@types/node@22.19.19)(jsdom@26.1.0))
       vue-tsc:
         specifier: ^2.1.10
         version: 2.2.12(typescript@5.6.3)
@@ -117,141 +120,159 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -485,6 +506,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -563,17 +590,17 @@ packages:
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0
+      vite: ^6.4.3
       vue: ^3.2.25
 
-  '@vitest/expect@2.1.9':
-    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
-  '@vitest/mocker@2.1.9':
-    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0
+      vite: ^6.4.3
     peerDependenciesMeta:
       msw:
         optional: true
@@ -583,17 +610,23 @@ packages:
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
-  '@vitest/runner@2.1.9':
-    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
 
-  '@vitest/snapshot@2.1.9':
-    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
 
-  '@vitest/spy@2.1.9':
-    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   '@volar/language-core@2.4.15':
     resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
@@ -721,9 +754,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -752,10 +782,6 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -778,10 +804,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
 
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -835,14 +857,6 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
-
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -865,28 +879,12 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  es-object-atoms@1.1.2:
-    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
-
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escape-string-regexp@4.0.0:
@@ -1042,10 +1040,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
-
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1055,17 +1049,6 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1088,25 +1071,9 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
-    engines: {node: '>= 0.4'}
 
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
@@ -1181,15 +1148,18 @@ packages:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsdom@25.0.1:
-    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
     peerDependencies:
-      canvas: ^2.11.2
+      canvas: ^3.0.0
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -1229,10 +1199,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1240,14 +1206,6 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
-
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1330,8 +1288,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -1411,9 +1369,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rrweb-cssom@0.7.1:
-    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
-
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
@@ -1477,6 +1432,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1506,8 +1464,12 @@ packages:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -1564,26 +1526,31 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  vite-node@2.1.9:
-    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.4.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
+        optional: true
+      jiti:
         optional: true
       less:
         optional: true
@@ -1599,25 +1566,32 @@ packages:
         optional: true
       terser:
         optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vitest-websocket-mock@0.4.0:
     resolution: {integrity: sha512-tGnOwE2nC8jfioQXDrX+lZ8EVrF+IO2NVqe1vV9h945W/hlR0S6ZYbMqCJGG3Nyd//c5XSe1IGLD2ZgE2D1I7Q==}
     peerDependencies:
       vitest: '>=2'
 
-  vitest@2.1.9:
-    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.9
-      '@vitest/ui': 2.1.9
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -1798,73 +1772,82 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@esbuild/aix-ppc64@0.21.5':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.21.5':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.5':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.21.5':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.21.5':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.5':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.5':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.21.5':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.21.5':
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
@@ -2050,6 +2033,13 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -2153,50 +2143,62 @@ snapshots:
       '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@22.19.19))(vue@3.5.35(typescript@5.6.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.3(@types/node@22.19.19))(vue@3.5.35(typescript@5.6.3))':
     dependencies:
-      vite: 5.4.21(@types/node@22.19.19)
+      vite: 6.4.3(@types/node@22.19.19)
       vue: 3.5.35(typescript@5.6.3)
 
-  '@vitest/expect@2.1.9':
+  '@vitest/expect@3.2.6':
     dependencies:
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
       chai: 5.3.3
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.19))':
+  '@vitest/mocker@3.2.6(vite@6.4.3(@types/node@22.19.19))':
     dependencies:
-      '@vitest/spy': 2.1.9
+      '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@22.19.19)
+      vite: 6.4.3(@types/node@22.19.19)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/runner@2.1.9':
+  '@vitest/pretty-format@3.2.6':
     dependencies:
-      '@vitest/utils': 2.1.9
-      pathe: 1.1.2
+      tinyrainbow: 2.0.0
 
-  '@vitest/snapshot@2.1.9':
+  '@vitest/runner@3.2.6':
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
       magic-string: 0.30.21
-      pathe: 1.1.2
+      pathe: 2.0.3
 
-  '@vitest/spy@2.1.9':
+  '@vitest/spy@3.2.6':
     dependencies:
-      tinyspy: 3.0.2
+      tinyspy: 4.0.4
 
   '@vitest/utils@2.1.9':
     dependencies:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@volar/language-core@2.4.15':
     dependencies:
@@ -2348,8 +2350,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  asynckit@0.4.0: {}
-
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -2375,11 +2375,6 @@ snapshots:
 
   cac@6.7.14: {}
 
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
   callsites@3.1.0: {}
 
   chai@5.3.3:
@@ -2402,10 +2397,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
 
   commander@10.0.1: {}
 
@@ -2448,14 +2439,6 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  delayed-stream@1.0.0: {}
-
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
   eastasianwidth@0.2.0: {}
 
   editorconfig@1.0.7:
@@ -2473,48 +2456,36 @@ snapshots:
 
   entities@7.0.1: {}
 
-  es-define-property@1.0.1: {}
-
-  es-errors@1.3.0: {}
-
   es-module-lexer@1.7.0: {}
 
-  es-object-atoms@1.1.2:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.3
-
-  esbuild@0.21.5:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escape-string-regexp@4.0.0: {}
 
@@ -2694,39 +2665,11 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
-      mime-types: 2.1.35
-
   fsevents@2.3.2:
     optional: true
 
   fsevents@2.3.3:
     optional: true
-
-  function-bind@1.1.2: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.3
-      math-intrinsics: 1.1.0
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.2
 
   glob-parent@5.1.2:
     dependencies:
@@ -2751,19 +2694,7 @@ snapshots:
 
   globals@14.0.0: {}
 
-  gopd@1.2.0: {}
-
   has-flag@4.0.0: {}
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hasown@2.0.3:
-    dependencies:
-      function-bind: 1.1.2
 
   he@1.2.0: {}
 
@@ -2832,23 +2763,24 @@ snapshots:
 
   js-cookie@3.0.7: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@25.0.1:
+  jsdom@26.1.0:
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
-      form-data: 4.0.5
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
-      rrweb-cssom: 0.7.1
+      rrweb-cssom: 0.8.0
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 5.1.2
@@ -2895,20 +2827,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  math-intrinsics@1.1.0: {}
-
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
-
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
 
   minimatch@10.2.5:
     dependencies:
@@ -2982,7 +2906,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
-  pathe@1.1.2: {}
+  pathe@2.0.3: {}
 
   pathval@2.0.1: {}
 
@@ -3070,8 +2994,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
-  rrweb-cssom@0.7.1: {}
-
   rrweb-cssom@0.8.0: {}
 
   run-parallel@1.2.0:
@@ -3124,6 +3046,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -3147,7 +3073,9 @@ snapshots:
 
   tinyrainbow@1.2.0: {}
 
-  tinyspy@3.0.2: {}
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@6.1.86: {}
 
@@ -3198,15 +3126,16 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@2.1.9(@types/node@22.19.19):
+  vite-node@3.2.4(@types/node@22.19.19):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.21(@types/node@22.19.19)
+      pathe: 2.0.3
+      vite: 6.4.3(@types/node@22.19.19)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - less
       - lightningcss
       - sass
@@ -3215,48 +3144,57 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
 
-  vite@5.4.21(@types/node@22.19.19):
+  vite@6.4.3(@types/node@22.19.19):
     dependencies:
-      esbuild: 0.21.5
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.15
       rollup: 4.60.4
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.19.19
       fsevents: 2.3.3
 
-  vitest-websocket-mock@0.4.0(vitest@2.1.9(@types/node@22.19.19)(jsdom@25.0.1)):
+  vitest-websocket-mock@0.4.0(vitest@3.2.6(@types/node@22.19.19)(jsdom@26.1.0)):
     dependencies:
       '@vitest/utils': 2.1.9
       mock-socket: 9.3.1
-      vitest: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)
+      vitest: 3.2.6(@types/node@22.19.19)(jsdom@26.1.0)
 
-  vitest@2.1.9(@types/node@22.19.19)(jsdom@25.0.1):
+  vitest@3.2.6(@types/node@22.19.19)(jsdom@26.1.0):
     dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.19))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@6.4.3(@types/node@22.19.19))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
       magic-string: 0.30.21
-      pathe: 1.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
+      tinyglobby: 0.2.16
       tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@22.19.19)
-      vite-node: 2.1.9(@types/node@22.19.19)
+      tinyrainbow: 2.0.0
+      vite: 6.4.3(@types/node@22.19.19)
+      vite-node: 3.2.4(@types/node@22.19.19)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19
-      jsdom: 25.0.1
+      jsdom: 26.1.0
     transitivePeerDependencies:
+      - jiti
       - less
       - lightningcss
       - msw
@@ -3266,6 +3204,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
 
   vscode-uri@3.1.0: {}
 

--- a/nodelite-server/web/pnpm-workspace.yaml
+++ b/nodelite-server/web/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+packages:
+  - .
+
+allowBuilds:
+  esbuild: true
+  vue-demi: true
+
+overrides:
+  vite: ^6.4.3
+
+onlyBuiltDependencies:
+  - esbuild
+  - vue-demi

--- a/nodelite-server/web/src/ws/client.spec.ts
+++ b/nodelite-server/web/src/ws/client.spec.ts
@@ -1,15 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WS } from 'vitest-websocket-mock';
-import { parseBrowserMessage, WsClient } from './client';
+import { parseBrowserMessage, WsClient, type WsClientLogger } from './client';
 import type { BrowserMessage } from '@/api/types';
+
+const wsUrl = 'ws://localhost:1234/ws/browser';
 
 describe('WsClient', () => {
   let server: WS;
   let client: WsClient;
   let fetchSpy: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  let logger: WsClientLogger;
 
   beforeEach(() => {
     vi.useRealTimers();
+    logger = {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
     Object.defineProperty(document, 'hidden', {
       configurable: true,
       value: false,
@@ -24,16 +32,20 @@ describe('WsClient', () => {
   });
 
   afterEach(() => {
+    if (client) {
+      client.destroy();
+    }
     if (server) {
       server.close();
     }
     fetchSpy.mockRestore();
+    vi.useRealTimers();
   });
 
   describe('connection lifecycle', () => {
     it('transitions from idle → connecting → open', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       expect(client.getState()).toEqual({ kind: 'idle' });
 
@@ -49,8 +61,8 @@ describe('WsClient', () => {
     });
 
     it('does not reconnect if already connecting', () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
       const state1 = client.getState();
@@ -61,8 +73,8 @@ describe('WsClient', () => {
     });
 
     it('does not reconnect if already open', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
       await server.connected;
@@ -75,8 +87,8 @@ describe('WsClient', () => {
     });
 
     it('disconnect() closes the connection and sets failed state', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
       await server.connected;
@@ -91,8 +103,8 @@ describe('WsClient', () => {
 
   describe('reconnect with exponential backoff', () => {
     it('schedules reconnect after close with exponential backoff + jitter', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
       await server.connected;
@@ -112,8 +124,8 @@ describe('WsClient', () => {
     });
 
     it('reconnects after the scheduled delay', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
       await server.connected;
@@ -127,7 +139,7 @@ describe('WsClient', () => {
 
       const delay = state.nextAttemptAt - Date.now();
 
-      server = new WS('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
       await new Promise((resolve) => setTimeout(resolve, delay + 100));
 
       const finalState = client.getState().kind;
@@ -135,10 +147,10 @@ describe('WsClient', () => {
     });
 
     it('caps backoff delay at 30s', async () => {
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      client = new WsClient(wsUrl, logger);
 
       for (let i = 0; i < 5; i++) {
-        server = new WS('ws://localhost:1234/ws/browser');
+        server = new WS(wsUrl);
         client.connect();
         await server.connected;
         server.close();
@@ -168,8 +180,8 @@ describe('WsClient', () => {
     });
 
     it('delivers InitialState to registered handlers', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       const handler = vi.fn();
       client.on('initial_state', handler);
@@ -201,8 +213,8 @@ describe('WsClient', () => {
     });
 
     it('delivers NodeUpsert to registered handlers', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       const handler = vi.fn();
       client.on('node_upsert', handler);
@@ -245,11 +257,10 @@ describe('WsClient', () => {
     });
 
     it('ignores malformed JSON without dispatching handlers', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       const handler = vi.fn();
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
       client.on('initial_state', handler);
 
       client.connect();
@@ -259,19 +270,17 @@ describe('WsClient', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(handler).not.toHaveBeenCalled();
-      expect(errorSpy).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
         'Failed to parse WebSocket message',
         expect.any(SyntaxError),
       );
-      errorSpy.mockRestore();
     });
 
     it('ignores unknown message types without dispatching handlers', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       const handler = vi.fn();
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       client.on('overview_update', handler);
 
       client.connect();
@@ -281,16 +290,14 @@ describe('WsClient', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(handler).not.toHaveBeenCalled();
-      expect(warnSpy).toHaveBeenCalledWith('Ignoring invalid WebSocket browser message');
-      warnSpy.mockRestore();
+      expect(logger.warn).toHaveBeenCalledWith('Ignoring invalid WebSocket browser message');
     });
 
     it('ignores known message types with missing required fields', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       const handler = vi.fn();
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       client.on('node_removed', handler);
 
       client.connect();
@@ -300,13 +307,12 @@ describe('WsClient', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(handler).not.toHaveBeenCalled();
-      expect(warnSpy).toHaveBeenCalledWith('Ignoring invalid WebSocket browser message');
-      warnSpy.mockRestore();
+      expect(logger.warn).toHaveBeenCalledWith('Ignoring invalid WebSocket browser message');
     });
 
     it('unsubscribes handlers via returned function', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       const handler = vi.fn();
       const unsubscribe = client.on('ping', handler);
@@ -328,8 +334,8 @@ describe('WsClient', () => {
 
   describe('dev DOM marker', () => {
     it('increments data-ws-conn-id on each successful connection', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
       await server.connected;
@@ -347,7 +353,7 @@ describe('WsClient', () => {
 
       const delay = state.nextAttemptAt - Date.now();
 
-      server = new WS('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
       await new Promise((resolve) => setTimeout(resolve, delay + 100));
       await server.connected;
 
@@ -358,54 +364,57 @@ describe('WsClient', () => {
   });
 
   describe('heartbeat (Ping/Pong)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
     it('sends Ping after 30s and restarts timer on Pong', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
+      await vi.advanceTimersByTimeAsync(100);
       await server.connected;
 
-      // Wait for first ping (30s)
-      await new Promise((resolve) => setTimeout(resolve, 30100));
+      await vi.advanceTimersByTimeAsync(30_000);
 
       expect(server.messages.length).toBeGreaterThan(0);
       expect(server.messages[0]).toBe(JSON.stringify({ type: 'ping' }));
 
-      // Send pong
       server.send(JSON.stringify({ type: 'pong' }));
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await vi.advanceTimersByTimeAsync(100);
 
-      // Wait for second ping (another 30s)
-      await new Promise((resolve) => setTimeout(resolve, 30100));
+      await vi.advanceTimersByTimeAsync(30_000);
 
       const pings = server.messages.filter((m) => m === JSON.stringify({ type: 'ping' }));
       expect(pings.length).toBeGreaterThanOrEqual(2);
-    }, 65000);
+    });
 
     it('closes connection if Pong not received within 10s', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
+      await vi.advanceTimersByTimeAsync(100);
       await server.connected;
 
       expect(client.getState().kind).toBe('open');
 
-      // Wait for ping (30s)
-      await new Promise((resolve) => setTimeout(resolve, 30100));
+      await vi.advanceTimersByTimeAsync(30_000);
 
       expect(server.messages).toContain(JSON.stringify({ type: 'ping' }));
 
-      // Don't send pong, wait for timeout (10s)
-      await new Promise((resolve) => setTimeout(resolve, 10100));
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(0);
 
+      expect(logger.warn).toHaveBeenCalledWith('Pong timeout, closing connection');
       expect(client.getState().kind).toBe('reconnecting');
-    }, 45000);
+    });
   });
 
   describe('reconnect stop condition', () => {
     it('stops reconnecting after 3 consecutive handshake failures', async () => {
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      client = new WsClient(wsUrl, logger);
 
       // Attempt 1: connect but server never opens
       client.connect();
@@ -461,8 +470,8 @@ describe('WsClient', () => {
 
   describe('visibility handling', () => {
     it('closes connection and stays idle when tab becomes hidden', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
       await server.connected;
@@ -481,8 +490,8 @@ describe('WsClient', () => {
     });
 
     it('reconnects when tab becomes visible after being hidden', async () => {
-      server = new WS('ws://localhost:1234/ws/browser');
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
+      client = new WsClient(wsUrl, logger);
 
       client.connect();
       await server.connected;
@@ -502,7 +511,7 @@ describe('WsClient', () => {
       }
 
       server.close();
-      server = new WS('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
 
       Object.defineProperty(document, 'hidden', {
         configurable: true,
@@ -517,7 +526,7 @@ describe('WsClient', () => {
     });
 
     it('resets handshake failure counter on visibility-triggered reconnect', async () => {
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      client = new WsClient(wsUrl, logger);
 
       // Simulate 3 failures to reach failed state
       for (let i = 0; i < 3; i++) {
@@ -543,7 +552,7 @@ describe('WsClient', () => {
       expect(client.getState().kind).toBe('failed');
 
       // Visibility change should reset counter and reconnect
-      server = new WS('ws://localhost:1234/ws/browser');
+      server = new WS(wsUrl);
 
       Object.defineProperty(document, 'hidden', {
         configurable: true,
@@ -560,7 +569,7 @@ describe('WsClient', () => {
 
   describe('auth probe on handshake failure', () => {
     it('probes /api/bootstrap on WS error during connecting', async () => {
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      client = new WsClient(wsUrl, logger);
       client.connect();
       await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -589,7 +598,7 @@ describe('WsClient', () => {
         url: 'http://localhost/verify-2fa',
       } as Response);
 
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      client = new WsClient(wsUrl, logger);
       client.connect();
       await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -612,7 +621,7 @@ describe('WsClient', () => {
         ok: false,
       } as Response);
 
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      client = new WsClient(wsUrl, logger);
       client.connect();
       await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -628,7 +637,7 @@ describe('WsClient', () => {
     it('does not navigate on successful probe (200)', async () => {
       const originalLocation = window.location.href;
 
-      client = new WsClient('ws://localhost:1234/ws/browser');
+      client = new WsClient(wsUrl, logger);
       client.connect();
       await new Promise((resolve) => setTimeout(resolve, 100));
 

--- a/nodelite-server/web/src/ws/client.ts
+++ b/nodelite-server/web/src/ws/client.ts
@@ -13,6 +13,18 @@ type MessageHandler<T extends BrowserMessage['type']> = (
 
 type UnsubscribeFn = () => void;
 
+export interface WsClientLogger {
+  log: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+const defaultLogger: WsClientLogger = {
+  log: (...args) => console.log(...args),
+  warn: (...args) => console.warn(...args),
+  error: (...args) => console.error(...args),
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -72,7 +84,10 @@ export class WsClient {
 
   private readonly handlers = new Map<string, Set<MessageHandler<BrowserMessage['type']>>>();
 
-  constructor(private readonly url: string) {
+  constructor(
+    private readonly url: string,
+    private readonly logger: WsClientLogger = defaultLogger,
+  ) {
     this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
     if (typeof document !== 'undefined') {
       document.addEventListener('visibilitychange', this.handleVisibilityChange);
@@ -92,7 +107,7 @@ export class WsClient {
       this.ws.onerror = this.onError.bind(this);
       this.ws.onclose = this.onClose.bind(this);
     } catch (e) {
-      console.error('WebSocket construction failed', e);
+      this.logger.error('WebSocket construction failed', e);
       this.scheduleReconnect();
     }
   }
@@ -140,14 +155,14 @@ export class WsClient {
     }
 
     this.startHeartbeat();
-    console.log('WebSocket connected');
+    this.logger.log('WebSocket connected');
   }
 
   private onMessage(event: MessageEvent): void {
     try {
       const msg = parseBrowserMessage(JSON.parse(event.data));
       if (!msg) {
-        console.warn('Ignoring invalid WebSocket browser message');
+        this.logger.warn('Ignoring invalid WebSocket browser message');
         return;
       }
 
@@ -161,12 +176,12 @@ export class WsClient {
         set.forEach((handler) => handler(msg));
       }
     } catch (e) {
-      console.error('Failed to parse WebSocket message', e);
+      this.logger.error('Failed to parse WebSocket message', e);
     }
   }
 
   private onError(event: Event): void {
-    console.error('WebSocket error', event);
+    this.logger.error('WebSocket error', event);
     if (this.state.kind === 'connecting') {
       this.handshakeFailures++;
       this.probeAuthState();
@@ -174,7 +189,7 @@ export class WsClient {
   }
 
   private onClose(event: CloseEvent): void {
-    console.log('WebSocket closed', event.code, event.reason);
+    this.logger.log('WebSocket closed', event.code, event.reason);
     this.ws = null;
     this.clearHeartbeat();
 
@@ -202,17 +217,17 @@ export class WsClient {
       .then((res) => {
         // fetch() follows 302 redirects, so check res.redirected + pathname
         if (res.redirected && new URL(res.url).pathname === '/verify-2fa') {
-          console.warn('Auth probe detected 2FA required, navigating to verify-2fa');
+          this.logger.warn('Auth probe detected 2FA required, navigating to verify-2fa');
           window.location.href = '/verify-2fa';
           return;
         }
         if (res.status === 401) {
-          console.warn('Auth probe detected 401, navigating to logout-and-reauth');
+          this.logger.warn('Auth probe detected 401, navigating to logout-and-reauth');
           window.location.href = '/logout-and-reauth';
         }
       })
       .catch((err) => {
-        console.error('Auth probe failed', err);
+        this.logger.error('Auth probe failed', err);
       });
   }
 
@@ -252,7 +267,7 @@ export class WsClient {
       if (this.ws && this.ws.readyState === WebSocket.OPEN) {
         this.ws.send(JSON.stringify({ type: 'ping' }));
         this.pongTimer = setTimeout(() => {
-          console.warn('Pong timeout, closing connection');
+          this.logger.warn('Pong timeout, closing connection');
           if (this.ws) this.ws.close();
         }, 10000);
       }
@@ -283,7 +298,7 @@ export class WsClient {
 
     if (document.hidden) {
       if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-        console.log('Tab hidden, closing WebSocket');
+        this.logger.log('Tab hidden, closing WebSocket');
         this.ws.close();
       }
     } else {
@@ -292,7 +307,7 @@ export class WsClient {
         this.state.kind === 'idle' ||
         this.state.kind === 'reconnecting'
       ) {
-        console.log('Tab visible, reconnecting');
+        this.logger.log('Tab visible, reconnecting');
         this.clearReconnectTimer();
         this.handshakeFailures = 0;
         this.reconnectAttempt = 0;

--- a/ops/prometheus/prometheus.yml
+++ b/ops/prometheus/prometheus.yml
@@ -7,8 +7,8 @@ scrape_configs:
     metrics_path: /metrics
     scheme: https
     basic_auth:
-      username: viewer
-      password: change-me
+      username: "<readonly-username>"
+      password_file: /etc/nodelite/secrets/metrics-password
     static_configs:
       - targets:
           - monitor.example.com

--- a/scripts/check-actions-pinned.sh
+++ b/scripts/check-actions-pinned.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+found=0
+
+for file in .github/workflows/*.yml .github/workflows/*.yaml; do
+  if [ ! -e "$file" ]; then
+    continue
+  fi
+
+  awk '
+    /uses:[[:space:]]*/ {
+      value = $0
+      sub(/^[[:space:]]*-[[:space:]]*uses:[[:space:]]*/, "", value)
+      sub(/^[[:space:]]*uses:[[:space:]]*/, "", value)
+      sub(/[[:space:]]*#.*/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+
+      if (value ~ /^\.\//) {
+        next
+      }
+
+      if (value !~ /@/) {
+        print FILENAME ":" FNR ":" $0
+        bad = 1
+        next
+      }
+
+      ref = value
+      sub(/^.*@/, "", ref)
+
+      if (length(ref) == 40 && ref !~ /[^0-9a-f]/) {
+        next
+      }
+
+      print FILENAME ":" FNR ":" $0
+      bad = 1
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$file" || found=1
+done
+
+if [ "$found" -ne 0 ]; then
+  printf '%s\n' "GitHub Actions uses must be pinned to full commit SHAs" >&2
+  exit 1
+fi

--- a/scripts/check-demo-credentials.sh
+++ b/scripts/check-demo-credentials.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+set --
+for path in README.md README.en.md config ops .github; do
+  if [ -e "$path" ]; then
+    set -- "$@" "$path"
+  fi
+done
+
+found=0
+
+check_pattern() {
+  pattern="$1"
+  shift
+  matches="$(grep -RInF -- "$pattern" "$@" 2>/dev/null || true)"
+  if [ -n "$matches" ]; then
+    found=1
+    printf '%s\n' "$matches"
+  fi
+}
+
+check_pattern "change-me" "$@"
+check_pattern "viewer:secret" "$@"
+check_pattern "Str0ng#Passphrase!2026" "$@"
+check_pattern "JBSWY3DPEHPK3PXP" "$@"
+
+if [ "$found" -ne 0 ]; then
+  printf '%s\n' "fixed demo credentials found in docs, config, ops, or workflows" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Upgrade patched web dev dependencies and add a high-severity pnpm audit gate.
- Speed up WebSocket heartbeat tests with fake timers and injected logging.
- Remove copyable demo credentials from docs/config/Prometheus examples and add a focused scan.
- Pin GitHub Actions to full commit SHAs, add Dependabot updates, and add a workflow pin guard.

## Validation
- pnpm audit --audit-level high
- pnpm lint
- pnpm typecheck
- pnpm test
- sh scripts/check-demo-credentials.sh
- sh scripts/check-actions-pinned.sh
- shellcheck scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
- NODELITE_SKIP_WEB_BUILD=1 cargo test --workspace
- NODELITE_SKIP_WEB_BUILD=1 cargo clippy --all-targets -- -D warnings

Closes #291
Closes #292
Closes #297
Closes #298