### PR TITLE
security(auth): consume TOTP steps atomically

### DIFF
--- a/nodelite-server/src/auth.rs
+++ b/nodelite-server/src/auth.rs
@@ -300,21 +300,26 @@ impl TwoFactorSessions {
         false
     }
 
-    /// 标记某个 TOTP `time_step` 已经被成功消费过;同一个 step 再次出现时,
-    /// `is_totp_step_used` 会返回 true,从而拒绝重放。
-    /// 标记会在该 step 离开 ±1 漂移窗口后自动过期。
-    pub fn mark_totp_step_used(&self, step: u64) {
+    /// 原子地检查并标记当前验证码匹配的所有 TOTP step。
+    ///
+    /// drift 窗口内可能有多个 step 生成同一个验证码。只要其中至少一个尚未
+    /// 被消费就接受本次验证,并把所有匹配 step 一并标记,避免碰撞码从相邻
+    /// step 再次通过。空列表或所有 step 都已被消费时返回 `false`。
+    pub fn try_mark_unused_totp_steps(&self, steps: &[u64]) -> bool {
+        let now = Instant::now();
         let mut store = lock_mutex(&self.inner);
-        prune_expired_sessions(&mut store, Instant::now());
-        let expires_at =
-            Instant::now() + Duration::from_secs(TWO_FACTOR_TOTP_REPLAY_RETENTION_SECS);
-        store.used_totp_steps.insert(step, expires_at);
-    }
-
-    pub fn is_totp_step_used(&self, step: u64) -> bool {
-        let mut store = lock_mutex(&self.inner);
-        prune_expired_sessions(&mut store, Instant::now());
-        store.used_totp_steps.contains_key(&step)
+        prune_expired_sessions(&mut store, now);
+        if steps
+            .iter()
+            .all(|step| store.used_totp_steps.contains_key(step))
+        {
+            return false;
+        }
+        let expires_at = now + Duration::from_secs(TWO_FACTOR_TOTP_REPLAY_RETENTION_SECS);
+        for step in steps {
+            store.used_totp_steps.insert(*step, expires_at);
+        }
+        true
     }
 
     pub fn create_authenticated(&self) -> AuthSessionResult<String> {
@@ -447,8 +452,9 @@ pub fn decode_totp_secret(value: &str) -> Option<Vec<u8>> {
 
 /// 返回当前 drift 窗口内与验证码匹配的所有 TOTP step。
 ///
-/// 调用方做 replay protection 时应检查所有返回 step，并在接受后把所有匹配
-/// step 标记为已用，避免 6 位码在相邻 step 碰撞时被重复使用。
+/// 调用方做 replay protection 时应把返回值交给
+/// [`TwoFactorSessions::try_mark_unused_totp_steps`],原子地检查并标记所有
+/// 匹配 step,避免 6 位码在相邻 step 碰撞时被重复使用。
 pub fn matching_totp_steps(totp_secret: Option<&[u8]>, code: &str) -> Vec<u64> {
     // 时钟回拨到 1970 之前 chrono 会返回负值;退化到 0 而不是 panic。
     let now_secs = Utc::now().timestamp().max(0) as u64;

--- a/nodelite-server/src/handlers/auth_routes/two_factor.rs
+++ b/nodelite-server/src/handlers/auth_routes/two_factor.rs
@@ -32,10 +32,9 @@ pub(crate) async fn verify_2fa_api(
     let client_ip = resolve_client_ip(&state.shared.config().trusted_proxies, peer_addr, &headers);
     ensure_verify_2fa_not_blocked(&state, &headers, client_ip).await?;
     let pending_token = require_pending_token(&state, &headers, client_ip).await?;
-    let Some(totp_steps) = current_unused_totp_steps(&state, &request.code).await else {
+    if !try_consume_current_totp(&state, &request.code).await {
         return Ok(handle_invalid_totp(&state, &headers, client_ip, &pending_token).await);
-    };
-    mark_totp_steps_used(&state, &totp_steps);
+    }
 
     let audit_user = readonly_auth_username(&state).await;
     let auth_token = create_authenticated_two_factor_session(&state)?;
@@ -132,26 +131,15 @@ async fn require_pending_token(
     Ok(pending_token)
 }
 
-async fn current_unused_totp_steps(state: &AppState, code: &str) -> Option<Vec<u64>> {
+async fn try_consume_current_totp(state: &AppState, code: &str) -> bool {
     let totp_secret = {
         let auth = state.readonly_auth.read().await;
         auth.totp_secret.clone()
     };
     let matching_steps = matching_totp_steps(totp_secret.as_deref(), code);
-    if matching_steps.is_empty()
-        || matching_steps
-            .iter()
-            .all(|step| state.two_factor_sessions.is_totp_step_used(*step))
-    {
-        return None;
-    }
-    Some(matching_steps)
-}
-
-fn mark_totp_steps_used(state: &AppState, steps: &[u64]) {
-    for step in steps {
-        state.two_factor_sessions.mark_totp_step_used(*step);
-    }
+    state
+        .two_factor_sessions
+        .try_mark_unused_totp_steps(&matching_steps)
 }
 
 async fn handle_invalid_totp(

--- a/nodelite-server/src/handlers/settings/security.rs
+++ b/nodelite-server/src/handlers/settings/security.rs
@@ -107,8 +107,8 @@ pub(super) fn settings_confirmation_error_for_sensitive_action(
             "verification code is required",
         ));
     };
-    let matching_steps = match unused_matching_totp_steps(state, &secret, code) {
-        Ok(steps) => steps,
+    match verify_and_consume_totp_steps(state, &secret, code) {
+        Ok(()) => {}
         Err(TotpVerificationError::Invalid) => {
             return Some(settings_json_error(
                 StatusCode::UNAUTHORIZED,
@@ -121,8 +121,7 @@ pub(super) fn settings_confirmation_error_for_sensitive_action(
                 "verification code already used",
             ));
         }
-    };
-    mark_totp_steps_used(state, &matching_steps);
+    }
     None
 }
 
@@ -131,28 +130,22 @@ enum TotpVerificationError {
     AlreadyUsed,
 }
 
-fn unused_matching_totp_steps(
+fn verify_and_consume_totp_steps(
     state: &AppState,
     secret: &[u8],
     code: &str,
-) -> Result<Vec<u64>, TotpVerificationError> {
+) -> Result<(), TotpVerificationError> {
     let matching_steps = matching_totp_steps(Some(secret), code);
     if matching_steps.is_empty() {
         return Err(TotpVerificationError::Invalid);
     }
-    if matching_steps
-        .iter()
-        .all(|step| state.two_factor_sessions.is_totp_step_used(*step))
+    if !state
+        .two_factor_sessions
+        .try_mark_unused_totp_steps(&matching_steps)
     {
         return Err(TotpVerificationError::AlreadyUsed);
     }
-    Ok(matching_steps)
-}
-
-fn mark_totp_steps_used(state: &AppState, steps: &[u64]) {
-    for step in steps {
-        state.two_factor_sessions.mark_totp_step_used(*step);
-    }
+    Ok(())
 }
 
 /// 开始网页端 2FA 绑定:生成一个新 TOTP secret 和本地 SVG 二维码。
@@ -231,16 +224,15 @@ pub(crate) async fn enable_two_factor(
     if secret_bytes.len() < 10 {
         return settings_json_error(StatusCode::BAD_REQUEST, "invalid TOTP secret");
     }
-    let matching_steps = match unused_matching_totp_steps(&state, &secret_bytes, &request.code) {
-        Ok(steps) => steps,
+    match verify_and_consume_totp_steps(&state, &secret_bytes, &request.code) {
+        Ok(()) => {}
         Err(TotpVerificationError::Invalid) => {
             return settings_json_error(StatusCode::UNAUTHORIZED, "invalid verification code");
         }
         Err(TotpVerificationError::AlreadyUsed) => {
             return settings_json_error(StatusCode::UNAUTHORIZED, "verification code already used");
         }
-    };
-    mark_totp_steps_used(&state, &matching_steps);
+    }
 
     let next_auth = ReadonlyAuthConfig {
         enable_2fa: true,
@@ -317,16 +309,15 @@ pub(crate) async fn disable_two_factor(
     else {
         return settings_json_error(StatusCode::CONFLICT, "2FA secret is not configured");
     };
-    let matching_steps = match unused_matching_totp_steps(&state, &secret, &request.code) {
-        Ok(steps) => steps,
+    match verify_and_consume_totp_steps(&state, &secret, &request.code) {
+        Ok(()) => {}
         Err(TotpVerificationError::Invalid) => {
             return settings_json_error(StatusCode::UNAUTHORIZED, "invalid verification code");
         }
         Err(TotpVerificationError::AlreadyUsed) => {
             return settings_json_error(StatusCode::UNAUTHORIZED, "verification code already used");
         }
-    };
-    mark_totp_steps_used(&state, &matching_steps);
+    }
 
     let next_auth = ReadonlyAuthConfig {
         enable_2fa: false,

--- a/nodelite-server/src/tests/auth_runtime_tests.rs
+++ b/nodelite-server/src/tests/auth_runtime_tests.rs
@@ -1,6 +1,8 @@
 //! Auth and runtime-focused library-unit tests.
 
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::sync::{Arc, Barrier};
+use std::thread;
 
 use axum::body::Body;
 use axum::http::{Request, header};
@@ -57,17 +59,54 @@ fn pending_session_invalidated_after_max_failed_attempts() {
 }
 
 #[test]
-fn totp_step_marked_used_blocks_replay() {
+fn totp_step_consumption_blocks_replay() {
     let sessions = TwoFactorSessions::new();
     let step = 12345_u64;
     let replay_retention =
         std::time::Duration::from_secs(crate::auth::TWO_FACTOR_TOTP_REPLAY_RETENTION_SECS);
     assert!(replay_retention >= std::time::Duration::from_secs(150));
-    assert!(!sessions.is_totp_step_used(step));
-    sessions.mark_totp_step_used(step);
-    assert!(sessions.is_totp_step_used(step));
-    assert!(!sessions.is_totp_step_used(step + 1));
-    assert!(!sessions.is_totp_step_used(step - 1));
+    assert!(sessions.try_mark_unused_totp_steps(&[step]));
+    assert!(!sessions.try_mark_unused_totp_steps(&[step]));
+    assert!(sessions.try_mark_unused_totp_steps(&[step + 1]));
+    assert!(sessions.try_mark_unused_totp_steps(&[step - 1]));
+}
+
+#[test]
+fn totp_steps_are_consumed_atomically_across_concurrent_requests() {
+    const WORKERS: usize = 16;
+
+    let sessions = TwoFactorSessions::new();
+    let barrier = Arc::new(Barrier::new(WORKERS));
+    let step = 12345_u64;
+    let handles = (0..WORKERS)
+        .map(|_| {
+            let sessions = sessions.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                sessions.try_mark_unused_totp_steps(&[step])
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let accepted = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("worker should not panic"))
+        .filter(|accepted| *accepted)
+        .count();
+
+    assert_eq!(accepted, 1);
+}
+
+#[test]
+fn totp_step_collision_marks_every_matching_step() {
+    let sessions = TwoFactorSessions::new();
+    let previous_step = 12344_u64;
+    let current_step = 12345_u64;
+
+    assert!(sessions.try_mark_unused_totp_steps(&[previous_step]));
+    assert!(sessions.try_mark_unused_totp_steps(&[previous_step, current_step]));
+    assert!(!sessions.try_mark_unused_totp_steps(&[previous_step, current_step]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- atomically prune, check, and consume every matching TOTP step under one mutex
- migrate login and all settings/security verification paths to the shared consume API
- add concurrent replay and adjacent-step collision regression coverage

## Security review

- no P0/P1/P2 findings in primary or independent differential review
- the critical section contains only bounded in-memory operations and no async wait
- residual boundary: replay state remains process-local; partially overlapping collision sets across a clock boundary remain a rare P3 edge outside this issue's atomic check/mark scope

## Validation

- cargo test -p nodelite-server auth_runtime_tests --locked
- cargo test -p nodelite-server settings_two_factor --locked
- cargo test -p nodelite-server --locked (369 passed, 8 ignored)
- cargo +stable fmt --all --check
- cargo clippy -p nodelite-server --all-targets --locked -- -D warnings

Closes #309
