### PR TITLE
security(server): verify versioned web updater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,16 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/server-web-update.sh scripts/test-install-server-summary.sh scripts/test-server-web-update.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/server-web-update.sh scripts/merge-release-checksums.sh scripts/test-install-server-summary.sh scripts/test-server-web-update.sh scripts/test-release-checksums.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
 
       - name: Test installer summaries
         run: sh scripts/test-install-server-summary.sh
 
       - name: Test verified web update bootstrap
         run: sh scripts/test-server-web-update.sh
+
+      - name: Test release checksum manifest
+        run: sh scripts/test-release-checksums.sh
 
       - name: Check demo credentials
         run: sh scripts/check-demo-credentials.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,13 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/server-web-update.sh scripts/test-install-server-summary.sh scripts/test-server-web-update.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
 
       - name: Test installer summaries
         run: sh scripts/test-install-server-summary.sh
+
+      - name: Test verified web update bootstrap
+        run: sh scripts/test-server-web-update.sh
 
       - name: Check demo credentials
         run: sh scripts/check-demo-credentials.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,10 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/test-install-server-summary.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/server-web-update.sh scripts/test-install-server-summary.sh scripts/test-server-web-update.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
+
+      - name: Test verified web update bootstrap
+        run: sh scripts/test-server-web-update.sh
 
       - name: Audit dependency advisories
         run: cargo audit --deny warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,8 +351,12 @@ jobs:
           path: release-assets
 
       - name: Merge checksums
-        # 把每个架构的 SHA256SUMS 合并为统一的 SHA256SUMS.txt,供安装脚本下载。
+        # 对即将上传的 installer 本体取摘要,再与二进制/SBOM 摘要合并。
         run: |
+          sha256sum \
+            release-assets/release-scripts/install-server.sh \
+            release-assets/release-scripts/install-agent.sh \
+            > release-assets/SHA256SUMS-scripts.txt
           find release-assets -type f -name 'SHA256SUMS-*.txt' | sort | xargs cat > release-assets/SHA256SUMS.txt
 
       - name: Create or update GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,10 +95,13 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Shellcheck installers
-        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/server-web-update.sh scripts/test-install-server-summary.sh scripts/test-server-web-update.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
+        run: shellcheck scripts/install-server.sh scripts/install-agent.sh scripts/server-web-update.sh scripts/merge-release-checksums.sh scripts/test-install-server-summary.sh scripts/test-server-web-update.sh scripts/test-release-checksums.sh scripts/check-demo-credentials.sh scripts/check-actions-pinned.sh
 
       - name: Test verified web update bootstrap
         run: sh scripts/test-server-web-update.sh
+
+      - name: Test release checksum manifest
+        run: sh scripts/test-release-checksums.sh
 
       - name: Audit dependency advisories
         run: cargo audit --deny warnings
@@ -229,6 +232,7 @@ jobs:
           path: |
             scripts/install-server.sh
             scripts/install-agent.sh
+            scripts/merge-release-checksums.sh
 
   build-agent-macos:
     # 先只发布 Agent 的 macOS 二进制,server 仍保持 Linux 官方发布范围。
@@ -355,12 +359,7 @@ jobs:
 
       - name: Merge checksums
         # 对即将上传的 installer 本体取摘要,再与二进制/SBOM 摘要合并。
-        run: |
-          sha256sum \
-            release-assets/release-scripts/install-server.sh \
-            release-assets/release-scripts/install-agent.sh \
-            > release-assets/SHA256SUMS-scripts.txt
-          find release-assets -type f -name 'SHA256SUMS-*.txt' | sort | xargs cat > release-assets/SHA256SUMS.txt
+        run: sh release-assets/release-scripts/merge-release-checksums.sh release-assets
 
       - name: Create or update GitHub release
         env:

