### PR TITLE
security: document FFI safety boundaries

### DIFF
--- a/nodelite-agent/src/collector_linux.rs
+++ b/nodelite-agent/src/collector_linux.rs
@@ -673,8 +673,10 @@ mod tests {
             "nodelite-missing-statvfs-{}-{unique}",
             std::process::id()
         ));
-        let error = real_statvfs(missing.to_string_lossy().as_ref())
-            .expect_err("missing mount paths should surface statvfs errors");
+        let error = match real_statvfs(missing.to_string_lossy().as_ref()) {
+            Ok(_) => panic!("missing mount paths should surface statvfs errors"),
+            Err(error) => error,
+        };
 
         assert!(error.to_string().contains("statvfs failed"));
     }

--- a/nodelite-agent/src/collector_linux.rs
+++ b/nodelite-agent/src/collector_linux.rs
@@ -522,10 +522,13 @@ fn real_statvfs(path: &str) -> Result<FilesystemStats> {
     let c_path =
         CString::new(path.as_bytes()).with_context(|| format!("path contains NUL byte: {path}"))?;
     let mut stats = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    // SAFETY: `c_path` is a live NUL-terminated C string and `stats` points to
+    // writable storage large enough for libc to fill one `statvfs` value.
     let result = unsafe { libc::statvfs(c_path.as_ptr(), stats.as_mut_ptr()) };
     if result != 0 {
         return Err(anyhow!("statvfs failed for {}", Path::new(path).display()));
     }
+    // SAFETY: `statvfs` returned success, which means libc initialized `stats`.
     let stats = unsafe { stats.assume_init() };
 
     let block_size = stats.f_frsize;
@@ -546,13 +549,14 @@ fn real_statvfs(path: &str) -> Result<FilesystemStats> {
 mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::time::{Duration, Instant};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use anyhow::Result;
 
     use super::{
         FilesystemStats, HostCollector, compute_cpu_usage, compute_network_metrics,
         parse_cpu_sample, parse_load_average, parse_memory_usage, parse_network_totals,
+        real_statvfs,
     };
 
     /// RAII 临时目录:构造时创建唯一目录,析构时递归删除。
@@ -657,6 +661,22 @@ mod tests {
                 > 20.0
         );
         assert!(metrics.packet_loss_percent.is_some());
+    }
+
+    #[test]
+    fn real_statvfs_reports_missing_mount_errors() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        let missing = std::env::temp_dir().join(format!(
+            "nodelite-missing-statvfs-{}-{unique}",
+            std::process::id()
+        ));
+        let error = real_statvfs(missing.to_string_lossy().as_ref())
+            .expect_err("missing mount paths should surface statvfs errors");
+
+        assert!(error.to_string().contains("statvfs failed"));
     }
 
     #[test]

--- a/nodelite-agent/src/collector_macos/metrics.rs
+++ b/nodelite-agent/src/collector_macos/metrics.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashSet;
 use std::ffi::CStr;
