### PR TITLE
perf(agent): reduce runtime and dependency footprint

### DIFF
--- a/nodelite-agent/Cargo.toml
+++ b/nodelite-agent/Cargo.toml
@@ -16,9 +16,9 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
-chrono.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["now", "std"] }
 clap.workspace = true
-futures.workspace = true
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 getrandom.workspace = true
 libc.workspace = true
 rustls.workspace = true
@@ -27,7 +27,7 @@ tokio = { workspace = true, features = ["rt", "macros", "net", "time", "sync", "
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 toml_edit.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "tracing-log"] }
 url.workspace = true
 nodelite-proto = { path = "../nodelite-proto" }
 

--- a/nodelite-agent/Cargo.toml
+++ b/nodelite-agent/Cargo.toml
@@ -23,7 +23,7 @@ getrandom.workspace = true
 libc.workspace = true
 rustls.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "time", "sync", "signal", "fs"] }
+tokio = { workspace = true, features = ["rt", "macros", "net", "time", "sync", "signal", "fs"] }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 toml_edit.workspace = true
 tracing.workspace = true
@@ -32,4 +32,4 @@ url.workspace = true
 nodelite-proto = { path = "../nodelite-proto" }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util", "rt-multi-thread"] }

--- a/nodelite-agent/src/main.rs
+++ b/nodelite-agent/src/main.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     nodelite_agent::runtime::run().await
 }

--- a/nodelite-proto/Cargo.toml
+++ b/nodelite-proto/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 
 [dependencies]
 base32 = "0.5"
-chrono.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 http.workspace = true
 ipnet.workspace = true
 serde.workspace = true


### PR DESCRIPTION
## Summary

- run the Agent on Tokio's current-thread runtime while keeping host collection and config persistence on the blocking pool
- trim unused Futures executor, Chrono local-clock/timezone, and tracing JSON/ANSI feature weight
- keep multi-thread Tokio enabled only for tests that require it

## Controlled Linux footprint

Static aarch64 musl release binaries, external authenticated mock WebSocket, 1-second reports, three runs per point:

| Scenario | Baseline PSS | Changed PSS | Threads |
|---|---:|---:|---:|
| 1 vCPU | 2,788 KiB | 2,660 KiB | 3 → 2 |
| 2 vCPU | 2,812 KiB | 2,660 KiB | 4 → 2 |
| 8 vCPU | 2,852 KiB | 2,660 KiB | 10 → 2 |

- static binary: 3,902,816 → 3,799,144 bytes (-2.66%)
- 500 mounts: final PSS 2,664 KiB; worst VmHWM only 256 KiB above ordinary-idle median
- satisfies the Issue's `<=7 MiB` alternative footprint gate, `<=2` steady threads, and `<1 MiB` mount-pressure increment

## Verification

- `cargo +stable fmt --all --check`
- `cargo test --workspace` (Agent 34, Proto 65, Server 369 passed; 8 manual load tests ignored; doc tests passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo build -p nodelite-agent --release`
- normal Agent dependency tree checked for removed feature-only dependencies

The glibc/systemd production host should still be remeasured after release; the portable target is documented separately in #325 / #328.

Closes #319
