### PR TITLE
fix(ui): contain long disk mount paths

### DIFF
--- a/nodelite-server/web/e2e/_helpers.ts
+++ b/nodelite-server/web/e2e/_helpers.ts
@@ -67,7 +67,8 @@ const nodeStatus = {
     disks: [
       {
         device: '/dev/sda1',
-        mount_point: '/',
+        mount_point:
+          '/private/var/folders/y8/a-very-long-temporary-volume-name/that-must-not-overlap',
         fs_type: 'ext4',
         total_bytes: 100_000_000_000,
         available_bytes: 60_000_000_000,

--- a/nodelite-server/web/e2e/node-detail-tabs.spec.ts
+++ b/nodelite-server/web/e2e/node-detail-tabs.spec.ts
@@ -50,7 +50,9 @@ test('long disk mounts stay within their column across the mobile breakpoint', a
   expect(desktopMountBox!.x + desktopMountBox!.width).toBeLessThanOrEqual(filesystemBox!.x);
   expect(await mount.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true);
   expect(
-    await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth),
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    ),
   ).toBe(true);
 
   await page.setViewportSize({ width: 560, height: 900 });
@@ -59,7 +61,9 @@ test('long disk mounts stay within their column across the mobile breakpoint', a
   await expect(mount).toHaveCSS('white-space', 'normal');
   expect(await mount.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
   expect(
-    await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth),
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    ),
   ).toBe(true);
 });
 

--- a/nodelite-server/web/e2e/node-detail-tabs.spec.ts
+++ b/nodelite-server/web/e2e/node-detail-tabs.spec.ts
@@ -30,6 +30,39 @@ test('network tab loads interface stats', async ({ page }) => {
   await expect(page.locator('[data-test="network-traffic-card"]')).toBeVisible();
 });
 
+test('long disk mounts stay within their column across the mobile breakpoint', async ({ page }) => {
+  await page.setViewportSize({ width: 561, height: 900 });
+  await page.goto('/nodes/node-a#hardware');
+  await waitForAppShell(page);
+
+  const mount = page.locator('[data-test="disk-mount"]');
+  const filesystem = mount.locator('xpath=following-sibling::span[1]');
+
+  await expect(mount).toBeVisible();
+  await expect(mount).toHaveCSS('overflow', 'hidden');
+  await expect(mount).toHaveCSS('text-overflow', 'ellipsis');
+  await expect(mount).toHaveCSS('white-space', 'nowrap');
+
+  const desktopMountBox = await mount.boundingBox();
+  const filesystemBox = await filesystem.boundingBox();
+  expect(desktopMountBox).not.toBeNull();
+  expect(filesystemBox).not.toBeNull();
+  expect(desktopMountBox!.x + desktopMountBox!.width).toBeLessThanOrEqual(filesystemBox!.x);
+  expect(await mount.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true);
+  expect(
+    await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth),
+  ).toBe(true);
+
+  await page.setViewportSize({ width: 560, height: 900 });
+  await expect(mount).toHaveCSS('overflow', 'visible');
+  await expect(mount).toHaveCSS('text-overflow', 'clip');
+  await expect(mount).toHaveCSS('white-space', 'normal');
+  expect(await mount.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+  expect(
+    await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth),
+  ).toBe(true);
+});
+
 test('logs tab streams entries', async ({ page }) => {
   await page.goto('/nodes/node-a');
   await waitForAppShell(page);

--- a/nodelite-server/web/src/components/HardwareDiskTableCard.vue
+++ b/nodelite-server/web/src/components/HardwareDiskTableCard.vue
@@ -34,7 +34,13 @@ const { t } = useI18n();
         data-test="disk-row"
       >
         <span class="device" :data-label="t('node.disk.device')">{{ row.device }}</span>
-        <span :data-label="t('node.disk.mount')">{{ row.mount }}</span>
+        <span
+          class="mount"
+          data-test="disk-mount"
+          :data-label="t('node.disk.mount')"
+          :title="row.mount"
+          >{{ row.mount }}</span
+        >
         <span :data-label="t('node.disk.filesystem')"
           ><em>{{ row.fs }}</em></span
         >
@@ -95,13 +101,13 @@ const { t } = useI18n();
 .disk-head,
 .disk-row {
   display: grid;
-  grid-template-columns: minmax(140px, 1.1fr) minmax(80px, 0.7fr) minmax(84px, 0.6fr) minmax(
+  grid-template-columns: minmax(140px, 1fr) minmax(180px, 1.5fr) minmax(84px, 0.6fr) minmax(
       160px,
       1fr
-    ) minmax(120px, 0.8fr);
+    ) minmax(140px, 0.8fr);
   gap: 12px;
   align-items: center;
-  min-width: 720px;
+  min-width: 780px;
   padding: 11px 12px;
 }
 
@@ -115,6 +121,16 @@ const { t } = useI18n();
   border-top: 1px solid var(--border-soft);
   color: var(--text-secondary);
   font-size: 13px;
+}
+
+.disk-row > span {
+  min-width: 0;
+}
+
+.mount {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .device,
@@ -203,6 +219,12 @@ const { t } = useI18n();
     gap: 10px;
     align-items: center;
     overflow-wrap: anywhere;
+  }
+
+  .mount {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
   }
 
   .disk-row > span::before {

--- a/nodelite-server/web/src/components/NodeHardwarePanel.spec.ts
+++ b/nodelite-server/web/src/components/NodeHardwarePanel.spec.ts
@@ -127,6 +127,19 @@ describe('NodeHardwarePanel', () => {
     expect(wrapper.find('.usage-track .bad').exists()).toBe(true);
   });
 
+  it('keeps long mount paths inside their grid cell and exposes the full value', () => {
+    const node = makeNodeStatus();
+    const mountPoint =
+      '/private/var/folders/y8/a-very-long-temporary-volume-name/that-must-not-overlap';
+    node.snapshot!.disks = [disk({ mount_point: mountPoint })];
+
+    const wrapper = mountHardware(node);
+    const mount = wrapper.get('[data-test="disk-mount"]');
+    expect(mount.classes()).toContain('mount');
+    expect(mount.attributes('title')).toBe(mountPoint);
+    expect(mount.text()).toBe(mountPoint);
+  });
+
   it('renders an empty disk placeholder without temperature fields', () => {
     const wrapper = mountHardware(makeNodeStatus({ snapshot: null }));
     expect(wrapper.find('[data-test="node-disks-empty"]').exists()).toBe(true);


### PR DESCRIPTION
## Summary

- keep long mount paths inside the mount column on desktop layouts
- preserve the complete path through the title attribute while showing an ellipsis
- restore wrapping on mobile layouts
- add Playwright geometry coverage around the 560px breakpoint

## Verification

- pnpm lint
- pnpm typecheck
- pnpm test (490 passed)
- pnpm build
- pnpm e2e (20 passed, 7 expected skipped)
- real in-app browser verification with macOS mount paths
- independent review: 0 P0/P1/P2

No GitHub issue was created for this browser-discovered UI regression.