+use std::mem;
+use std::ptr;
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
@@ -212,6 +214,12 @@ fn collect_network_totals_via_sysctl(cache: &mut NetworkInterfaceCache) -> Resul
 
 fn collect_network_totals_and_indices_via_iflist2(len: usize) -> Result<(NetworkTotals, Vec<u16>)> {
     let buffer = syscall::read_network_iflist2(len)?;
+    Ok(parse_network_totals_and_indices_from_iflist2(&buffer))
+}
+
+pub(super) fn parse_network_totals_and_indices_from_iflist2(
+    buffer: &[u8],
+) -> (NetworkTotals, Vec<u16>) {
     let mut seen_indices = HashSet::new();
     let mut indices = Vec::new();
     let mut rx_bytes = 0_u64;
@@ -220,25 +228,38 @@ fn collect_network_totals_and_indices_via_iflist2(len: usize) -> Result<(Network
     let mut tx_packets = 0_u64;
     let mut rx_dropped_packets = 0_u64;
     let mut next = buffer.as_ptr();
+    // SAFETY: `next` points at the start of `buffer`; adding exactly
+    // `buffer.len()` yields the one-past-the-end pointer for the same slice.
     let end = unsafe { next.add(buffer.len()) };
 
     while next < end {
-        let ifm = next.cast::<libc::if_msghdr>();
-        let message_len = unsafe { (*ifm).ifm_msglen as usize };
-        if message_len == 0 {
+        let remaining = (end as usize).saturating_sub(next as usize);
+        if remaining < mem::size_of::<libc::if_msghdr>() {
+            break;
+        }
+        // SAFETY: The remaining byte count was checked for a full header.
+        // `NET_RT_IFLIST2` buffers are byte streams, so use unaligned reads.
+        let ifm = unsafe { ptr::read_unaligned(next.cast::<libc::if_msghdr>()) };
+        let message_len = ifm.ifm_msglen as usize;
+        if message_len == 0 || message_len > remaining {
             break;
         }
 
-        if unsafe { (*ifm).ifm_type } == libc::RTM_IFINFO2 as u8 {
-            let ifm2 = next.cast::<libc::if_msghdr2>();
-            let flags = unsafe { (*ifm2).ifm_flags };
-            let index = unsafe { (*ifm2).ifm_index };
+        if ifm.ifm_type == libc::RTM_IFINFO2 as u8 {
+            if message_len < mem::size_of::<libc::if_msghdr2>() {
+                break;
+            }
+            // SAFETY: The message declares enough bytes for `if_msghdr2`, and
+            // the previous check keeps the read inside `buffer`.
+            let ifm2 = unsafe { ptr::read_unaligned(next.cast::<libc::if_msghdr2>()) };
+            let flags = ifm2.ifm_flags;
+            let index = ifm2.ifm_index;
             if flags & libc::IFF_LOOPBACK == 0
                 && flags & libc::IFF_UP != 0
                 && seen_indices.insert(index)
             {
                 indices.push(index);
-                let data = unsafe { &(*ifm2).ifm_data };
+                let data = ifm2.ifm_data;
                 rx_bytes = rx_bytes.saturating_add(data.ifi_ibytes);
                 tx_bytes = tx_bytes.saturating_add(data.ifi_obytes);
                 rx_packets = rx_packets.saturating_add(data.ifi_ipackets);
@@ -247,10 +268,12 @@ fn collect_network_totals_and_indices_via_iflist2(len: usize) -> Result<(Network
             }
         }
 
+        // SAFETY: `message_len` is non-zero and no larger than the remaining
+        // bytes, so the next cursor stays within the same buffer or at `end`.
         next = unsafe { next.add(message_len) };
     }
 
-    Ok((
+    (
         NetworkTotals {
             rx_bytes,
             tx_bytes,
@@ -260,7 +283,7 @@ fn collect_network_totals_and_indices_via_iflist2(len: usize) -> Result<(Network
             tx_dropped_packets: 0,
         },
         indices,
-    ))
+    )
 }
 
 fn collect_cached_network_totals(cache: &NetworkInterfaceCache) -> Result<NetworkTotals> {
@@ -315,18 +338,31 @@ fn collect_network_totals_via_ifaddrs() -> Result<NetworkReading> {
     let mut rx_dropped_packets = 0_u64;
     let mut current = addrs.as_ptr();
     while !current.is_null() {
+        // SAFETY: `current` starts at the head returned by `getifaddrs` and is
+        // advanced through `ifa_next` while `addrs` keeps the list alive.
         let iface = unsafe { &*current };
+        let address_family = if iface.ifa_addr.is_null() {
+            None
+        } else {
+            // SAFETY: `ifa_addr` was checked non-null and belongs to the live
+            // `getifaddrs` list guarded by `addrs`.
+            Some(unsafe { (*iface.ifa_addr).sa_family as i32 })
+        };
         if !iface.ifa_addr.is_null()
-            && unsafe { (*iface.ifa_addr).sa_family as i32 } == libc::AF_LINK
+            && address_family == Some(libc::AF_LINK)
             && iface.ifa_flags & libc::IFF_LOOPBACK as u32 == 0
             && iface.ifa_flags & libc::IFF_UP as u32 != 0
             && !iface.ifa_data.is_null()
         {
+            // SAFETY: macOS `getifaddrs` entries provide `ifa_name` as a
+            // NUL-terminated interface name for the lifetime of the list.
             let name = unsafe { CStr::from_ptr(iface.ifa_name) }
                 .to_string_lossy()
                 .into_owned();
             if seen_names.insert(name.clone()) {
                 sampled_names.push(name);
+                // SAFETY: For AF_LINK entries with non-null `ifa_data`, macOS
+                // stores a valid `if_data` counter block for this interface.
                 let data = unsafe { &*(iface.ifa_data as *const libc::if_data) };
                 rx_bytes = rx_bytes.saturating_add(u64::from(data.ifi_ibytes));
                 tx_bytes = tx_bytes.saturating_add(u64::from(data.ifi_obytes));

--- a/nodelite-agent/src/collector_macos/syscall.rs
+++ b/nodelite-agent/src/collector_macos/syscall.rs
@@ -34,7 +34,10 @@ const IFMIB_IFDATA: libc::c_int = 2;
 const NETLINK_GENERIC: libc::c_int = 0;
 
 pub(super) fn read_uname() -> Result<libc::utsname> {
+    // SAFETY: `utsname` is a plain C output struct; all-zero bytes are a valid
+    // staging value before `uname` overwrites the fields.
     let mut uts = unsafe { mem::zeroed::<libc::utsname>() };
+    // SAFETY: `uts` is a live, writable `utsname` value for libc to populate.
     let result = unsafe { libc::uname(&mut uts) };
     if result != 0 {
         return Err(anyhow!("uname failed"));
@@ -43,6 +46,8 @@ pub(super) fn read_uname() -> Result<libc::utsname> {
 }
 
 pub(super) fn c_chars_to_string(value: &[libc::c_char]) -> Result<String> {
+    // SAFETY: Callers pass fixed-size name fields returned by libc/kernel
+    // structs, which macOS stores as NUL-terminated C strings.
     let text = unsafe { CStr::from_ptr(value.as_ptr()) }
         .to_str()
         .context("invalid utf-8 in C string")?;
@@ -51,6 +56,8 @@ pub(super) fn c_chars_to_string(value: &[libc::c_char]) -> Result<String> {
 
 pub(super) fn read_sysctl_string(name: &[u8]) -> Result<String> {
     let mut size = 0_usize;
+    // SAFETY: `name` is supplied by this module's callers as a NUL-terminated
+    // sysctl name, and the size-query form uses no output buffer.
     let result = unsafe {
         libc::sysctlbyname(
             name.as_ptr().cast(),
@@ -65,6 +72,8 @@ pub(super) fn read_sysctl_string(name: &[u8]) -> Result<String> {
     }
 
     let mut buffer = vec![0_u8; size];
+    // SAFETY: `buffer` is valid for `size` bytes and `name` remains the same
+    // live NUL-terminated sysctl name used for the size query.
     let result = unsafe {
         libc::sysctlbyname(
             name.as_ptr().cast(),
@@ -84,6 +93,8 @@ pub(super) fn read_sysctl_string(name: &[u8]) -> Result<String> {
 }
 
 pub(super) fn count_cpu_cores() -> Result<u32> {
+    // SAFETY: `_SC_NPROCESSORS_ONLN` does not use pointers; libc returns the
+    // core count by value or a non-positive error/sentinel value.
     let cores = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
     if cores <= 0 {
         return Err(anyhow!("_SC_NPROCESSORS_ONLN returned {cores}"));
@@ -97,6 +108,8 @@ pub(super) fn read_uptime_secs() -> Result<u64> {
             tv_sec: 0,
             tv_nsec: 0,
         };
+        // SAFETY: `spec` is writable storage for one `timespec`, and each
+        // `clock_id` is a libc constant accepted by `clock_gettime`.
         let result = unsafe { libc::clock_gettime(clock_id, &mut spec) };
         if result == 0 {
             return u64::try_from(spec.tv_sec).context("negative uptime reported by clock_gettime");
@@ -108,11 +121,15 @@ pub(super) fn read_uptime_secs() -> Result<u64> {
 /// 使用 `host_processor_info` 汇总所有逻辑核心的累计 tick。
 pub(super) fn collect_cpu_sample() -> Result<CpuSample> {
     #[allow(deprecated)]
+    // SAFETY: `mach_host_self` has no preconditions and returns the current
+    // task's host port by value.
     let host = unsafe { libc::mach_host_self() };
     let mut cpu_count: libc::natural_t = 0;
     let mut cpu_info: libc::processor_cpu_load_info_t = ptr::null_mut();
     let mut info_count: libc::mach_msg_type_number_t = 0;
 
+    // SAFETY: All output pointers refer to live stack variables, and `cpu_info`
+    // is the kernel-owned buffer pointer that Mach fills on success.
     let status = unsafe {
         libc::host_processor_info(
             host,
@@ -126,6 +143,8 @@ pub(super) fn collect_cpu_sample() -> Result<CpuSample> {
         return Err(anyhow!("host_processor_info failed"));
     }
 
+    // SAFETY: A successful `host_processor_info` call returned a non-null
+    // `cpu_info` buffer with one load-info record per reported CPU.
     let samples = unsafe { slice::from_raw_parts(cpu_info, cpu_count as usize) };
     let mut total = 0_u64;
     let mut idle = 0_u64;
@@ -137,6 +156,8 @@ pub(super) fn collect_cpu_sample() -> Result<CpuSample> {
     }
 
     let deallocate_size = mem::size_of::<libc::integer_t>().saturating_mul(info_count as usize);
+    // SAFETY: `cpu_info` is the Mach-allocated buffer returned above, and the
+    // deallocation size is derived from Mach's returned element count.
     unsafe {
         libc::vm_deallocate(
             #[allow(deprecated)]
@@ -151,6 +172,7 @@ pub(super) fn collect_cpu_sample() -> Result<CpuSample> {
 
 pub(super) fn collect_load_average() -> Result<nodelite_proto::LoadAverage> {
     let mut loads = [0_f64; 3];
+    // SAFETY: `loads` has space for exactly the three samples requested.
     let result = unsafe { libc::getloadavg(loads.as_mut_ptr(), 3) };
     if result != 3 {
         return Err(anyhow!("getloadavg returned {result}"));
@@ -163,7 +185,11 @@ pub(super) fn collect_load_average() -> Result<nodelite_proto::LoadAverage> {
 }
 
 pub(super) fn read_memory_statistics() -> Result<MemoryStatistics> {
+    // SAFETY: `_SC_PHYS_PAGES` returns a scalar page count and does not access
+    // caller-provided memory.
     let total_pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+    // SAFETY: `_SC_PAGESIZE` returns a scalar page size and does not access
+    // caller-provided memory.
     let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
     if total_pages <= 0 || page_size <= 0 {
         return Err(anyhow!(
@@ -172,9 +198,15 @@ pub(super) fn read_memory_statistics() -> Result<MemoryStatistics> {
     }
 
     #[allow(deprecated)]
+    // SAFETY: `mach_host_self` has no preconditions and returns the current
+    // task's host port by value.
     let host = unsafe { libc::mach_host_self() };
     let mut count = libc::HOST_VM_INFO64_COUNT;
+    // SAFETY: `vm_statistics64` is a plain C output struct; zeroed bytes are a
+    // valid staging value before `host_statistics64` writes it.
     let mut stats = unsafe { mem::zeroed::<libc::vm_statistics64>() };
+    // SAFETY: `stats` and `count` are live writable outputs, and `count` starts
+    // with the kernel-documented element count for `HOST_VM_INFO64`.
     let status = unsafe {
         libc::host_statistics64(
             host,
@@ -199,8 +231,12 @@ pub(super) fn read_memory_statistics() -> Result<MemoryStatistics> {
 
 pub(super) fn read_swap_usage() -> Result<(u64, u64)> {
     let mut mib = [libc::CTL_VM, libc::VM_SWAPUSAGE];
+    // SAFETY: `xsw_usage` is a plain C output struct; zeroing creates a valid
+    // staging value before sysctl fills it.
     let mut swap = unsafe { mem::zeroed::<libc::xsw_usage>() };
     let mut size = mem::size_of::<libc::xsw_usage>();
+    // SAFETY: `mib` names the VM swap sysctl, and `swap`/`size` describe a
+    // writable output buffer of the correct type.
     let result = unsafe {
         libc::sysctl(
             mib.as_mut_ptr(),
@@ -219,11 +255,16 @@ pub(super) fn read_swap_usage() -> Result<(u64, u64)> {
 
 pub(super) fn mounted_filesystems() -> Result<Vec<libc::statfs>> {
     let mut mounts: *mut libc::statfs = ptr::null_mut();
+    // SAFETY: `mounts` is a live output pointer slot. macOS returns a pointer
+    // to kernel-managed mount data that remains valid until the next call.
     let count = unsafe { libc::getmntinfo(&mut mounts, libc::MNT_NOWAIT) };
     if count <= 0 || mounts.is_null() {
         return Err(anyhow!("getmntinfo returned no mounts"));
     }
 
+    // SAFETY: `getmntinfo` returned `count > 0` and a non-null pointer. The
+    // slice is immediately copied into an owned `Vec` before another call can
+    // invalidate the backing storage.
     let mounts = unsafe { slice::from_raw_parts(mounts, count as usize) };
     Ok(mounts.to_vec())
 }
@@ -231,6 +272,8 @@ pub(super) fn mounted_filesystems() -> Result<Vec<libc::statfs>> {
 pub(super) fn network_iflist2_len() -> Result<usize> {
     let mut mib = [libc::CTL_NET, libc::PF_ROUTE, 0, 0, libc::NET_RT_IFLIST2, 0];
     let mut len = 0_usize;
+    // SAFETY: The size-query form passes no output buffer; `len` is a live
+    // writable slot for the kernel-reported byte count.
     let result = unsafe {
         libc::sysctl(
             mib.as_mut_ptr(),
@@ -250,6 +293,8 @@ pub(super) fn network_iflist2_len() -> Result<usize> {
 pub(super) fn read_network_iflist2(mut len: usize) -> Result<Vec<u8>> {
     let mut mib = [libc::CTL_NET, libc::PF_ROUTE, 0, 0, libc::NET_RT_IFLIST2, 0];
     let mut buffer = vec![0_u8; len];
+    // SAFETY: `buffer` is valid for the requested `len` bytes, and `len` is
+    // updated by the kernel to the number of bytes actually written.
     let result = unsafe {
         libc::sysctl(
             mib.as_mut_ptr(),
@@ -278,6 +323,8 @@ pub(super) fn collect_interface_data(index: u16) -> Result<IfMibData> {
     ];
     let mut if_data = MaybeUninit::<IfMibData>::uninit();
     let mut size = mem::size_of::<IfMibData>();
+    // SAFETY: `if_data` points to writable storage for one `IfMibData`, and
+    // `size` advertises exactly that buffer length to sysctl.
     let result = unsafe {
         libc::sysctl(
             mib_data.as_mut_ptr(),
@@ -292,11 +339,15 @@ pub(super) fn collect_interface_data(index: u16) -> Result<IfMibData> {
     if result != 0 || size < mem::size_of::<IfMibData>() {
         return Err(anyhow!("sysctl IFMIB_IFDATA failed for interface {index}"));
     }
+    // SAFETY: sysctl succeeded and reported enough bytes to initialize the
+    // entire `IfMibData` value.
     Ok(unsafe { if_data.assume_init() })
 }
 
 pub(super) fn get_ifaddrs() -> Result<IfAddrsGuard> {
     let mut addrs: *mut libc::ifaddrs = ptr::null_mut();
+    // SAFETY: `addrs` is a live output pointer slot. On success ownership of
+    // the linked list is transferred to `IfAddrsGuard` for `freeifaddrs`.
     let result = unsafe { libc::getifaddrs(&mut addrs) };
     if result != 0 || addrs.is_null() {
         return Err(anyhow!("getifaddrs failed"));
@@ -312,6 +363,8 @@ impl IfAddrsGuard {
 
 impl Drop for IfAddrsGuard {
     fn drop(&mut self) {
+        // SAFETY: `IfAddrsGuard` is only constructed after successful
+        // `getifaddrs`, so `self.0` is the matching list head to free once.
         unsafe {
             libc::freeifaddrs(self.0);
         }

--- a/nodelite-agent/src/collector_macos/tests.rs
+++ b/nodelite-agent/src/collector_macos/tests.rs
@@ -1,3 +1,5 @@
+use std::mem;
+use std::ptr;
 use std::time::{Duration, Instant};
 
 use super::super::shared::{NetworkSample, NetworkTotals, compute_network_metrics};
@@ -5,6 +7,7 @@ use super::identity::{extract_plist_value, parse_os_name_from_plist};
 use super::metrics::{
     NetworkInterfaceCache, NetworkInterfaceSignature, ObservedNetworkSample,
     compute_available_memory_bytes, compute_network_metrics_if_same_interfaces,
+    parse_network_totals_and_indices_from_iflist2,
 };
 
 #[test]
@@ -154,7 +157,40 @@ fn network_interface_cache_only_matches_same_non_empty_list() {
 }
 
 #[test]
+fn iflist2_parser_ignores_truncated_headers() {
+    let buffer = vec![0_u8; mem::size_of::<libc::if_msghdr>().saturating_sub(1)];
+    let (totals, indices) = parse_network_totals_and_indices_from_iflist2(&buffer);
+
+    assert_eq!(totals.rx_bytes, 0);
+    assert_eq!(totals.tx_bytes, 0);
+    assert!(indices.is_empty());
+}
+
+#[test]
+fn iflist2_parser_stops_on_overlong_messages() {
+    let mut buffer = vec![0_u8; mem::size_of::<libc::if_msghdr>()];
+    // SAFETY: `if_msghdr` is a plain C header used here only as a byte fixture;
+    // zeroed fields are overwritten as needed before the unaligned write.
+    let mut header = unsafe { mem::zeroed::<libc::if_msghdr>() };
+    header.ifm_msglen = (buffer.len() + 1) as _;
+    header.ifm_type = libc::RTM_IFINFO2 as _;
+    // SAFETY: `buffer` has exactly enough bytes for one header, and
+    // `write_unaligned` matches the parser's byte-stream assumptions.
+    unsafe {
+        ptr::write_unaligned(buffer.as_mut_ptr().cast::<libc::if_msghdr>(), header);
+    }
+
+    let (totals, indices) = parse_network_totals_and_indices_from_iflist2(&buffer);
+
+    assert_eq!(totals.rx_packets, 0);
+    assert_eq!(totals.tx_packets, 0);
+    assert!(indices.is_empty());
+}
+
+#[test]
 fn available_memory_does_not_underflow_when_compressor_is_large() {
+    // SAFETY: `vm_statistics64` is a plain C statistics struct; this test
+    // assigns the fields used by `compute_available_memory_bytes`.
     let mut stats = unsafe { std::mem::zeroed::<libc::vm_statistics64>() };
     stats.free_count = 5_431;
     stats.inactive_count = 520_105;

--- a/nodelite-server/src/handlers/api_routes.rs
+++ b/nodelite-server/src/handlers/api_routes.rs
@@ -217,6 +217,8 @@ fn process_resident_memory_bytes() -> Option<u64> {
     {
         let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
         let resident_pages = statm.split_whitespace().nth(1)?.parse::<u64>().ok()?;
+        // SAFETY: `_SC_PAGESIZE` does not use pointers; libc returns the page
+        // size by value or a non-positive error/sentinel value.
         let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
         if page_size <= 0 {
             return None;
@@ -226,28 +228,41 @@ fn process_resident_memory_bytes() -> Option<u64> {
 
     #[cfg(target_os = "macos")]
     {
-        let mut info = std::mem::MaybeUninit::<libc::proc_taskinfo>::zeroed();
-        let size = std::mem::size_of::<libc::proc_taskinfo>() as libc::c_int;
-        let status = unsafe {
-            libc::proc_pidinfo(
-                libc::getpid(),
-                libc::PROC_PIDTASKINFO,
-                0,
-                info.as_mut_ptr().cast(),
-                size,
-            )
-        };
-        if status != size {
-            return None;
-        }
-        let info = unsafe { info.assume_init() };
-        Some(info.pti_resident_size)
+        // SAFETY: `getpid` has no preconditions and returns the current process
+        // id by value.
+        let pid = unsafe { libc::getpid() };
+        process_resident_memory_bytes_for_pid(pid)
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         None
     }
+}
+
+#[cfg(target_os = "macos")]
+fn process_resident_memory_bytes_for_pid(pid: libc::pid_t) -> Option<u64> {
+    let mut info = std::mem::MaybeUninit::<libc::proc_taskinfo>::zeroed();
+    let size = std::mem::size_of::<libc::proc_taskinfo>() as libc::c_int;
+    // SAFETY: `info` points to writable storage for exactly one
+    // `proc_taskinfo`, and `size` matches that buffer. `proc_pidinfo` reports
+    // short/error writes via its byte-count return value, checked below.
+    let status = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTASKINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            size,
+        )
+    };
+    if status != size {
+        return None;
+    }
+    // SAFETY: A full-size `proc_pidinfo` result means the kernel initialized
+    // every byte of `info`.
+    let info = unsafe { info.assume_init() };
+    Some(info.pti_resident_size)
 }
 
 /// 审计日志查询接口。默认按时间倒序返回最近 100 条。
@@ -421,5 +436,20 @@ mod tests {
             "nodelite_metrics_response_body_bytes {}",
             body.len()
         )));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn process_resident_memory_bytes_reads_linux_statm() {
+        let bytes = super::process_resident_memory_bytes()
+            .expect("linux /proc/self/statm should report resident memory");
+
+        assert!(bytes > 0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn process_resident_memory_bytes_rejects_invalid_macos_pid() {
+        assert_eq!(super::process_resident_memory_bytes_for_pid(-1), None);
     }
 }

--- a/nodelite-server/src/registry/storage/write.rs
+++ b/nodelite-server/src/registry/storage/write.rs
@@ -1,6 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::Write;
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -189,13 +189,8 @@ fn acquire_registry_lock(path: &Path) -> RegistryResult<RegistryFileLock> {
 fn lock_file_exclusive(file: &File, lock_path: &Path) -> RegistryResult<()> {
     #[cfg(unix)]
     {
-        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-        if result != 0 {
-            return Err(RegistryError::io(
-                "locking",
-                lock_path,
-                std::io::Error::last_os_error(),
-            ));
+        if let Err(error) = flock_fd(file.as_raw_fd(), libc::LOCK_EX) {
+            return Err(RegistryError::io("locking", lock_path, error));
         }
     }
 
@@ -210,13 +205,25 @@ fn lock_file_exclusive(file: &File, lock_path: &Path) -> RegistryResult<()> {
 fn unlock_file(file: &File) {
     #[cfg(unix)]
     {
-        let _ = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+        let _ = flock_fd(file.as_raw_fd(), libc::LOCK_UN);
     }
 
     #[cfg(not(unix))]
     {
         let _ = file;
     }
+}
+
+#[cfg(unix)]
+fn flock_fd(fd: RawFd, operation: libc::c_int) -> std::io::Result<()> {
+    // SAFETY: `flock` only receives the process-local file descriptor and lock
+    // operation by value. Callers keep valid descriptors alive for normal use;
+    // invalid descriptors are reported by the kernel as `EBADF`.
+    let result = unsafe { libc::flock(fd, operation) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 fn harden_registry_permissions(path: &Path) -> RegistryResult<()> {
@@ -288,4 +295,16 @@ where
 {
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(unlock));
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(harden));
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    #[test]
+    fn flock_fd_reports_bad_file_descriptors() {
+        let error = super::flock_fd(-1, libc::LOCK_EX)
+            .expect_err("invalid file descriptors should surface EBADF");
+
+        assert_eq!(error.raw_os_error(), Some(libc::EBADF));
+    }
 }


### PR DESCRIPTION
## Summary
- add adjacent SAFETY comments for Linux statvfs, macOS libc/Mach/sysctl/getifaddrs paths, and server flock/proc_pidinfo calls
- add boundary coverage for Linux statvfs failures, macOS proc_pidinfo failures, Unix flock EBADF, and truncated/overlong macOS iflist2 buffers
- parse macOS iflist2 byte buffers with explicit bounds checks and unaligned reads

## Verification
- cargo fmt --all --check
- NODELITE_SKIP_WEB_BUILD=1 cargo test --workspace --locked
- NODELITE_SKIP_WEB_BUILD=1 cargo clippy --all-targets -- -D warnings

Closes #245