--- a/nodelite-server/src/handlers/settings/helpers.rs
+++ b/nodelite-server/src/handlers/settings/helpers.rs
@@ -89,43 +89,20 @@ pub(super) fn is_writable_paths_subset_of_install_root(
 }
 
 pub(super) fn server_update_shell_command(log_path: &Path, cache_dir: &Path) -> String {
-    let installer_url = format!(
-        "{}/releases/latest/download/install-server.sh",
-        env!("CARGO_PKG_REPOSITORY")
-    );
     [
-        "set -u".to_string(),
-        "umask 077".to_string(),
-        format!("log={}", shell_quote(&log_path.display().to_string())),
         format!(
-            "cache_dir={}",
+            "NODELITE_UPDATE_LOG={}",
+            shell_quote(&log_path.display().to_string())
+        ),
+        format!(
+            "NODELITE_UPDATE_CACHE_DIR={}",
             shell_quote(&cache_dir.display().to_string())
         ),
-        "mkdir -p \"$cache_dir\"".to_string(),
-        "chmod 0700 \"$cache_dir\" >>\"$log\" 2>&1 || true".to_string(),
-        "tmp_script=\"$(mktemp \"$cache_dir/install-server.XXXXXX\")\"".to_string(),
-        "trap 'rm -f \"$tmp_script\"' EXIT".to_string(),
-        "chmod 0600 \"$tmp_script\" >>\"$log\" 2>&1".to_string(),
-        ": >\"$log\"".to_string(),
-        "echo \"nodelite-update: started at $(date -u +%Y-%m-%dT%H:%M:%SZ)\" >>\"$log\"".to_string(),
         format!(
-            "echo \"nodelite-update: downloading {}\" >>\"$log\"",
-            shell_quote(&installer_url)
+            "NODELITE_UPDATE_REPOSITORY={}",
+            shell_quote(env!("CARGO_PKG_REPOSITORY"))
         ),
-        format!(
-            "curl -fsSL {} -o \"$tmp_script\" >>\"$log\" 2>&1",
-            shell_quote(&installer_url)
-        ),
-        "download_status=$?".to_string(),
-        "if [ \"$download_status\" -ne 0 ]; then echo \"nodelite-update: finished exit=$download_status at $(date -u +%Y-%m-%dT%H:%M:%SZ)\" >>\"$log\"; exit \"$download_status\"; fi".to_string(),
-        "chmod 0700 \"$tmp_script\" >>\"$log\" 2>&1".to_string(),
-        "chmod_status=$?".to_string(),
-        "if [ \"$chmod_status\" -ne 0 ]; then echo \"nodelite-update: finished exit=$chmod_status at $(date -u +%Y-%m-%dT%H:%M:%SZ)\" >>\"$log\"; exit \"$chmod_status\"; fi".to_string(),
-        "echo \"nodelite-update: running installer in upgrade mode\" >>\"$log\"".to_string(),
-        format!(
-            "NODELITE_SERVER_MODE=upgrade sh \"$tmp_script\" >>\"$log\" 2>&1; update_status=$?; echo \"nodelite-update: finished exit=$update_status at $(date -u +%Y-%m-%dT%H:%M:%SZ)\" >>\"$log\"; exit \"$update_status\" # {}",
-            shell_quote(&installer_url)
-        ),
+        include_str!("../../../../scripts/server-web-update.sh").to_string(),
     ]
     .join("\n")
 }
@@ -321,18 +298,33 @@ mod tests {
     }
 
     #[test]
