### PR TITLE
docs: define memory measurement methodology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,12 @@ NodeLite 是一个轻量级 Rust 监控系统，采用 Server-Agent 架构。
 - Token 认证，可选 TOTP 2FA
 - SQLite 历史数据、审计日志与告警状态存储
 - Vue 3 Web UI，由 server 嵌入静态构建产物
-- 低资源占用：服务端目标 < 15MB，Agent 目标 < 2MB
+- 低资源占用：按场景跟踪 Server/Agent 的 RSS、PSS、匿名内存与 cgroup 总预算
 
 性能目标：
 - 200 节点并发：18,677 指标/秒
 - p95 延迟：< 5ms
-- 内存占用：服务端 < 15MB，Agent < 2MB
+- 内存：同机、同构建、同负载做回归比较；采集规范见 `docs/memory-measurement.md`
 
 ## 架构
 

--- a/README.en.md
+++ b/README.en.md
@@ -175,6 +175,14 @@ cargo tarpaulin --config tarpaulin.toml
 
 Performance baselines should be rerun with release builds on the target machine. The README no longer keeps long benchmark tables because those numbers drift as the code evolves.
 
+Memory baselines don't use a single usage number. Server and Agent reports must
+separate process RSS/PSS, anonymous resident memory, and systemd cgroup
+`MemoryCurrent`; the latter includes reclaimable filesystem page cache created
+by SQLite and WAL I/O and isn't a Rust heap or leak metric. See the
+[memory measurement methodology](docs/memory-measurement.md) for commands,
+cold/warm scenarios, and the report template. Unscoped `Server <15MB` and
+`Agent <2MB` statements are no longer release gates.
+
 Common loopback benchmarks:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ cargo tarpaulin --config tarpaulin.toml
 
 性能基线建议用 release 构建在目标机器上重新跑，README 不再维护长表格，避免数据随版本漂移后增加阅读负担。
 
+内存基线不使用单一的“占用”数字。Server/Agent 报告必须同时区分进程 RSS/PSS、
+匿名驻留内存和 systemd cgroup `MemoryCurrent`；后者包含 SQLite/WAL 产生的可回收
+filesystem page cache，不能直接当作 Rust heap 或泄漏。完整采集命令、冷/热缓存场景
+和报告模板见 [内存测量规范](docs/memory-measurement.md)。没有平台与口径的
+`Server <15MB` / `Agent <2MB` 不再作为发布门槛。
+
 常用 loopback 压测：
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1702,16 +1702,15 @@ curl -u '&lt;readonly-username&gt;:&lt;generated-strong-password&gt;' 'https://m
               </button>
               <div class="faq-a" hidden>
                 <div class="faq-a-inner">
-                  <p><code>800-1000 KB</code> 只能看作 Agent 的冷启动基线，不应该理解成长时间运行后的固定占用。</p>
+                  <p>NodeLite 不使用单一的“内存占用”数字作为发布基线。进程 RSS/PSS、匿名驻留内存和 systemd cgroup <code>MemoryCurrent</code> 回答的是不同问题，必须结合负载场景一起记录。</p>
                   <ul>
-                    <li><strong>服务端</strong>：4-10 MB 内存</li>
-                    <li><strong>Agent 冷启动</strong>：约 800 KB</li>
-                    <li><strong>Agent 运行 24 小时后</strong>：约 1.2 MB</li>
-                    <li><strong>Agent 运行 72 小时后</strong>：约 3 MB</li>
-                    <li><strong>200 节点并发</strong>：p95 延迟 &lt; 5ms，metrics 吞吐 18,677/s</li>
+                    <li><strong>RSS/PSS</strong>：用于比较进程驻留工作集；PSS 会按比例分摊共享页。</li>
+                    <li><strong>匿名内存</strong>：用于近似观察 heap、线程栈和 runtime 私有状态。</li>
+                    <li><strong>MemoryCurrent</strong>：用于 systemd 总资源预算，也包含 SQLite/WAL 产生的可回收文件页缓存。</li>
+                    <li><strong>对照条件</strong>：使用同一机器、同一构建目标和相同节点数，区分 dashboard/History 冷、热场景。</li>
                   </ul>
-                  <p>也就是说，当前版本的 Agent 常驻内存会随着运行时长增加而缓慢上升。这个现象已经在文档里明确标注，实际表现还会受到反向代理、SQLite I/O、历史保留时长和宿主机环境影响。</p>
-                  <p>如果你对常驻内存比较敏感，建议把这些数字当作实测参考值，而不是容量上限，并在自己的环境中持续观察 RSS 变化。</p>
+                  <p>生产实例中的 cgroup 数字可能明显高于进程 RSS，其中大部分差值可能是可回收的数据库文件页缓存，不能直接描述为 Rust heap 或内存泄漏。</p>
+                  <p>完整采集命令、场景定义和报告模板见 <a href="https://github.com/XiNian-dada/NodeLite/blob/main/docs/memory-measurement.md" target="_blank" rel="noopener">内存测量规范</a>。</p>
                 </div>
               </div>
             </div>

