### PR TITLE
perf(server): add token cache diagnostics for issue #306

### DIFF
--- a/nodelite-server/src/load_test/scenarios.rs
+++ b/nodelite-server/src/load_test/scenarios.rs
@@ -413,6 +413,22 @@ async fn run_reconnect_storm_scenario(node_count: usize) -> Result<StormScenario
         );
     }
 
+    // 输出 token 缓存统计 (issue #306)
+    let cache_hits = server.registry.token_cache_hits();
+    let cache_misses = server.registry.token_cache_misses();
+    let cache_hit_rate = server.registry.token_cache_hit_rate();
+    let registry_revision = server.registry.registry_revision();
+    println!(
+        "STORM_CACHE_STATS nodes={} cycles={} sessions={} cache_hits={} cache_misses={} hit_rate={:.2}% registry_revision={}",
+        node_count,
+        LOAD_TEST_STORM_CYCLES,
+        node_count * LOAD_TEST_STORM_CYCLES,
+        cache_hits,
+        cache_misses,
+        cache_hit_rate,
+        registry_revision
+    );
+
     server.shutdown().await?;
 
     Ok(StormScenarioResult {

--- a/nodelite-server/src/load_test/server.rs
+++ b/nodelite-server/src/load_test/server.rs
@@ -25,6 +25,7 @@ pub(super) struct TestServer {
     pub(super) addr: SocketAddr,
     pub(super) shared: SharedState,
     pub(super) history: HistoryStore,
+    pub(super) registry: crate::registry::NodeRegistry,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
     server_handle: JoinHandle<Result<(), std::io::Error>>,
     temp_dir: PathBuf,
@@ -93,6 +94,7 @@ impl TestServer {
         )
         .await?;
         let history = state.history.clone();
+        let registry = state.registry.clone();
 
         let shared = state.shared.clone();
         let protected_routes = Router::new()
@@ -126,6 +128,7 @@ impl TestServer {
                 addr,
                 shared,
                 history,
+                registry,
                 shutdown_tx: Some(shutdown_tx),
                 server_handle,
                 temp_dir,

--- a/nodelite-server/src/registry.rs
+++ b/nodelite-server/src/registry.rs
@@ -215,6 +215,9 @@ pub struct NodeRegistry {
     token_verify_limiter: Arc<Semaphore>,
     /// Token 验证结果缓存:减少重连场景的 Argon2id 开销。
     token_cache: Arc<ParkingLotMutex<LruCache<TokenCacheKey, TokenCacheEntry>>>,
+    /// Token 缓存诊断计数器 (issue #306)。
+    token_cache_hits: Arc<AtomicU64>,
+    token_cache_misses: Arc<AtomicU64>,
     #[cfg(test)]
     token_verify_probe: Option<Arc<TokenVerifyProbe>>,
 }

--- a/nodelite-server/src/registry/auth.rs
+++ b/nodelite-server/src/registry/auth.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 #[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::AtomicUsize;
 #[cfg(test)]
 use std::time::Duration;
 use std::time::Instant;
@@ -127,6 +128,7 @@ impl NodeRegistry {
             if let Some(entry) = cache.get(&cache_key) {
                 let age = entry.cached_at.elapsed();
                 if age < TOKEN_CACHE_TTL {
+                    self.token_cache_hits.fetch_add(1, Ordering::Relaxed);
                     return Ok(entry.verified);
                 }
                 // TTL 过期,移除旧条目
@@ -157,12 +159,14 @@ impl NodeRegistry {
             if let Some(entry) = cache.get(&cache_key) {
                 let age = entry.cached_at.elapsed();
                 if age < TOKEN_CACHE_TTL {
+                    self.token_cache_hits.fetch_add(1, Ordering::Relaxed);
                     return Ok(entry.verified);
                 }
             }
         }
 
-        // 执行实际的 Argon2id 验证
+        // 缓存未命中,执行实际的 Argon2id 验证
+        self.token_cache_misses.fetch_add(1, Ordering::Relaxed);
         let input = input.to_string();
         let token_hash = token_hash.to_string();
         #[cfg(test)]

--- a/nodelite-server/src/registry/lifecycle.rs
+++ b/nodelite-server/src/registry/lifecycle.rs
@@ -40,6 +40,8 @@ impl NodeRegistry {
             token_cache: Arc::new(ParkingLotMutex::new(LruCache::new(
                 std::num::NonZeroUsize::new(TOKEN_CACHE_CAPACITY).expect("cache capacity > 0"),
             ))),
+            token_cache_hits: Arc::new(AtomicU64::new(0)),
+            token_cache_misses: Arc::new(AtomicU64::new(0)),
             #[cfg(test)]
             token_verify_probe: None,
         })
@@ -48,6 +50,31 @@ impl NodeRegistry {
     /// 当前注册表状态版本。任一注册表 reload / 写入导致的内存状态变化都会递增。
     pub fn registry_revision(&self) -> u64 {
         self.registry_revision.load(Ordering::Acquire)
+    }
+
+    /// Token 缓存命中计数（累积值，issue #306）。
+    #[cfg(test)]
+    pub fn token_cache_hits(&self) -> u64 {
+        self.token_cache_hits.load(Ordering::Relaxed)
+    }
+
+    /// Token 缓存未命中计数（累积值，issue #306）。
+    #[cfg(test)]
+    pub fn token_cache_misses(&self) -> u64 {
+        self.token_cache_misses.load(Ordering::Relaxed)
+    }
+
+    /// Token 缓存命中率（百分比，issue #306）。
+    #[cfg(test)]
+    pub fn token_cache_hit_rate(&self) -> f64 {
+        let hits = self.token_cache_hits() as f64;
+        let misses = self.token_cache_misses() as f64;
+        let total = hits + misses;
+        if total == 0.0 {
+            0.0
+        } else {
+            (hits / total) * 100.0
+        }
     }
 
     /// 刷新节点的 Token:生成新明文 token, 哈希入库,代次 +1, 延长过期时间。


### PR DESCRIPTION
## Summary
Add instrumentation to measure token verification cache performance in reconnect storm scenarios, confirming the cache is working correctly.

## Changes
- Add `token_cache_hits` and `token_cache_misses` atomic counters to `NodeRegistry`
- Track cache hits/misses in `verify_hashed_token` hot path
- Add test-only getter methods for `cache_hits`, `cache_misses`, `hit_rate`
- Add `STORM_CACHE_STATS` output in reconnect storm load test
- Expose `NodeRegistry` through `TestServer` for diagnostic access

## Test Results

| Nodes | Cycles | Sessions | Cache Hits | Cache Misses | Hit Rate | Registry Revision |
|-------|--------|----------|------------|--------------|----------|-------------------|
| 20    | 4      | 80       | 60         | 20           | 75.00%   | 1                 |
| 50    | 4      | 200      | 150        | 50           | 75.00%   | 1                 |
| 100   | 4      | 400      | 300        | 100          | 75.00%   | 1                 |
| 200   | 4      | 800      | 600        | 200          | 75.00%   | 1                 |

## Key Findings

**Cache hit rate: 75%** - Matches theoretical expectation:
- Each node reconnects 4 times during the storm test
- First connection: cache miss (Argon2id verification required)
- Subsequent 3 connections: cache hit (cached result reused)
- Formula: 3 hits / 4 total = 75% hit rate

**Registry revision stability** - Stays at 1 throughout test:
- No token refreshes occur during reconnect storm
- Cache key `(token_hash, registry_revision)` remains stable
- All reconnections can reuse cached verification results

**Linear scalability** - Performance consistent across fleet sizes:
- 20 nodes → 200 nodes maintain identical 75% hit rate
- No cache eviction observed (512-entry LRU capacity sufficient)

## Conclusion
✅ Token verification cache is performing as designed
✅ No further optimization needed
✅ Diagnostic counters preserved for future investigations

Closes #306