-    fn server_update_shell_command_uses_private_cache_dir_for_temp_script() {
+    fn server_update_shell_command_embeds_versioned_verified_bootstrap() {
         let config = sample_server_config();
         let log_path = Path::new("/tmp/nodelite-update.log");
         let cache_dir = server_update_cache_dir(&config);
         let command = server_update_shell_command(log_path, &cache_dir);
 
         assert!(command.contains("umask 077"));
-        assert!(command.contains("cache_dir='/opt/nodelite/data/.server-update-cache'"));
+        assert!(
+            command.contains("NODELITE_UPDATE_CACHE_DIR='/opt/nodelite/data/.server-update-cache'")
+        );
         assert!(command.contains("mkdir -p \"$cache_dir\""));
         assert!(command.contains("tmp_script=\"$(mktemp \"$cache_dir/install-server.XXXXXX\")\""));
         assert!(command.contains("chmod 0600 \"$tmp_script\""));
+        assert!(command.contains("asset_base_url=\"$repository/releases/download/$target_tag\""));
+        assert!(command.contains("installer sha256=$actual_sha256 verified"));
+        assert!(command.contains("NODELITE_SERVER_VERSION=\"$target_tag\""));
+        assert!(command.contains("NODELITE_SERVER_BASE_URL=\"$asset_base_url\""));
+        assert!(!command.contains("releases/latest/download/install-server.sh"));
         assert!(!command.contains("${HOME:-/tmp}/.cache"));
+
+        let verify_position = command
+            .find("installer sha256=$actual_sha256 verified")
+            .expect("checksum verification log should be present");
+        let execute_position = command
+            .find("sh \"$tmp_script\"")
+            .expect("installer execution should be present");
+        assert!(verify_position < execute_position);
     }
 
     fn sample_server_config() -> ServerConfig {

--- a/scripts/merge-release-checksums.sh
+++ b/scripts/merge-release-checksums.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+assets_dir="${1:-release-assets}"
+assets_parent="$(dirname -- "$assets_dir")"
+assets_name="$(basename -- "$assets_dir")"
+
+server_installer="$assets_name/release-scripts/install-server.sh"
+agent_installer="$assets_name/release-scripts/install-agent.sh"
+script_checksums="$assets_name/SHA256SUMS-scripts.txt"
+merged_checksums="$assets_name/SHA256SUMS.txt"
+
+(
+  cd "$assets_parent"
+  [ -f "$server_installer" ] || {
+    printf '%s\n' "missing release asset: $server_installer" >&2
+    exit 1
+  }
+  [ -f "$agent_installer" ] || {
+    printf '%s\n' "missing release asset: $agent_installer" >&2
+    exit 1
+  }
+
+  sha256sum "$server_installer" "$agent_installer" >"$script_checksums"
+  find "$assets_name" -type f -name 'SHA256SUMS-*.txt' | sort | while IFS= read -r checksum_file; do
+    cat "$checksum_file"
+  done >"$merged_checksums"
+)

--- a/scripts/server-web-update.sh
+++ b/scripts/server-web-update.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+# Web settings update bootstrap. This file is embedded in the server binary at
+# compile time, so the downloaded installer is never trusted before its release
+# checksum has been verified.
+
+set -u
+umask 077
+
+: "${NODELITE_UPDATE_LOG:?NODELITE_UPDATE_LOG is required}"
+: "${NODELITE_UPDATE_CACHE_DIR:?NODELITE_UPDATE_CACHE_DIR is required}"
+: "${NODELITE_UPDATE_REPOSITORY:?NODELITE_UPDATE_REPOSITORY is required}"
+
+log="$NODELITE_UPDATE_LOG"
+cache_dir="$NODELITE_UPDATE_CACHE_DIR"
+repository="${NODELITE_UPDATE_REPOSITORY%/}"
+tmp_script=""
+tmp_checksums=""
+
+# shellcheck disable=SC2317 # Invoked indirectly by the EXIT trap.
+cleanup() {
+  [ -n "$tmp_script" ] && rm -f "$tmp_script"
+  [ -n "$tmp_checksums" ] && rm -f "$tmp_checksums"
+  return 0
+}
+
+finish() {
+  status="$1"
+  printf '%s\n' "nodelite-update: finished exit=$status at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$log"
+  exit "$status"
+}
+
+fail_update() {
+  printf '%s\n' "nodelite-update: error: $1" >>"$log"
+  finish 1
+}
+
+calculate_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | sed 's/[[:space:]].*$//'
+    return 0
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | sed 's/[[:space:]].*$//'
+    return 0
+  fi
+  return 1
+}
+
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+: >"$log" || exit 1
+printf '%s\n' "nodelite-update: started at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$log"
+mkdir -p "$cache_dir" || fail_update "failed to create private update cache"
+chmod 0700 "$cache_dir" || fail_update "failed to secure private update cache"
+
+case "$repository" in
+  https://github.com/*/*)
+    ;;
+  *)
+    fail_update "release repository must be an https://github.com owner/repository URL"
+    ;;
+esac
+
+release_url="$repository/releases/latest"
+printf '%s\n' "nodelite-update: resolving stable release from $release_url" >>"$log"
+if ! resolved_url="$(curl -fsSIL -o /dev/null -w '%{url_effective}' "$release_url")"; then
+  fail_update "failed to resolve latest stable release"
+fi
+
+tag_prefix="$repository/releases/tag/"
+case "$resolved_url" in
+  "$tag_prefix"*)
+    target_tag="${resolved_url#"$tag_prefix"}"
+    ;;
+  *)
+    fail_update "latest release redirected outside the configured repository"
+    ;;
+esac
+case "$target_tag" in
+  ""|*-*|*[!A-Za-z0-9._+]*)
+    fail_update "resolved release tag is not a stable version tag"
+    ;;
+esac
+
+asset_base_url="$repository/releases/download/$target_tag"
+installer_url="$asset_base_url/install-server.sh"
+checksums_url="$asset_base_url/SHA256SUMS.txt"
+printf '%s\n' "nodelite-update: target release tag=$target_tag" >>"$log"
+printf '%s\n' "nodelite-update: installer url=$installer_url" >>"$log"
+
+tmp_script="$(mktemp "$cache_dir/install-server.XXXXXX")" \
+  || fail_update "failed to create temporary installer file"
+tmp_checksums="$(mktemp "$cache_dir/SHA256SUMS.XXXXXX")" \
+  || fail_update "failed to create temporary checksum file"
+chmod 0600 "$tmp_script" "$tmp_checksums" \
+  || fail_update "failed to secure temporary update files"
+
+if ! curl -fsSL "$checksums_url" -o "$tmp_checksums" >>"$log" 2>&1; then
+  fail_update "failed to download release checksums"
+fi
+expected_sha256="$(awk -v artifact="install-server.sh" '
+  NF >= 2 {
+    path = $2
+    sub(/^\*/, "", path)
+    count = split(path, parts, "/")
+    if (parts[count] == artifact) {
+      print $1
+    }
+  }
+' "$tmp_checksums")"
+case "$expected_sha256" in
+  ""|*[!0-9A-Fa-f]*)
+    fail_update "release checksums contain an invalid installer digest"
+    ;;
+esac
+if [ "${#expected_sha256}" -ne 64 ]; then
+  fail_update "release checksums contain an invalid installer digest"
+fi
+expected_sha256="$(printf '%s' "$expected_sha256" | tr 'A-F' 'a-f')"
+
+if ! curl -fsSL "$installer_url" -o "$tmp_script" >>"$log" 2>&1; then
+  fail_update "failed to download versioned installer"
+fi
+if ! actual_sha256="$(calculate_sha256 "$tmp_script")"; then
+  fail_update "missing required command: sha256sum or shasum"
+fi
+if [ "$actual_sha256" != "$expected_sha256" ]; then
+  fail_update "downloaded installer checksum mismatch"
+fi
+printf '%s\n' "nodelite-update: installer sha256=$actual_sha256 verified" >>"$log"
+
+chmod 0700 "$tmp_script" || fail_update "failed to make verified installer executable"
+printf '%s\n' "nodelite-update: running verified installer in upgrade mode" >>"$log"
+NODELITE_SERVER_VERSION="$target_tag" \
+NODELITE_SERVER_BASE_URL="$asset_base_url" \
+NODELITE_SERVER_MODE=upgrade \
+  sh "$tmp_script" >>"$log" 2>&1
+update_status="$?"
+finish "$update_status"