--- a/docs/memory-measurement.md
+++ b/docs/memory-measurement.md
@@ -1,0 +1,194 @@
+# Memory measurement methodology
+
+NodeLite does not use a single memory number as the release baseline. Process
+RSS, proportional set size, anonymous memory, and a systemd cgroup answer
+different questions and must be recorded together.
+
+All byte totals in benchmark reports use binary units: 1 KiB = 1024 bytes and
+1 MiB = 1024 KiB.
+
+## Required report context
+
+Every result must include:
+
+- NodeLite commit or release tag, release target, allocator, and build command;
+- operating system, kernel, architecture, vCPU count, and total RAM;
+- Server or Agent uptime and the number of established Agent/browser sessions;
+- report interval and whether the process is disconnected or authenticated;
+- whether dashboard and History pages were opened before collection;
+- History/Audit database and WAL sizes;
+- whether the sample represents a cold process or a warmed workload;
+- swap activity during the sample, not only the amount of cold data in swap.
+
+For fleet tests, report idle, 5, 200, and 1000 Agents separately. For the
+Agent, report disconnected idle, authenticated idle, 1-second reporting, and a
+large-mount workload separately.
+
+## Reference production sample
+
+The following 2026-07-10 sample is context, not a portable release gate. The
+Linux Server had 5 Agents, 4 days of uptime, an approximately 31 MiB History DB,
+a 4.1 MiB History WAL, a 572 KiB Audit DB, and no sustained swap I/O:
+
+| Metric | Observed |
+|---|---:|
+| systemd `MemoryCurrent` | 38.45 MiB |
+| process RSS / PSS | 15.6 MiB |
+| `RssAnon` / `Pss_Anon` | 8.3-8.5 MiB |
+| `RssFile` / `Pss_File` | 7.3 MiB |
+| cgroup `file` | 28.55 MiB |
+| cgroup `file_mapped` | 7.29 MiB |
+| cgroup `file_dirty` / `file_writeback` | 24 KiB / 0 |
+| cgroup `sock` | 12 KiB |
+| `SwapPss` | 6.14 MiB |
+
+The roughly 21.3 MiB gap between cgroup `file` and process `RssFile` was
+reclaimable filesystem page cache, consistent with the SQLite DB/WAL working
+set. `vmstat 1 5` reported `si=0` and `so=0`, so the cold swapped pages weren't
+thrashing. This sample demonstrates why `MemoryCurrent=38.45MiB` must not be
+reported as a 38.45 MiB Rust heap.
+
+An Ubuntu Agent from the same observation window reported approximately 7.3
+MiB current, 7.6 MiB peak, and 4 tasks after 4 days. It showed a stable runtime
+baseline rather than continuing growth, but the sample didn't include PSS and
+must not be compared directly with a different build target or host.
+
+A separate controlled Linux benchmark for the Agent current-thread runtime
+change used static aarch64 musl release binaries, an external mock WebSocket
+server, successful authentication, and 1-second reports. Each result was the
+median of three runs on the same host:
+
+| Scenario | Baseline PSS | Changed PSS | Threads before/after |
+|---|---:|---:|---:|
+| 1 vCPU authenticated | 2,788 KiB | 2,660 KiB | 3 / 2 |
+| 2 vCPU authenticated | 2,812 KiB | 2,660 KiB | 4 / 2 |
+| 8 vCPU authenticated | 2,852 KiB | 2,660 KiB | 10 / 2 |
+| 2 vCPU disconnected | 2,604 KiB | 2,440 KiB | not recorded / 2 |
+
+The 1-vCPU authenticated `VmRSS` changed from 2,688 KiB to 2,560 KiB. With
+500 bind mounts, the changed build reached 2,664 KiB PSS and a worst observed
+`VmHWM` of 2,688 KiB, within 256 KiB of the ordinary-idle median. These musl
+results demonstrate a reproducible comparison protocol; they do not replace a
+glibc/systemd measurement on the deployment host.
+
+## Linux process metrics
+
+Set `service` to `nodelite-server.service` or `nodelite-agent.service`:
+
+```bash
+service=nodelite-server.service
+pid=$(systemctl show "$service" -p MainPID --value)
+
+grep -E \
+  '^(VmRSS|RssAnon|RssFile|RssShmem|VmData|VmStk|Threads)' \
+  "/proc/$pid/status"
+
+grep -E \
+  '^(Rss|Pss|Pss_Anon|Pss_File|Private|Shared|Anonymous|Swap|SwapPss)' \
+  "/proc/$pid/smaps_rollup"
+```
+
+Interpretation:
+
+- `VmRSS`/`Rss` is the process resident set and includes private and mapped
+  file-backed pages. Shared pages are counted in full.
+- `Pss` divides shared pages proportionally and is the preferred process-level
+  comparison when it is available.
+- `RssAnon`/`Pss_Anon` is the useful first approximation for heap, stacks,
+  runtime state, and private SQLite page caches. It is not a perfect Rust heap
+  measurement.
+- `RssFile`/`Pss_File` includes executable, shared-library, mmap, and other
+  file-backed resident pages.
+- `SwapPss` can contain cold pages without indicating active memory pressure.
+  Check `vmstat` before describing it as swap thrashing.
+- `Threads` is part of the Agent baseline because Tokio runtime selection can
+  change both stack reservation and scheduling overhead.
+
+## systemd cgroup metrics
+
+```bash
+service=nodelite-server.service
+cgroup="/sys/fs/cgroup/system.slice/$service"
+
+systemctl show "$service" \
+  -p MemoryCurrent -p MemoryPeak -p TasksCurrent
+
+grep -E \
+  '^(anon|file|file_mapped|file_dirty|file_writeback|kernel|sock|slab|pagetables|active_file|inactive_file) ' \
+  "$cgroup/memory.stat"
+```
+
+`MemoryCurrent` is the total memory charged to the service cgroup. It includes
+process anonymous memory, mapped files, kernel allocations, socket memory, and
+filesystem page cache created by database and log I/O. It is the correct number
+for a systemd resource budget, but it is not a Rust heap or leak metric.
+
+The cgroup `file` counter can be much larger than process `RssFile`: SQLite DB
+and WAL pages can remain in the reclaimable filesystem cache after they are no
+longer mapped into the process. Record `file_mapped`, `file_dirty`, and
+`file_writeback` before attributing the difference to an application leak.
+
+Do not run global `drop_caches`, switch to direct I/O, or continuously clear
+caches merely to reduce `systemctl status` output. Those actions affect the
+whole host and can make History latency worse. If a cold-cache experiment is
+required, run it on an isolated disposable host and label it explicitly.
+
+## Database and swap context
+
+```bash
+data_dir=/var/lib/nodelite
+pid=$(systemctl show nodelite-server.service -p MainPID --value)
+
+du -h "$data_dir"
+find "$data_dir" -maxdepth 1 -type f \
+  \( -name '*.sqlite3' -o -name '*.sqlite3-wal' -o -name '*.sqlite3-shm' \) \
+  -exec ls -lh {} +
+lsof -p "$pid" | grep -E 'sqlite|wal|shm|snapshot|server.json'
+vmstat 1 5
+```
+
+Record History DB/WAL sizes for both cold and warmed History scenarios. In
+`vmstat`, sustained non-zero `si`/`so` indicates active swap I/O; a non-zero
+`SwapPss` with `si=0` and `so=0` does not by itself show thrashing.
+
+## Scenario protocol
+
+Use release binaries on the same host for before/after comparisons.
+
+1. Start the service and wait for initialization to settle.
+2. Record the cold idle sample before opening dashboard or History pages.
+3. Connect the declared number of external Agents and wait for authentication.
+4. Record authenticated idle after at least five stable sample intervals.
+5. Open the dashboard and record the warmed dashboard sample.
+6. Query representative History windows, record the warmed History sample,
+   and include DB/WAL sizes and query p95.
+7. Keep sampling long enough to observe `MemoryPeak` and confirm whether RSS
+   returns to a stable plateau.
+
+External-client fleet measurements must read the Server PID only. The built-in
+loopback load tests run fake clients and Server in one process; their latency
+and throughput are useful, but their RSS is not a Server-only memory baseline.
+
+## Reporting template
+
+| Field | Value |
+|---|---|
+| Version / target | |
+| Host / kernel / vCPU / RAM | |
+| Uptime | |
+| Scenario and Agent/browser count | |
+| Report interval | |
+| Dashboard/History warmed | |
+| `MemoryCurrent` / `MemoryPeak` | |
+| RSS / PSS | |
+| `RssAnon` / `RssFile` | |
+| cgroup `anon` / `file` / `file_mapped` | |
+| `SwapPss`; `vmstat si/so` | |
+| Threads / TasksCurrent | |
+| History DB / WAL / SHM | |
+| Audit DB / WAL / SHM | |
+| Query/API p95 | |
+
+Release decisions should compare like-for-like scenarios and define budgets
+per scenario. Historical `<15MB Server` and `<2MB Agent` statements did not
+specify a platform or metric and are therefore not release gates.


### PR DESCRIPTION
## Summary

- define a repeatable RSS/PSS, anonymous-memory, and systemd cgroup measurement methodology
- document the 2026-07-10 production Server/Agent samples and the controlled Agent runtime comparison
- remove unscoped `<15MB` / `<2MB` release gates from README and CLAUDE guidance
- replace the website FAQ's obsolete 800KB/1.2MB/3MB claims with metric-aware guidance

## Verification

- `git diff --check`
- repository-wide search for stale current memory claims
- verified README, CLAUDE, website FAQ, commands, units, scenario matrix, and report template against Issue acceptance criteria

Closes #325