--- a/scripts/server-web-update.sh
+++ b/scripts/server-web-update.sh
@@ -15,11 +15,20 @@ cache_dir="$NODELITE_UPDATE_CACHE_DIR"
 repository="${NODELITE_UPDATE_REPOSITORY%/}"
 tmp_script=""
 tmp_checksums=""
+tmp_resolved_url=""
+active_pid=""
+
+CURL_CONNECT_TIMEOUT_SECS=10
+CURL_RESOLVE_TIMEOUT_SECS=30
+CURL_DOWNLOAD_TIMEOUT_SECS=60
+CHECKSUM_MAX_BYTES=1048576
+INSTALLER_MAX_BYTES=1048576
 
 # shellcheck disable=SC2317 # Invoked indirectly by the EXIT trap.
 cleanup() {
   [ -n "$tmp_script" ] && rm -f "$tmp_script"
   [ -n "$tmp_checksums" ] && rm -f "$tmp_checksums"
+  [ -n "$tmp_resolved_url" ] && rm -f "$tmp_resolved_url"
   return 0
 }
 
@@ -32,6 +41,37 @@ finish() {
 fail_update() {
   printf '%s\n' "nodelite-update: error: $1" >>"$log"
   finish 1
+}
+
+# shellcheck disable=SC2317 # Invoked indirectly by the signal traps.
+stop_active_process() {
+  if [ -n "$active_pid" ]; then
+    kill -TERM "$active_pid" 2>/dev/null || true
+    wait "$active_pid" 2>/dev/null || true
+    active_pid=""
+  fi
+}
+
+# shellcheck disable=SC2317 # Invoked indirectly by the signal traps.
+handle_signal() {
+  signal_name="$1"
+  signal_status="$2"
+  stop_active_process
+  printf '%s\n' "nodelite-update: interrupted signal=$signal_name" >>"$log"
+  finish "$signal_status"
+}
+
+run_secure_curl() {
+  curl \
+    --proto '=https' \
+    --proto-redir '=https' \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT_SECS" \
+    "$@" &
+  active_pid="$!"
+  wait "$active_pid"
+  command_status="$?"
+  active_pid=""
+  return "$command_status"
 }
 
 calculate_sha256() {
@@ -47,12 +87,18 @@ calculate_sha256() {
 }
 
 trap cleanup EXIT
-trap 'exit 130' HUP INT TERM
+trap 'handle_signal HUP 129' HUP
+trap 'handle_signal INT 130' INT
+trap 'handle_signal TERM 143' TERM
 
 : >"$log" || exit 1
 printf '%s\n' "nodelite-update: started at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$log"
 mkdir -p "$cache_dir" || fail_update "failed to create private update cache"
 chmod 0700 "$cache_dir" || fail_update "failed to secure private update cache"
+tmp_resolved_url="$(mktemp "$cache_dir/release-url.XXXXXX")" \
+  || fail_update "failed to create temporary release URL file"
+chmod 0600 "$tmp_resolved_url" \
+  || fail_update "failed to secure temporary release URL file"
 
 case "$repository" in
   https://github.com/*/*)
@@ -64,9 +110,15 @@ esac
 
 release_url="$repository/releases/latest"
 printf '%s\n' "nodelite-update: resolving stable release from $release_url" >>"$log"
-if ! resolved_url="$(curl -fsSIL -o /dev/null -w '%{url_effective}' "$release_url")"; then
+if ! run_secure_curl \
+  --max-time "$CURL_RESOLVE_TIMEOUT_SECS" \
+  -fsSIL \
+  -o /dev/null \
+  -w '%{url_effective}' \
+  "$release_url" >"$tmp_resolved_url"; then
   fail_update "failed to resolve latest stable release"
 fi
+resolved_url="$(cat "$tmp_resolved_url")"
 
 tag_prefix="$repository/releases/tag/"
 case "$resolved_url" in
@@ -96,8 +148,17 @@ tmp_checksums="$(mktemp "$cache_dir/SHA256SUMS.XXXXXX")" \
 chmod 0600 "$tmp_script" "$tmp_checksums" \
   || fail_update "failed to secure temporary update files"
 
-if ! curl -fsSL "$checksums_url" -o "$tmp_checksums" >>"$log" 2>&1; then
+if ! run_secure_curl \
+  --max-time "$CURL_DOWNLOAD_TIMEOUT_SECS" \
+  --max-filesize "$CHECKSUM_MAX_BYTES" \
+  -fsSL \
+  "$checksums_url" \
+  -o "$tmp_checksums" >>"$log" 2>&1; then
   fail_update "failed to download release checksums"
+fi
+checksum_size="$(wc -c <"$tmp_checksums" | tr -d '[:space:]')"
+if [ "$checksum_size" -gt "$CHECKSUM_MAX_BYTES" ]; then
+  fail_update "release checksum manifest exceeds size limit"
 fi
 expected_sha256="$(awk -v artifact="install-server.sh" '
   NF >= 2 {
@@ -119,8 +180,17 @@ if [ "${#expected_sha256}" -ne 64 ]; then
 fi
 expected_sha256="$(printf '%s' "$expected_sha256" | tr 'A-F' 'a-f')"
 
-if ! curl -fsSL "$installer_url" -o "$tmp_script" >>"$log" 2>&1; then
+if ! run_secure_curl \
+  --max-time "$CURL_DOWNLOAD_TIMEOUT_SECS" \
+  --max-filesize "$INSTALLER_MAX_BYTES" \
+  -fsSL \
+  "$installer_url" \
+  -o "$tmp_script" >>"$log" 2>&1; then
   fail_update "failed to download versioned installer"
+fi
+installer_size="$(wc -c <"$tmp_script" | tr -d '[:space:]')"
+if [ "$installer_size" -gt "$INSTALLER_MAX_BYTES" ]; then
+  fail_update "downloaded installer exceeds size limit"
 fi
 if ! actual_sha256="$(calculate_sha256 "$tmp_script")"; then
   fail_update "missing required command: sha256sum or shasum"
@@ -135,6 +205,9 @@ printf '%s\n' "nodelite-update: running verified installer in upgrade mode" >>"$
 NODELITE_SERVER_VERSION="$target_tag" \
 NODELITE_SERVER_BASE_URL="$asset_base_url" \
 NODELITE_SERVER_MODE=upgrade \
-  sh "$tmp_script" >>"$log" 2>&1
+  sh "$tmp_script" >>"$log" 2>&1 &
+active_pid="$!"
+wait "$active_pid"
 update_status="$?"
+active_pid=""
 finish "$update_status"

--- a/scripts/test-release-checksums.sh
+++ b/scripts/test-release-checksums.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+MERGE_SCRIPT="$SCRIPT_DIR/merge-release-checksums.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/nodelite-release-checksums-test.XXXXXX")"
+ASSETS_DIR="$TEST_ROOT/release-assets"
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$ASSETS_DIR/release-scripts" "$ASSETS_DIR/release-test"
+cp "$SCRIPT_DIR/install-server.sh" "$ASSETS_DIR/release-scripts/install-server.sh"
+cp "$SCRIPT_DIR/install-agent.sh" "$ASSETS_DIR/release-scripts/install-agent.sh"
+printf '%064d  release-assets/release-test/nodelite-server-test\n' 0 \
+  >"$ASSETS_DIR/release-test/SHA256SUMS-test.txt"
+
+(
+  cd "$TEST_ROOT"
+  sh "$MERGE_SCRIPT" release-assets
+)
+
+server_sha256="$(sha256sum "$ASSETS_DIR/release-scripts/install-server.sh" | sed 's/[[:space:]].*$//')"
+agent_sha256="$(sha256sum "$ASSETS_DIR/release-scripts/install-agent.sh" | sed 's/[[:space:]].*$//')"
+grep -Fx "$server_sha256  release-assets/release-scripts/install-server.sh" \
+  "$ASSETS_DIR/SHA256SUMS.txt" >/dev/null
+grep -Fx "$agent_sha256  release-assets/release-scripts/install-agent.sh" \
+  "$ASSETS_DIR/SHA256SUMS.txt" >/dev/null
+grep -Fx "$(printf '%064d' 0)  release-assets/release-test/nodelite-server-test" \
+  "$ASSETS_DIR/SHA256SUMS.txt" >/dev/null
+
+if [ "$(grep -Ec '^[0-9a-f]{64}  release-assets/release-scripts/install-(server|agent)\.sh$' "$ASSETS_DIR/SHA256SUMS.txt")" -ne 2 ]; then
+  printf '%s\n' "release installer checksum entries used an unexpected path or format" >&2
+  exit 1
+fi

--- a/scripts/test-server-web-update.sh
+++ b/scripts/test-server-web-update.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+BOOTSTRAP="$SCRIPT_DIR/server-web-update.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/nodelite-web-update-test.XXXXXX")"
+FAKE_BIN="$TEST_ROOT/bin"
+FIXTURES="$TEST_ROOT/fixtures"
+LOG_PATH="$TEST_ROOT/update.log"
+CACHE_DIR="$TEST_ROOT/cache"
+MARKER_PATH="$TEST_ROOT/installer-ran"
+REPOSITORY="https://github.com/example/NodeLite"
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$FAKE_BIN" "$FIXTURES"
+
+cat >"$FIXTURES/install-server.sh" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n%s\n%s\n' \
+  "$NODELITE_SERVER_VERSION" \
+  "$NODELITE_SERVER_BASE_URL" \
+  "$NODELITE_SERVER_MODE" >"$TEST_MARKER_PATH"
+EOF
+installer_sha256="$(sha256sum "$FIXTURES/install-server.sh" | sed 's/[[:space:]].*$//')"
+printf '%s  %s\n' "$installer_sha256" "release-assets/release-scripts/install-server.sh" \
+  >"$FIXTURES/SHA256SUMS.txt"
+
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/bin/sh
+set -eu
+
+output=""
+write_effective_url=0
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    -w)
+      write_effective_url=1
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+case "$url" in
+  */releases/latest)
+    [ "$write_effective_url" -eq 1 ] || exit 1
+    printf '%s' "$FAKE_REDIRECT_URL"
+    ;;
+  */releases/download/v1.2.3/SHA256SUMS.txt)
+    cp "$FAKE_FIXTURES/SHA256SUMS.txt" "$output"
+    ;;
+  */releases/download/v1.2.3/install-server.sh)
+    cp "$FAKE_FIXTURES/install-server.sh" "$output"
+    ;;
+  *)
+    printf '%s\n' "unexpected curl URL: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod 0700 "$FAKE_BIN/curl"
+
+export FAKE_FIXTURES="$FIXTURES"
+export FAKE_REDIRECT_URL="$REPOSITORY/releases/tag/v1.2.3"
+export TEST_MARKER_PATH="$MARKER_PATH"
+
+run_bootstrap() {
+  PATH="$FAKE_BIN:$PATH" \
+  NODELITE_UPDATE_LOG="$LOG_PATH" \
+  NODELITE_UPDATE_CACHE_DIR="$CACHE_DIR" \
+  NODELITE_UPDATE_REPOSITORY="$REPOSITORY" \
+    sh "$BOOTSTRAP"
+}
+
+run_bootstrap
+sed -n '1p' "$MARKER_PATH" | grep -Fx 'v1.2.3' >/dev/null
+sed -n '2p' "$MARKER_PATH" | grep -Fx "$REPOSITORY/releases/download/v1.2.3" >/dev/null
+sed -n '3p' "$MARKER_PATH" | grep -Fx 'upgrade' >/dev/null
+grep -F "nodelite-update: target release tag=v1.2.3" "$LOG_PATH" >/dev/null
+grep -F "nodelite-update: installer sha256=$installer_sha256 verified" "$LOG_PATH" >/dev/null
+
+rm -f "$MARKER_PATH"
+printf '%064d  install-server.sh\n' 0 >"$FIXTURES/SHA256SUMS.txt"
+if run_bootstrap; then
+  printf '%s\n' "checksum mismatch unexpectedly succeeded" >&2
+  exit 1
+fi
+[ ! -e "$MARKER_PATH" ] || {
+  printf '%s\n' "installer ran after checksum mismatch" >&2
+  exit 1
+}
+grep -F "nodelite-update: error: downloaded installer checksum mismatch" "$LOG_PATH" >/dev/null
+
+printf '%s  %s\n' "$installer_sha256" "install-server.sh" >"$FIXTURES/SHA256SUMS.txt"
+FAKE_REDIRECT_URL="$REPOSITORY/releases/tag/v1.2.3-rc.1"
+export FAKE_REDIRECT_URL
+if run_bootstrap; then
+  printf '%s\n' "pre-release redirect unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -F "nodelite-update: error: resolved release tag is not a stable version tag" \
+  "$LOG_PATH" >/dev/null
+
+FAKE_REDIRECT_URL="https://github.com/attacker/NodeLite/releases/tag/v1.2.3"
+export FAKE_REDIRECT_URL
+if run_bootstrap; then
+  printf '%s\n' "cross-repository redirect unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -F "nodelite-update: error: latest release redirected outside the configured repository" \
+  "$LOG_PATH" >/dev/null

--- a/scripts/test-server-web-update.sh
+++ b/scripts/test-server-web-update.sh
@@ -9,6 +9,7 @@ FIXTURES="$TEST_ROOT/fixtures"
 LOG_PATH="$TEST_ROOT/update.log"
 CACHE_DIR="$TEST_ROOT/cache"
 MARKER_PATH="$TEST_ROOT/installer-ran"
+CURL_LOG_PATH="$TEST_ROOT/curl.log"
 REPOSITORY="https://github.com/example/NodeLite"
 
 cleanup() {
@@ -25,7 +26,9 @@ printf '%s\n%s\n%s\n' \
   "$NODELITE_SERVER_VERSION" \
   "$NODELITE_SERVER_BASE_URL" \
   "$NODELITE_SERVER_MODE" >"$TEST_MARKER_PATH"
+exit "${FAKE_INSTALLER_EXIT:-0}"
 EOF
+cp "$FIXTURES/install-server.sh" "$FIXTURES/install-server.original.sh"
 installer_sha256="$(sha256sum "$FIXTURES/install-server.sh" | sed 's/[[:space:]].*$//')"
 printf '%s  %s\n' "$installer_sha256" "release-assets/release-scripts/install-server.sh" \
   >"$FIXTURES/SHA256SUMS.txt"
@@ -37,6 +40,7 @@ set -eu
 output=""
 write_effective_url=0
 url=""
+printf '%s\n' "$*" >>"$FAKE_CURL_LOG"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -o)
@@ -45,6 +49,9 @@ while [ "$#" -gt 0 ]; do
       ;;
     -w)
       write_effective_url=1
+      shift 2
+      ;;
+    --proto|--proto-redir|--connect-timeout|--max-time|--max-filesize)
       shift 2
       ;;
     -*)
@@ -56,6 +63,19 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+if [ -n "${FAKE_CURL_SIGNAL:-}" ]; then
+  case "$url" in
+    */releases/latest)
+      trap 'exit 0' HUP INT TERM
+      parent_pid="$(ps -o ppid= -p "$$" | tr -d '[:space:]')"
+      kill "-$FAKE_CURL_SIGNAL" "$parent_pid"
+      while :; do
+        sleep 1
+      done
+      ;;
+  esac
+fi
 
 case "$url" in
   */releases/latest)
@@ -78,6 +98,8 @@ chmod 0700 "$FAKE_BIN/curl"
 
 export FAKE_FIXTURES="$FIXTURES"
 export FAKE_REDIRECT_URL="$REPOSITORY/releases/tag/v1.2.3"
+export FAKE_CURL_LOG="$CURL_LOG_PATH"
+export FAKE_INSTALLER_EXIT=0
 export TEST_MARKER_PATH="$MARKER_PATH"
 
 run_bootstrap() {
@@ -88,40 +110,118 @@ run_bootstrap() {
     sh "$BOOTSTRAP"
 }
 
+capture_bootstrap_status() {
+  set +e
+  run_bootstrap
+  bootstrap_status="$?"
+  set -e
+}
+
+assert_status() {
+  expected_status="$1"
+  if [ "$bootstrap_status" -ne "$expected_status" ]; then
+    printf '%s\n' "expected bootstrap status $expected_status, got $bootstrap_status" >&2
+    exit 1
+  fi
+}
+
+assert_installer_did_not_run() {
+  [ ! -e "$MARKER_PATH" ] || {
+    printf '%s\n' "installer ran before bootstrap validation completed" >&2
+    exit 1
+  }
+}
+
 run_bootstrap
 sed -n '1p' "$MARKER_PATH" | grep -Fx 'v1.2.3' >/dev/null
 sed -n '2p' "$MARKER_PATH" | grep -Fx "$REPOSITORY/releases/download/v1.2.3" >/dev/null
 sed -n '3p' "$MARKER_PATH" | grep -Fx 'upgrade' >/dev/null
 grep -F "nodelite-update: target release tag=v1.2.3" "$LOG_PATH" >/dev/null
 grep -F "nodelite-update: installer sha256=$installer_sha256 verified" "$LOG_PATH" >/dev/null
+if [ "$(wc -l <"$CURL_LOG_PATH" | tr -d '[:space:]')" -ne 3 ]; then
+  printf '%s\n' "expected exactly three curl calls" >&2
+  exit 1
+fi
+if grep -v -- '--proto =https --proto-redir =https --connect-timeout 10' \
+  "$CURL_LOG_PATH" >/dev/null; then
+  printf '%s\n' "curl call omitted required HTTPS restrictions or connect timeout" >&2
+  exit 1
+fi
+grep -F -- '--max-time 30' "$CURL_LOG_PATH" >/dev/null
+grep -F -- '--max-time 60 --max-filesize 1048576' "$CURL_LOG_PATH" >/dev/null
 
 rm -f "$MARKER_PATH"
 printf '%064d  install-server.sh\n' 0 >"$FIXTURES/SHA256SUMS.txt"
-if run_bootstrap; then
-  printf '%s\n' "checksum mismatch unexpectedly succeeded" >&2
-  exit 1
-fi
-[ ! -e "$MARKER_PATH" ] || {
-  printf '%s\n' "installer ran after checksum mismatch" >&2
-  exit 1
-}
+capture_bootstrap_status
+assert_status 1
+assert_installer_did_not_run
 grep -F "nodelite-update: error: downloaded installer checksum mismatch" "$LOG_PATH" >/dev/null
+
+printf '%s  install-server.sh\n%s  install-server.sh\n' \
+  "$installer_sha256" "$installer_sha256" >"$FIXTURES/SHA256SUMS.txt"
+capture_bootstrap_status
+assert_status 1
+assert_installer_did_not_run
+grep -F "nodelite-update: error: release checksums contain an invalid installer digest" \
+  "$LOG_PATH" >/dev/null
+
+printf '%s  other-script.sh\n' "$installer_sha256" >"$FIXTURES/SHA256SUMS.txt"
+capture_bootstrap_status
+assert_status 1
+assert_installer_did_not_run
+grep -F "nodelite-update: error: release checksums contain an invalid installer digest" \
+  "$LOG_PATH" >/dev/null
+
+dd if=/dev/zero of="$FIXTURES/install-server.sh" bs=1048576 count=1 2>/dev/null
+printf 'x' >>"$FIXTURES/install-server.sh"
+oversized_sha256="$(sha256sum "$FIXTURES/install-server.sh" | sed 's/[[:space:]].*$//')"
+printf '%s  install-server.sh\n' "$oversized_sha256" >"$FIXTURES/SHA256SUMS.txt"
+capture_bootstrap_status
+assert_status 1
+assert_installer_did_not_run
+grep -F "nodelite-update: error: downloaded installer exceeds size limit" "$LOG_PATH" >/dev/null
+cp "$FIXTURES/install-server.original.sh" "$FIXTURES/install-server.sh"
 
 printf '%s  %s\n' "$installer_sha256" "install-server.sh" >"$FIXTURES/SHA256SUMS.txt"
 FAKE_REDIRECT_URL="$REPOSITORY/releases/tag/v1.2.3-rc.1"
 export FAKE_REDIRECT_URL
-if run_bootstrap; then
-  printf '%s\n' "pre-release redirect unexpectedly succeeded" >&2
-  exit 1
-fi
+capture_bootstrap_status
+assert_status 1
+assert_installer_did_not_run
 grep -F "nodelite-update: error: resolved release tag is not a stable version tag" \
   "$LOG_PATH" >/dev/null
 
 FAKE_REDIRECT_URL="https://github.com/attacker/NodeLite/releases/tag/v1.2.3"
 export FAKE_REDIRECT_URL
-if run_bootstrap; then
-  printf '%s\n' "cross-repository redirect unexpectedly succeeded" >&2
-  exit 1
-fi
+capture_bootstrap_status
+assert_status 1
+assert_installer_did_not_run
 grep -F "nodelite-update: error: latest release redirected outside the configured repository" \
   "$LOG_PATH" >/dev/null
+
+FAKE_REDIRECT_URL="$REPOSITORY/releases/tag/v1.2.3"
+FAKE_INSTALLER_EXIT=42
+export FAKE_REDIRECT_URL FAKE_INSTALLER_EXIT
+capture_bootstrap_status
+assert_status 42
+grep -F "nodelite-update: finished exit=42" "$LOG_PATH" >/dev/null
+
+FAKE_INSTALLER_EXIT=0
+export FAKE_INSTALLER_EXIT
+for signal_case in HUP:129 INT:130 TERM:143; do
+  signal_name="${signal_case%:*}"
+  signal_status="${signal_case#*:}"
+  rm -f "$MARKER_PATH"
+  FAKE_CURL_SIGNAL="$signal_name"
+  export FAKE_CURL_SIGNAL
+  capture_bootstrap_status
+  assert_status "$signal_status"
+  assert_installer_did_not_run
+  grep -F "nodelite-update: interrupted signal=$signal_name" "$LOG_PATH" >/dev/null
+  grep -F "nodelite-update: finished exit=$signal_status" "$LOG_PATH" >/dev/null
+  if find "$CACHE_DIR" -type f -print -quit | grep . >/dev/null; then
+    printf '%s\n' "temporary update files remained after $signal_name" >&2
+    exit 1
+  fi
+done
+unset FAKE_CURL_SIGNAL


### PR DESCRIPTION
## Summary

- resolve the stable GitHub release to a concrete same-repository tag before downloading updater code
- verify the versioned installer against the release checksum manifest before root execution
- keep final Server binary checksum verification pinned to the same versioned asset base
- publish and test installer checksum entries in the release workflow
- restrict updater downloads to HTTPS with time, size, signal, logging, and cleanup bounds

## Security review

- no P0/P1/P2 findings remain after primary and independent differential review
- follow-up hardening covers signal exit logging, child termination, HTTPS-only redirects, timeouts, size limits, duplicate/missing digest rejection, and release manifest correspondence
- residual boundary: GitHub release write compromise can replace both assets and checksums; independent signatures or attestations are outside this issue

## Validation

- cargo test --workspace --locked (467 passed, 8 ignored)
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo +stable fmt --all --check
- ShellCheck for installer, updater, and checksum scripts
- updater success/failure/signal regression suite
- release checksum manifest aggregation test
- CI and release workflow YAML parsing

Closes #311
