### PR TITLE
perf(ui): scale realtime node monitoring

### DIFF
--- a/nodelite-proto/tests/browser_message_contract.rs
+++ b/nodelite-proto/tests/browser_message_contract.rs
@@ -1,0 +1,139 @@
+//! Locks the browser WebSocket JSON contract to the fixture consumed by the Vue client tests.
+
+use std::{env, fs, path::PathBuf};
+
+use chrono::{TimeZone, Utc};
+use nodelite_proto::{
+    BrowserMessage, NodeListIdentity, NodeListItem, NodeListLoadAverage, NodeListMemoryUsage,
+    NodeListSnapshot, OverviewData,
+};
+use serde::Serialize;
+
+const UPDATE_FIXTURES_ENV: &str = "UPDATE_BROWSER_MESSAGE_FIXTURES";
+
+#[derive(Serialize)]
+struct BrowserMessageContract {
+    server_to_browser: ServerToBrowserMessages,
+    browser_to_server: BrowserToServerMessages,
+}
+
+#[derive(Serialize)]
+struct ServerToBrowserMessages {
+    initial_state: BrowserMessage,
+    overview_update: BrowserMessage,
+    node_upsert: BrowserMessage,
+    node_removed: BrowserMessage,
+    pong: BrowserMessage,
+}
+
+#[derive(Serialize)]
+struct BrowserToServerMessages {
+    ping: BrowserMessage,
+}
+
+#[test]
+fn browser_message_fixture_matches_rust_serialization() {
+    let expected = render_contract_fixture();
+    let fixture_path = fixture_path();
+
+    if env::var_os(UPDATE_FIXTURES_ENV).is_some() {
+        let parent = fixture_path
+            .parent()
+            .expect("browser message fixture should have a parent directory");
+        fs::create_dir_all(parent).expect("create browser message fixture directory");
+        fs::write(&fixture_path, &expected).expect("write browser message contract fixture");
+    }
+
+    let actual = fs::read_to_string(&fixture_path).unwrap_or_else(|error| {
+        panic!(
+            "read browser message fixture at {}: {error}; regenerate with {UPDATE_FIXTURES_ENV}=1 cargo test -p nodelite-proto --test browser_message_contract",
+            fixture_path.display()
+        )
+    });
+
+    assert_eq!(
+        actual, expected,
+        "browser message contract changed; review both Rust and TypeScript types, then regenerate with {UPDATE_FIXTURES_ENV}=1 cargo test -p nodelite-proto --test browser_message_contract"
+    );
+}
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../nodelite-server/web/src/ws/__fixtures__/browser_messages.json")
+}
+
+fn render_contract_fixture() -> String {
+    let contract = contract_fixture();
+    let json = serde_json::to_string_pretty(&contract).expect("serialize browser message contract");
+    format!("{json}\n")
+}
+
+fn contract_fixture() -> BrowserMessageContract {
+    let generated_at = Utc
+        .with_ymd_and_hms(2026, 7, 1, 12, 34, 56)
+        .single()
+        .expect("valid fixture timestamp");
+    let overview = OverviewData {
+        generated_at,
+        total_nodes: 1,
+        online_nodes: 1,
+        offline_nodes: 0,
+        total_rx_bytes: 123_456,
+        total_tx_bytes: 654_321,
+        current_rx_bytes_per_sec: 128.5,
+        current_tx_bytes_per_sec: 256.25,
+        average_latency_ms: Some(15.5),
+    };
+    let node = NodeListItem {
+        identity: NodeListIdentity {
+            node_id: "contract-node-01".to_string(),
+            node_label: "Contract Node".to_string(),
+            hostname: "contract.example".to_string(),
+            tags: vec!["contract".to_string(), "edge".to_string()],
+        },
+        geoip_country: Some("Singapore".to_string()),
+        geoip_city: Some("Singapore".to_string()),
+        geoip_latitude: Some(1.3521),
+        geoip_longitude: Some(103.8198),
+        location_override_country: None,
+        location_override_city: None,
+        location_override_latitude: None,
+        location_override_longitude: None,
+        snapshot: Some(NodeListSnapshot {
+            cpu_usage_percent: Some(37.5),
+            load: NodeListLoadAverage { one: 0.75 },
+            memory: NodeListMemoryUsage {
+                total_bytes: 8_589_934_592,
+                used_bytes: 3_221_225_472,
+            },
+        }),
+        latency_ms: Some(12),
+        online: true,
+    };
+
+    BrowserMessageContract {
+        server_to_browser: ServerToBrowserMessages {
+            initial_state: BrowserMessage::InitialState {
+                generated_at,
+                overview: overview.clone(),
+                nodes: vec![node.clone()],
+            },
+            overview_update: BrowserMessage::OverviewUpdate {
+                generated_at,
+                overview,
+            },
+            node_upsert: BrowserMessage::NodeUpsert {
+                generated_at,
+                node: Box::new(node),
+            },
+            node_removed: BrowserMessage::NodeRemoved {
+                generated_at,
+                node_id: "contract-node-01".to_string(),
+            },
+            pong: BrowserMessage::Pong,
+        },
+        browser_to_server: BrowserToServerMessages {
+            ping: BrowserMessage::Ping,
+        },
+    }
+}

--- a/nodelite-server/web/src/api/types.ts
+++ b/nodelite-server/web/src/api/types.ts
@@ -500,7 +500,7 @@ export interface RefreshNodeTokenRequest {
 }
 
 // --- WebSocket Browser Messages (nodelite-proto/src/message.rs BrowserMessage) ---
-// TODO(Stage 6.2): Auto-generate from proto crate instead of hand-writing.
+// Cross-language fixtures lock these definitions to Rust serialization in CI.
 
 export type BrowserMessage =
   | {

--- a/nodelite-server/web/src/components/NodeList.spec.ts
+++ b/nodelite-server/web/src/components/NodeList.spec.ts
@@ -3,6 +3,7 @@ import { mount, flushPromises, RouterLinkStub } from '@vue/test-utils';
 import { createApp, defineComponent, h } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
+import { NODE_CARD_HEIGHT, NODE_GRID_GAP } from '@/lib/gridVirtualizer';
 import { useNodesStore } from '@/stores/nodes';
 import { makeNode } from '@/api/__fixtures__/nodes';
 import NodeList from './NodeList.vue';
@@ -43,6 +44,18 @@ const FAKE_DICT = {
 };
 
 const Stub = defineComponent({ render: () => h('div') });
+const mountedWrappers = new Set<{ unmount: () => void }>();
+const originalInnerWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth')!;
+const originalInnerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight')!;
+const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY')!;
+let scrollY = 0;
+let animationFrames: FrameRequestCallback[] = [];
+
+function runAnimationFrames(): void {
+  const pending = animationFrames;
+  animationFrames = [];
+  pending.forEach((callback) => callback(0));
+}
 
 async function mountList(nodes: ReturnType<typeof makeNode>[]) {
   const pinia = createPinia();
@@ -55,6 +68,7 @@ async function mountList(nodes: ReturnType<typeof makeNode>[]) {
       stubs: { RouterLink: RouterLinkStub },
     },
   });
+  mountedWrappers.add(wrapper);
   await flushPromises();
   return wrapper;
 }
@@ -62,6 +76,19 @@ async function mountList(nodes: ReturnType<typeof makeNode>[]) {
 describe('NodeList', () => {
   beforeEach(async () => {
     __resetI18nForTest();
+    scrollY = 0;
+    animationFrames = [];
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+    Object.defineProperty(window, 'scrollY', { configurable: true, get: () => scrollY });
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        animationFrames.push(callback);
+        return animationFrames.length;
+      }),
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -75,9 +102,14 @@ describe('NodeList', () => {
   });
 
   afterEach(() => {
+    for (const wrapper of mountedWrappers) wrapper.unmount();
+    mountedWrappers.clear();
     __resetI18nForTest();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+    Object.defineProperty(window, 'innerWidth', originalInnerWidth);
+    Object.defineProperty(window, 'innerHeight', originalInnerHeight);
+    Object.defineProperty(window, 'scrollY', originalScrollY);
   });
 
   it('renders one card per node, keyed by node id', async () => {
@@ -94,5 +126,61 @@ describe('NodeList', () => {
     const wrapper = await mountList([]);
     expect(wrapper.findAll('[data-test="node-card"]')).toHaveLength(0);
     expect(wrapper.find('[data-test="node-list-empty"]').text()).toBe('Waiting for data…');
+  });
+
+  it('keeps the mounted card count below 50 for 500 nodes', async () => {
+    const nodes = Array.from({ length: 500 }, (_, index) =>
+      makeNode({
+        identity: {
+          node_id: `node-${String(index).padStart(3, '0')}`,
+          node_label: `Node ${index}`,
+          hostname: `host-${index}`,
+          tags: [],
+        },
+      }),
+    );
+    const wrapper = await mountList(nodes);
+
+    const cards = wrapper.findAll('[data-test="node-card"]');
+    expect(cards.length).toBeGreaterThan(0);
+    expect(cards.length).toBeLessThan(50);
+    expect(wrapper.find('[data-test="node-grid-window"]').attributes('data-start-index')).toBe('0');
+  });
+
+  it('moves the rendered node window after scrolling', async () => {
+    const nodes = Array.from({ length: 500 }, (_, index) =>
+      makeNode({
+        identity: {
+          node_id: `node-${String(index).padStart(3, '0')}`,
+          node_label: `Node ${index}`,
+          hostname: `host-${index}`,
+          tags: [],
+        },
+      }),
+    );
+    const wrapper = await mountList(nodes);
+    const firstNodeId = wrapper.find('[data-test="node-card"]').attributes('data-node-id');
+
+    scrollY = (NODE_CARD_HEIGHT + NODE_GRID_GAP) * 20;
+    window.dispatchEvent(new Event('scroll'));
+    runAnimationFrames();
+    await flushPromises();
+
+    const cards = wrapper.findAll('[data-test="node-card"]');
+    expect(cards.length).toBeLessThan(50);
+    expect(cards[0]?.attributes('data-node-id')).not.toBe(firstNodeId);
+    expect(wrapper.find('[data-test="node-grid-window"]').attributes('data-start-index')).toBe(
+      '54',
+    );
+  });
+
+  it('keeps visible cards linked to their detail route', async () => {
+    const wrapper = await mountList([
+      makeNode({
+        identity: { node_id: 'srv 1', node_label: 'Server', hostname: 'host', tags: [] },
+      }),
+    ]);
+
+    expect(wrapper.findComponent(RouterLinkStub).props('to')).toBe('/nodes/srv%201');
   });
 });

--- a/nodelite-server/web/src/components/NodeList.vue
+++ b/nodelite-server/web/src/components/NodeList.vue
@@ -1,14 +1,98 @@
 <script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import {
+  gridColumnCount,
+  gridVirtualWindow,
+  NODE_CARD_HEIGHT,
+  NODE_GRID_GAP,
+} from '@/lib/gridVirtualizer';
 import { useNodesStore } from '@/stores/nodes';
 import NodeCard from './NodeCard.vue';
 
 const nodesStore = useNodesStore();
+const section = ref<HTMLElement | null>(null);
+const listWidth = ref(window.innerWidth);
+const viewportWidth = ref(window.innerWidth);
+const viewportHeight = ref(window.innerHeight);
+const scrollY = ref(window.scrollY);
+const sectionTop = ref(0);
+let scrollFrame: number | null = null;
+let resizeObserver: ResizeObserver | null = null;
+
+const columns = computed(() => gridColumnCount(listWidth.value, viewportWidth.value));
+const virtualWindow = computed(() =>
+  gridVirtualWindow(
+    nodesStore.nodes.length,
+    columns.value,
+    scrollY.value - sectionTop.value,
+    viewportHeight.value,
+  ),
+);
+const visibleNodes = computed(() =>
+  nodesStore.nodes.slice(virtualWindow.value.startIndex, virtualWindow.value.endIndex),
+);
+const spacerStyle = computed(() => ({ height: `${virtualWindow.value.totalHeight}px` }));
+const gridStyle = computed(() => ({
+  '--node-grid-columns': String(columns.value),
+  '--node-card-height': `${NODE_CARD_HEIGHT}px`,
+  '--node-grid-gap': `${NODE_GRID_GAP}px`,
+  transform: `translate3d(0, ${virtualWindow.value.offsetTop}px, 0)`,
+}));
+
+function measureLayout(): void {
+  const element = section.value;
+  if (!element) return;
+  const rect = element.getBoundingClientRect();
+  listWidth.value = rect.width || element.clientWidth || window.innerWidth;
+  viewportWidth.value = window.innerWidth;
+  viewportHeight.value = window.innerHeight;
+  scrollY.value = window.scrollY;
+  sectionTop.value = rect.top + window.scrollY;
+}
+
+function updateScrollPosition(): void {
+  if (scrollFrame !== null) return;
+  scrollFrame = window.requestAnimationFrame(() => {
+    scrollFrame = null;
+    scrollY.value = window.scrollY;
+  });
+}
+
+onMounted(() => {
+  measureLayout();
+  window.addEventListener('scroll', updateScrollPosition, { passive: true });
+  window.addEventListener('resize', measureLayout);
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(measureLayout);
+    const element = section.value;
+    if (element) resizeObserver.observe(element);
+  }
+});
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', updateScrollPosition);
+  window.removeEventListener('resize', measureLayout);
+  resizeObserver?.disconnect();
+  if (scrollFrame !== null) window.cancelAnimationFrame(scrollFrame);
+});
 </script>
 
 <template>
-  <section class="nodes-section" data-test="node-list">
-    <div v-if="nodesStore.nodes.length > 0" class="node-grid">
-      <NodeCard v-for="node in nodesStore.nodes" :key="node.identity.node_id" :node="node" />
+  <section ref="section" class="nodes-section" data-test="node-list">
+    <div
+      v-if="nodesStore.nodes.length > 0"
+      class="node-grid-spacer"
+      data-test="node-grid-spacer"
+      :style="spacerStyle"
+    >
+      <div
+        class="node-grid"
+        data-test="node-grid-window"
+        :data-start-index="virtualWindow.startIndex"
+        :style="gridStyle"
+      >
+        <NodeCard v-for="node in visibleNodes" :key="node.identity.node_id" :node="node" />
+      </div>
     </div>
     <p v-else class="nodes-empty" data-test="node-list-empty">
       {{ $t('common.waiting_for_data') }}
@@ -20,20 +104,26 @@ const nodesStore = useNodesStore();
 .nodes-section {
   margin-top: 0;
 }
+.node-grid-spacer {
+  position: relative;
+  width: 100%;
+}
 .node-grid {
+  position: absolute;
+  inset: 0 0 auto;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(var(--node-grid-columns), minmax(0, 1fr));
+  gap: var(--node-grid-gap);
+  will-change: transform;
+}
+.node-grid :deep(.node-card) {
+  height: var(--node-card-height);
+  min-height: var(--node-card-height);
 }
 .nodes-empty {
   color: var(--text-muted);
   font-size: 13px;
   margin: 0;
   padding: 24px 0;
-}
-@media (min-width: 1920px) {
-  .node-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
 }
 </style>

--- a/nodelite-server/web/src/lib/gridVirtualizer.spec.ts
+++ b/nodelite-server/web/src/lib/gridVirtualizer.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  gridColumnCount,
+  gridVirtualWindow,
+  NODE_CARD_HEIGHT,
+  NODE_GRID_GAP,
+} from './gridVirtualizer';
+
+describe('gridColumnCount', () => {
+  it('matches the responsive card grid', () => {
+    expect(gridColumnCount(319, 1280)).toBe(1);
+    expect(gridColumnCount(654, 1280)).toBe(2);
+    expect(gridColumnCount(1200, 1280)).toBe(3);
+    expect(gridColumnCount(1800, 1800)).toBe(5);
+    expect(gridColumnCount(1800, 1920)).toBe(4);
+  });
+});
+
+describe('gridVirtualWindow', () => {
+  it('limits a 500-node grid to viewport rows plus overscan', () => {
+    const window = gridVirtualWindow(500, 3, 0, 800);
+    expect(window.startIndex).toBe(0);
+    expect(window.endIndex).toBe(15);
+    expect(window.totalRows).toBe(167);
+    expect(window.totalHeight).toBe(167 * (NODE_CARD_HEIGHT + NODE_GRID_GAP) - NODE_GRID_GAP);
+  });
+
+  it('moves the item window by whole grid rows', () => {
+    const rowStride = NODE_CARD_HEIGHT + NODE_GRID_GAP;
+    const window = gridVirtualWindow(500, 3, rowStride * 20, 800);
+    expect(window.startRow).toBe(18);
+    expect(window.startIndex).toBe(54);
+    expect(window.endIndex - window.startIndex).toBeLessThan(50);
+    expect(window.offsetTop).toBe(rowStride * 18);
+  });
+
+  it('clamps empty and past-the-end windows', () => {
+    expect(gridVirtualWindow(0, 0, 0, 800)).toMatchObject({
+      totalRows: 0,
+      startIndex: 0,
+      endIndex: 0,
+      totalHeight: 0,
+    });
+    expect(gridVirtualWindow(5, 2, 99_999, 800)).toMatchObject({
+      startIndex: 5,
+      endIndex: 5,
+    });
+  });
+});

--- a/nodelite-server/web/src/lib/gridVirtualizer.ts
+++ b/nodelite-server/web/src/lib/gridVirtualizer.ts
@@ -1,0 +1,58 @@
+export const NODE_CARD_HEIGHT = 282;
+export const NODE_GRID_GAP = 14;
+export const NODE_GRID_MIN_COLUMN_WIDTH = 320;
+export const NODE_GRID_OVERSCAN_ROWS = 2;
+
+export interface GridVirtualWindow {
+  columns: number;
+  totalRows: number;
+  startRow: number;
+  endRow: number;
+  startIndex: number;
+  endIndex: number;
+  offsetTop: number;
+  totalHeight: number;
+}
+
+export function gridColumnCount(containerWidth: number, viewportWidth: number): number {
+  if (viewportWidth >= 1920) return 4;
+  const width = Number.isFinite(containerWidth) && containerWidth > 0 ? containerWidth : 1;
+  return Math.max(
+    1,
+    Math.floor((width + NODE_GRID_GAP) / (NODE_GRID_MIN_COLUMN_WIDTH + NODE_GRID_GAP)),
+  );
+}
+
+export function gridVirtualWindow(
+  itemCount: number,
+  columns: number,
+  scrollTop: number,
+  viewportHeight: number,
+): GridVirtualWindow {
+  const safeCount = Math.max(0, Math.floor(itemCount));
+  const safeColumns = Math.max(1, Math.floor(columns));
+  const totalRows = Math.ceil(safeCount / safeColumns);
+  const rowStride = NODE_CARD_HEIGHT + NODE_GRID_GAP;
+  const startRow = Math.min(
+    totalRows,
+    Math.max(0, Math.floor(scrollTop / rowStride) - NODE_GRID_OVERSCAN_ROWS),
+  );
+  const endRow = Math.min(
+    totalRows,
+    Math.max(
+      startRow,
+      Math.ceil((scrollTop + Math.max(0, viewportHeight)) / rowStride) + NODE_GRID_OVERSCAN_ROWS,
+    ),
+  );
+
+  return {
+    columns: safeColumns,
+    totalRows,
+    startRow,
+    endRow,
+    startIndex: Math.min(safeCount, startRow * safeColumns),
+    endIndex: Math.min(safeCount, endRow * safeColumns),
+    offsetTop: startRow * rowStride,
+    totalHeight: totalRows === 0 ? 0 : totalRows * rowStride - NODE_GRID_GAP,
+  };
+}

--- a/nodelite-server/web/src/stores/nodeStatus.spec.ts
+++ b/nodelite-server/web/src/stores/nodeStatus.spec.ts
@@ -2,7 +2,7 @@ import { setActivePinia, createPinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiAbortError, ApiError } from '@/api/client';
 import { apiClient } from '@/api';
-import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import { makeNode, makeNodeStatus } from '@/api/__fixtures__/nodes';
 import { useNodeStatusStore } from './nodeStatus';
 
 vi.mock('@/api', async () => {
@@ -190,5 +190,125 @@ describe('useNodeStatusStore', () => {
     resolve(makeNodeStatus());
     await Promise.all([first, second]);
     expect(mockStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('merges realtime summaries while preserving full detail fields', async () => {
+    const initial = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, node_id: 'a', os: 'freebsd' },
+    });
+    mockStatus.mockResolvedValueOnce(initial);
+    const store = useNodeStatusStore();
+    await store.load('a');
+
+    store.applyRealtimeSummary(
+      makeNode({
+        identity: {
+          node_id: 'a',
+          node_label: 'Realtime A',
+          hostname: 'realtime-a',
+          tags: ['edge'],
+        },
+        snapshot: {
+          cpu_usage_percent: 88,
+          load: { one: 4.2 },
+          memory: { total_bytes: 16_000, used_bytes: 12_000 },
+        },
+        latency_ms: 320,
+        online: false,
+      }),
+    );
+
+    expect(store.data).toMatchObject({
+      identity: {
+        node_id: 'a',
+        node_label: 'Realtime A',
+        hostname: 'realtime-a',
+        os: 'freebsd',
+        tags: ['edge'],
+      },
+      snapshot: {
+        collected_at: initial.snapshot?.collected_at,
+        cpu_usage_percent: 88,
+        load: { one: 4.2, five: 0.4, fifteen: 0.5 },
+        memory: {
+          total_bytes: 16_000,
+          used_bytes: 12_000,
+          available_bytes: 4_000,
+        },
+        disks: initial.snapshot?.disks,
+        network: initial.snapshot?.network,
+      },
+      latency_ms: 320,
+      online: false,
+    });
+  });
+
+  it('ignores realtime summaries for a different active node', async () => {
+    const initial = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, node_id: 'a' },
+    });
+    mockStatus.mockResolvedValueOnce(initial);
+    const store = useNodeStatusStore();
+    await store.load('a');
+
+    store.applyRealtimeSummary(
+      makeNode({
+        identity: { node_id: 'b', node_label: 'B', hostname: 'b', tags: [] },
+        latency_ms: 999,
+      }),
+    );
+
+    expect(store.data).toEqual(initial);
+  });
+
+  it('accepts a null realtime snapshot', async () => {
+    mockStatus.mockResolvedValueOnce(
+      makeNodeStatus({ identity: { ...makeNodeStatus().identity, node_id: 'a' } }),
+    );
+    const store = useNodeStatusStore();
+    await store.load('a');
+
+    store.applyRealtimeSummary(
+      makeNode({
+        identity: { node_id: 'a', node_label: 'A', hostname: 'a', tags: [] },
+        snapshot: null,
+      }),
+    );
+
+    expect(store.data?.snapshot).toBeNull();
+  });
+
+  it('marks the active node as removed and ignores its late REST response', async () => {
+    let resolve: (value: ReturnType<typeof makeNodeStatus>) => void = () => {};
+    mockStatus.mockReturnValueOnce(
+      new Promise((done) => {
+        resolve = done;
+      }),
+    );
+    const store = useNodeStatusStore();
+    const pending = store.load('a');
+
+    store.markRemoved('a');
+    expect(store.data).toBeNull();
+    expect(store.error).toMatchObject({ status: 404 });
+    expect(store.loading).toBe(false);
+
+    resolve(makeNodeStatus({ identity: { ...makeNodeStatus().identity, node_id: 'a' } }));
+    await pending;
+    expect(store.data).toBeNull();
+    expect(store.error).toMatchObject({ status: 404 });
+  });
+
+  it('ignores removal events for a different node', async () => {
+    const initial = makeNodeStatus({
+      identity: { ...makeNodeStatus().identity, node_id: 'a' },
+    });
+    mockStatus.mockResolvedValueOnce(initial);
+    const store = useNodeStatusStore();
+    await store.load('a');
+
+    store.markRemoved('b');
+    expect(store.data).toEqual(initial);
+    expect(store.error).toBeNull();
   });
 });

--- a/nodelite-server/web/src/stores/nodeStatus.spec.ts
+++ b/nodelite-server/web/src/stores/nodeStatus.spec.ts
@@ -216,6 +216,7 @@ describe('useNodeStatusStore', () => {
         latency_ms: 320,
         online: false,
       }),
+      '2026-06-01T12:00:00Z',
     );
 
     expect(store.data).toMatchObject({
@@ -256,6 +257,7 @@ describe('useNodeStatusStore', () => {
         identity: { node_id: 'b', node_label: 'B', hostname: 'b', tags: [] },
         latency_ms: 999,
       }),
+      '2026-06-01T12:00:00Z',
     );
 
     expect(store.data).toEqual(initial);
@@ -273,9 +275,35 @@ describe('useNodeStatusStore', () => {
         identity: { node_id: 'a', node_label: 'A', hostname: 'a', tags: [] },
         snapshot: null,
       }),
+      '2026-06-01T12:00:00Z',
     );
 
     expect(store.data?.snapshot).toBeNull();
+  });
+
+  it('uses the server message time when realtime data creates the first snapshot', async () => {
+    mockStatus.mockResolvedValueOnce(
+      makeNodeStatus({
+        identity: { ...makeNodeStatus().identity, node_id: 'a' },
+        snapshot: null,
+      }),
+    );
+    const store = useNodeStatusStore();
+    await store.load('a');
+
+    store.applyRealtimeSummary(
+      makeNode({
+        identity: { node_id: 'a', node_label: 'A', hostname: 'a', tags: [] },
+        snapshot: {
+          cpu_usage_percent: 50,
+          load: { one: 1.5 },
+          memory: { total_bytes: 100, used_bytes: 60 },
+        },
+      }),
+      '2026-06-01T12:34:56Z',
+    );
+
+    expect(store.data?.snapshot?.collected_at).toBe('2026-06-01T12:34:56Z');
   });
 
   it('marks the active node as removed and ignores its late REST response', async () => {

--- a/nodelite-server/web/src/stores/nodeStatus.ts
+++ b/nodelite-server/web/src/stores/nodeStatus.ts
@@ -54,14 +54,14 @@ export const useNodeStatusStore = defineStore('nodeStatus', () => {
     await fetchFor(nodeId.value);
   }
 
-  function applyRealtimeSummary(summary: NodeListItem): void {
+  function applyRealtimeSummary(summary: NodeListItem, generatedAt: string): void {
     const current = data.value;
     if (!current || nodeId.value !== summary.identity.node_id) return;
 
     const snapshot = summary.snapshot
       ? {
           ...current.snapshot,
-          collected_at: current.snapshot?.collected_at ?? new Date().toISOString(),
+          collected_at: current.snapshot?.collected_at ?? generatedAt,
           cpu_usage_percent: summary.snapshot.cpu_usage_percent,
           load: {
             one: summary.snapshot.load.one,

--- a/nodelite-server/web/src/stores/nodeStatus.ts
+++ b/nodelite-server/web/src/stores/nodeStatus.ts
@@ -1,14 +1,14 @@
 import { defineStore } from 'pinia';
 import { ref, shallowRef } from 'vue';
-import { apiClient, type NodeStatus } from '@/api';
-import { ApiAbortError } from '@/api/client';
+import { apiClient, type NodeListItem, type NodeStatus } from '@/api';
+import { ApiAbortError, ApiError } from '@/api/client';
 import { useDedupeAsync } from '@/composables/useDedupeAsync';
 
 /**
  * Active node's full status (GET /api/nodes/{id}). Single active node — the
- * NodeDetail view drives load(id) on mount and refresh(id) on each poll.
- * If the id changes (navigating between nodes), data is cleared so a stale
- * node's snapshot never flashes under the new id.
+ * NodeDetail view loads the full record once, then merges lightweight
+ * WebSocket summaries into the realtime fields. If the id changes, data is
+ * cleared so a stale node's snapshot never flashes under the new id.
  */
 export const useNodeStatusStore = defineStore('nodeStatus', () => {
   const nodeId = ref<string | null>(null);
@@ -48,11 +48,77 @@ export const useNodeStatusStore = defineStore('nodeStatus', () => {
     await fetchFor(id);
   }
 
-  /** Re-fetch the current node (polling). No-op if no node is active. */
+  /** Re-fetch the current node. No-op if no node is active. */
   async function refresh(): Promise<void> {
     if (nodeId.value === null) return;
     await fetchFor(nodeId.value);
   }
 
-  return { nodeId, data, loading, error, load, refresh };
+  function applyRealtimeSummary(summary: NodeListItem): void {
+    const current = data.value;
+    if (!current || nodeId.value !== summary.identity.node_id) return;
+
+    const snapshot = summary.snapshot
+      ? {
+          ...current.snapshot,
+          collected_at: current.snapshot?.collected_at ?? new Date().toISOString(),
+          cpu_usage_percent: summary.snapshot.cpu_usage_percent,
+          load: {
+            one: summary.snapshot.load.one,
+            five: current.snapshot?.load.five ?? summary.snapshot.load.one,
+            fifteen: current.snapshot?.load.fifteen ?? summary.snapshot.load.one,
+          },
+          memory: {
+            total_bytes: summary.snapshot.memory.total_bytes,
+            used_bytes: summary.snapshot.memory.used_bytes,
+            available_bytes: Math.max(
+              summary.snapshot.memory.total_bytes - summary.snapshot.memory.used_bytes,
+              0,
+            ),
+            swap_total_bytes: current.snapshot?.memory.swap_total_bytes ?? 0,
+            swap_used_bytes: current.snapshot?.memory.swap_used_bytes ?? 0,
+          },
+          uptime_secs: current.snapshot?.uptime_secs ?? 0,
+          disks: current.snapshot?.disks ?? [],
+          network: current.snapshot?.network ?? {
+            total_rx_bytes: 0,
+            total_tx_bytes: 0,
+            rx_bytes_per_sec: null,
+            tx_bytes_per_sec: null,
+            packet_loss_percent: null,
+          },
+        }
+      : null;
+
+    data.value = {
+      ...current,
+      identity: {
+        ...current.identity,
+        node_label: summary.identity.node_label,
+        hostname: summary.identity.hostname,
+        tags: summary.identity.tags,
+      },
+      geoip_country: summary.geoip_country,
+      geoip_city: summary.geoip_city,
+      geoip_latitude: summary.geoip_latitude,
+      geoip_longitude: summary.geoip_longitude,
+      location_override_country: summary.location_override_country,
+      location_override_city: summary.location_override_city,
+      location_override_latitude: summary.location_override_latitude,
+      location_override_longitude: summary.location_override_longitude,
+      snapshot,
+      latency_ms: summary.latency_ms,
+      online: summary.online,
+    };
+  }
+
+  function markRemoved(removedNodeId: string): void {
+    if (nodeId.value !== removedNodeId) return;
+    requests.abort();
+    data.value = null;
+    loading.value = false;
+    error.value = new ApiError(404, 'node removed');
+  }
+
+  return { nodeId, data, loading, error, load, refresh, applyRealtimeSummary, markRemoved };
 });

--- a/nodelite-server/web/src/stores/nodes.spec.ts
+++ b/nodelite-server/web/src/stores/nodes.spec.ts
@@ -142,9 +142,10 @@ describe('useNodesStore', () => {
       const a = makeNode({ identity: { node_id: 'a', node_label: 'A', hostname: 'a', tags: [] } });
 
       store.applyServerState([a], '2026-06-01T12:01:00Z');
-      store.removeNode('a', '2026-06-01T12:00:00Z');
+      const removed = store.removeNode('a', '2026-06-01T12:00:00Z');
 
       expect(store.nodes).toEqual([a]);
+      expect(removed).toBe(false);
     });
 
     it('InitialState resets timestamp guard (Lagged resync)', () => {

--- a/nodelite-server/web/src/stores/nodes.spec.ts
+++ b/nodelite-server/web/src/stores/nodes.spec.ts
@@ -100,6 +100,25 @@ describe('useNodesStore', () => {
       expect(store.nodes).toContainEqual(b);
     });
 
+    it('updates an existing node without rebuilding the list or map', () => {
+      const store = useNodesStore();
+      const a = makeNode({ identity: { node_id: 'a', node_label: 'A', hostname: 'a', tags: [] } });
+      const b = makeNode({ identity: { node_id: 'b', node_label: 'B', hostname: 'b', tags: [] } });
+      const updatedA = makeNode({
+        identity: { node_id: 'a', node_label: 'A Updated', hostname: 'a', tags: [] },
+      });
+      store.applyServerState([a, b], '2026-06-01T12:00:00Z');
+      const listReference = store.nodes;
+      const mapReference = store.nodesById;
+
+      store.upsertNode(updatedA, '2026-06-01T12:01:00Z');
+
+      expect(store.nodes).toBe(listReference);
+      expect(store.nodesById).toBe(mapReference);
+      expect(store.nodes).toEqual([updatedA, b]);
+      expect(store.nodesById.get('a')).toEqual(updatedA);
+    });
+
     it('removeNode deletes from the Map', () => {
       const store = useNodesStore();
       const a = makeNode({ identity: { node_id: 'a', node_label: 'A', hostname: 'a', tags: [] } });
@@ -109,6 +128,23 @@ describe('useNodesStore', () => {
       store.removeNode('a', '2026-06-01T12:01:00Z');
 
       expect(store.nodes).toEqual([b]);
+    });
+
+    it('reindexes nodes after removal for later in-place updates', () => {
+      const store = useNodesStore();
+      const a = makeNode({ identity: { node_id: 'a', node_label: 'A', hostname: 'a', tags: [] } });
+      const b = makeNode({ identity: { node_id: 'b', node_label: 'B', hostname: 'b', tags: [] } });
+      const c = makeNode({ identity: { node_id: 'c', node_label: 'C', hostname: 'c', tags: [] } });
+      const updatedC = makeNode({
+        identity: { node_id: 'c', node_label: 'C Updated', hostname: 'c', tags: [] },
+      });
+      store.applyServerState([a, b, c], '2026-06-01T12:00:00Z');
+
+      store.removeNode('a', '2026-06-01T12:01:00Z');
+      store.upsertNode(updatedC, '2026-06-01T12:02:00Z');
+
+      expect(store.nodes).toEqual([b, updatedC]);
+      expect(store.nodesById.get('c')).toEqual(updatedC);
     });
 
     it('applyServerState always accepts (no guard)', () => {

--- a/nodelite-server/web/src/stores/nodes.ts
+++ b/nodelite-server/web/src/stores/nodes.ts
@@ -1,12 +1,13 @@
 import { defineStore } from 'pinia';
-import { computed, ref } from 'vue';
+import { ref, shallowRef, triggerRef } from 'vue';
 import { apiClient, type NodeListItem } from '@/api';
 import { ApiAbortError } from '@/api/client';
 
 /**
- * Node list state. Refactored to Map-keyed for O(1) incremental upserts
- * from WebSocket (Stage 3.5b). Polling lifecycle is NOT owned by the store —
- * see composables/usePolling.ts. Stores hold state + refresh() only.
+ * Node list state. A Map and index table keep WebSocket upserts O(1), while a
+ * shallow array preserves iteration order without rebuilding via Array.from
+ * for every message. Polling lifecycle is NOT owned by the store — see
+ * composables/usePolling.ts. Stores hold state + refresh() only.
  *
  * Timestamp guard: single global `lastGeneratedAt` protects against stale
  * messages (e.g., a delayed incremental arriving after a fresh InitialState).
@@ -16,13 +17,12 @@ import { ApiAbortError } from '@/api/client';
  * updates.
  */
 export const useNodesStore = defineStore('nodes', () => {
-  const nodesById = ref<Map<string, NodeListItem>>(new Map());
+  const nodes = shallowRef<NodeListItem[]>([]);
+  const nodesById = shallowRef<Map<string, NodeListItem>>(new Map());
+  const nodeIndexById = new Map<string, number>();
   const lastGeneratedAt = ref<string | null>(null);
   const loading = ref(false);
   const error = ref<Error | null>(null);
-
-  // Computed array for components that iterate (preserves existing API)
-  const nodes = computed(() => Array.from(nodesById.value.values()));
 
   async function refresh(): Promise<void> {
     if (loading.value) return;
@@ -45,6 +45,12 @@ export const useNodesStore = defineStore('nodes', () => {
   function applyServerState(items: NodeListItem[], generatedAt: string): void {
     const next = new Map<string, NodeListItem>();
     for (const item of items) next.set(item.identity.node_id, item);
+    const nextItems = Array.from(next.values());
+    nodeIndexById.clear();
+    nextItems.forEach((item, index) => {
+      nodeIndexById.set(item.identity.node_id, index);
+    });
+    nodes.value = nextItems;
     nodesById.value = next;
     lastGeneratedAt.value = generatedAt;
   }
@@ -53,7 +59,17 @@ export const useNodesStore = defineStore('nodes', () => {
   function upsertNode(node: NodeListItem, generatedAt: string): void {
     if (lastGeneratedAt.value && Date.parse(generatedAt) < Date.parse(lastGeneratedAt.value))
       return;
-    nodesById.value.set(node.identity.node_id, node);
+    const nodeId = node.identity.node_id;
+    const index = nodeIndexById.get(nodeId);
+    if (index === undefined) {
+      nodeIndexById.set(nodeId, nodes.value.length);
+      nodes.value.push(node);
+    } else {
+      nodes.value[index] = node;
+    }
+    nodesById.value.set(nodeId, node);
+    triggerRef(nodes);
+    triggerRef(nodesById);
     lastGeneratedAt.value = generatedAt;
   }
 
@@ -62,7 +78,17 @@ export const useNodesStore = defineStore('nodes', () => {
     if (lastGeneratedAt.value && Date.parse(generatedAt) < Date.parse(lastGeneratedAt.value)) {
       return false;
     }
-    nodesById.value.delete(nodeId);
+    const index = nodeIndexById.get(nodeId);
+    if (index !== undefined) {
+      nodes.value.splice(index, 1);
+      nodeIndexById.delete(nodeId);
+      for (let nextIndex = index; nextIndex < nodes.value.length; nextIndex++) {
+        const nextNode = nodes.value[nextIndex];
+        if (nextNode) nodeIndexById.set(nextNode.identity.node_id, nextIndex);
+      }
+      triggerRef(nodes);
+    }
+    if (nodesById.value.delete(nodeId)) triggerRef(nodesById);
     lastGeneratedAt.value = generatedAt;
     return true;
   }

--- a/nodelite-server/web/src/stores/nodes.ts
+++ b/nodelite-server/web/src/stores/nodes.ts
@@ -51,16 +51,20 @@ export const useNodesStore = defineStore('nodes', () => {
 
   // From WS NodeUpsert
   function upsertNode(node: NodeListItem, generatedAt: string): void {
-    if (lastGeneratedAt.value && Date.parse(generatedAt) < Date.parse(lastGeneratedAt.value)) return;
+    if (lastGeneratedAt.value && Date.parse(generatedAt) < Date.parse(lastGeneratedAt.value))
+      return;
     nodesById.value.set(node.identity.node_id, node);
     lastGeneratedAt.value = generatedAt;
   }
 
   // From WS NodeRemoved
-  function removeNode(nodeId: string, generatedAt: string): void {
-    if (lastGeneratedAt.value && Date.parse(generatedAt) < Date.parse(lastGeneratedAt.value)) return;
+  function removeNode(nodeId: string, generatedAt: string): boolean {
+    if (lastGeneratedAt.value && Date.parse(generatedAt) < Date.parse(lastGeneratedAt.value)) {
+      return false;
+    }
     nodesById.value.delete(nodeId);
     lastGeneratedAt.value = generatedAt;
+    return true;
   }
 
   return {

--- a/nodelite-server/web/src/views/NodeDetailView.spec.ts
+++ b/nodelite-server/web/src/views/NodeDetailView.spec.ts
@@ -7,7 +7,28 @@ import { createApp, defineComponent, h } from 'vue';
 import NodeDetailView from './NodeDetailView.vue';
 import { setupI18n, getI18n, __resetI18nForTest } from '@/i18n';
 import { apiClient } from '@/api';
-import { makeNodeStatus } from '@/api/__fixtures__/nodes';
+import { makeNode, makeNodeStatus } from '@/api/__fixtures__/nodes';
+
+const wsMock = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(message: never) => void>>();
+
+  return {
+    on: vi.fn((type: string, handler: (message: never) => void) => {
+      const existing = handlers.get(type) ?? new Set<(message: never) => void>();
+      existing.add(handler);
+      handlers.set(type, existing);
+      return () => {
+        existing.delete(handler);
+      };
+    }),
+    emit(type: string, message: unknown): void {
+      for (const handler of handlers.get(type) ?? []) handler(message as never);
+    },
+    reset(): void {
+      handlers.clear();
+    },
+  };
+});
 
 vi.mock('@/api', async () => {
   const actual = await vi.importActual<typeof import('@/api')>('@/api');
@@ -21,6 +42,8 @@ vi.mock('@/api', async () => {
     },
   };
 });
+
+vi.mock('@/ws', () => ({ useWebSocket: () => wsMock }));
 
 const mockStatus = vi.mocked(apiClient.nodeStatus);
 const mockHistory = vi.mocked(apiClient.nodeHistory);
@@ -137,6 +160,7 @@ const FAKE_DICT = {
 };
 
 const Stub = defineComponent({ render: () => h('div') });
+const mountedWrappers = new Set<{ unmount: () => void }>();
 
 function makeRouter(): Router {
   return createRouter({
@@ -157,6 +181,7 @@ async function mountDetail(id = 'srv-1') {
   const wrapper = mount(NodeDetailView, {
     global: { plugins: [pinia, router, getI18n()] },
   });
+  mountedWrappers.add(wrapper);
   await flushPromises();
   return { wrapper, router };
 }
@@ -165,6 +190,7 @@ describe('NodeDetailView', () => {
   beforeEach(async () => {
     window.localStorage.clear();
     __resetI18nForTest();
+    wsMock.reset();
     mockStatus.mockResolvedValue(
       makeNodeStatus({
         identity: {
@@ -190,10 +216,13 @@ describe('NodeDetailView', () => {
   });
 
   afterEach(() => {
+    for (const wrapper of mountedWrappers) wrapper.unmount();
+    mountedWrappers.clear();
     window.localStorage.clear();
     __resetI18nForTest();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('loads the node status for the route id', async () => {
@@ -321,5 +350,93 @@ describe('NodeDetailView', () => {
     await flushPromises();
     expect(wrapper.find('[data-test="log-panel"]').exists()).toBe(true);
     expect(mockLogs).toHaveBeenCalledWith('srv-1', 200);
+  });
+
+  it('applies websocket node updates without polling the full status', async () => {
+    vi.useFakeTimers();
+    const { wrapper } = await mountDetail('srv-1');
+    expect(mockStatus).toHaveBeenCalledTimes(1);
+
+    wsMock.emit('node_upsert', {
+      type: 'node_upsert',
+      generated_at: '2026-06-01T12:00:00Z',
+      node: makeNode({
+        identity: {
+          node_id: 'srv-1',
+          node_label: 'Realtime Server',
+          hostname: 'realtime-server',
+          tags: ['region:us'],
+        },
+        snapshot: {
+          cpu_usage_percent: 88,
+          load: { one: 2.5 },
+          memory: { total_bytes: 8_000_000_000, used_bytes: 4_000_000_000 },
+        },
+        latency_ms: 320,
+        online: true,
+      }),
+    });
+    await flushPromises();
+
+    expect(wrapper.find('.node-title__name').text()).toBe('Realtime Server');
+    expect(wrapper.find('[data-test="node-status-badge"]').classes()).toContain('latency');
+    expect(wrapper.find('[data-test="summary-cpu"]').text()).toContain('88%');
+    expect(wrapper.find('[data-test="summary-latency"]').text()).toContain('320 ms');
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await flushPromises();
+    expect(mockStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not poll the full status while waiting for websocket reconnects', async () => {
+    vi.useFakeTimers();
+    await mountDetail('srv-1');
+    expect(mockStatus).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await flushPromises();
+    expect(mockStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows not-found when the active node is removed over websocket', async () => {
+    const { wrapper } = await mountDetail('srv-1');
+
+    wsMock.emit('node_removed', {
+      type: 'node_removed',
+      generated_at: '2026-06-01T12:00:00Z',
+      node_id: 'srv-1',
+    });
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="node-not-found"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="node-detail-view"]').exists()).toBe(false);
+  });
+
+  it('ignores stale websocket removal messages', async () => {
+    const { wrapper } = await mountDetail('srv-1');
+    wsMock.emit('initial_state', {
+      type: 'initial_state',
+      generated_at: '2026-06-01T12:01:00Z',
+      overview: {},
+      nodes: [
+        makeNode({
+          identity: {
+            node_id: 'srv-1',
+            node_label: 'Server One',
+            hostname: 'server-one',
+            tags: [],
+          },
+        }),
+      ],
+    });
+    wsMock.emit('node_removed', {
+      type: 'node_removed',
+      generated_at: '2026-06-01T12:00:00Z',
+      node_id: 'srv-1',
+    });
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="node-detail-view"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="node-not-found"]').exists()).toBe(false);
   });
 });

--- a/nodelite-server/web/src/views/NodeDetailView.spec.ts
+++ b/nodelite-server/web/src/views/NodeDetailView.spec.ts
@@ -439,4 +439,31 @@ describe('NodeDetailView', () => {
     expect(wrapper.find('[data-test="node-detail-view"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="node-not-found"]').exists()).toBe(false);
   });
+
+  it('treats an authoritative initial state without the active node as removed', async () => {
+    let resolve: (value: ReturnType<typeof makeNodeStatus>) => void = () => {};
+    mockStatus.mockReset();
+    mockStatus.mockReturnValueOnce(
+      new Promise((done) => {
+        resolve = done;
+      }),
+    );
+    const { wrapper } = await mountDetail('srv-1');
+
+    wsMock.emit('initial_state', {
+      type: 'initial_state',
+      generated_at: '2026-06-01T12:01:00Z',
+      overview: {},
+      nodes: [],
+    });
+    resolve(
+      makeNodeStatus({
+        identity: { ...makeNodeStatus().identity, node_id: 'srv-1' },
+      }),
+    );
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="node-not-found"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="node-detail-view"]').exists()).toBe(false);
+  });
 });

--- a/nodelite-server/web/src/views/NodeDetailView.vue
+++ b/nodelite-server/web/src/views/NodeDetailView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import AppLayout from '@/components/AppLayout.vue';
 import NodeHardwarePanel from '@/components/NodeHardwarePanel.vue';
@@ -22,9 +22,11 @@ import { useNodeStatusStore } from '@/stores/nodeStatus';
 import { useDetailHistoryStore } from '@/stores/detailHistory';
 import { useMonitorHistoryStore } from '@/stores/monitorHistory';
 import { useNodeLogsStore } from '@/stores/nodeLogs';
+import { useNodesStore } from '@/stores/nodes';
+import { useWebSocket } from '@/ws';
 import { ApiError } from '@/api/client';
 
-const NODE_DETAIL_REFRESH_MS = 5000;
+const NODE_DETAIL_AUX_REFRESH_MS = 5000;
 
 const TABS = ['overview', 'network', 'hardware', 'logs', 'settings'] as const;
 type TabId = (typeof TABS)[number];
@@ -40,7 +42,9 @@ const store = useNodeStatusStore();
 const historyStore = useDetailHistoryStore();
 const monitorStore = useMonitorHistoryStore();
 const logsStore = useNodeLogsStore();
+const nodesStore = useNodesStore();
 const selection = useChartSelection();
+const ws = useWebSocket();
 
 const nodeId = computed(() => String(route.params.id ?? ''));
 const node = computed(() => store.data);
@@ -102,15 +106,47 @@ function ensureTabData(): void {
   if (logsNeeded.value) void logsStore.loadIfStale(id);
 }
 
+async function loadNode(id: string): Promise<void> {
+  await store.load(id);
+  const summary = nodesStore.nodesById.get(id);
+  if (summary) store.applyRealtimeSummary(summary);
+}
+
+const currentSummary = computed(() => nodesStore.nodesById.get(nodeId.value) ?? null);
+
+watch(currentSummary, (summary) => {
+  if (summary) store.applyRealtimeSummary(summary);
+});
+
+const wsUnsubscribers: Array<() => void> = [];
+
 onMounted(() => {
-  void store.load(nodeId.value);
+  wsUnsubscribers.push(
+    ws.on('initial_state', (msg) => {
+      nodesStore.applyServerState(msg.nodes, msg.generated_at);
+    }),
+    ws.on('node_upsert', (msg) => {
+      nodesStore.upsertNode(msg.node, msg.generated_at);
+    }),
+    ws.on('node_removed', (msg) => {
+      if (nodesStore.removeNode(msg.node_id, msg.generated_at)) {
+        store.markRemoved(msg.node_id);
+      }
+    }),
+  );
+
+  void loadNode(nodeId.value);
   ensureTabData();
+});
+
+onUnmounted(() => {
+  for (const unsubscribe of wsUnsubscribers) unsubscribe();
 });
 
 // Navigating between nodes (same component, new :id) reloads.
 watch(nodeId, (id) => {
   closeZoom();
-  if (id) void store.load(id);
+  if (id) void loadNode(id);
   ensureTabData();
 });
 
@@ -121,13 +157,12 @@ watch([activeTab, selection.windowHours], ([tab]) => {
 });
 
 usePolling(() => {
-  void store.refresh();
   if (historyNeeded.value) void historyStore.refresh();
   if (monitorNeeded.value && nodeId.value) {
     void monitorStore.refresh(nodeId.value, selection.windowHours.value);
   }
   if (logsNeeded.value) void logsStore.refresh();
-}, NODE_DETAIL_REFRESH_MS);
+}, NODE_DETAIL_AUX_REFRESH_MS);
 
 // --- Monitor zoom modal ---
 const modalMetric = ref<OverviewMonitorMetric | null>(null);
@@ -217,7 +252,12 @@ const modalConfig = computed(() => {
             :title="$t(ipRevealed ? 'node.meta.ip_hide' : 'node.meta.ip_reveal')"
             data-test="node-ip-toggle"
             @click="ipRevealed = !ipRevealed"
-          >IP: <span class="node-ip-value" :class="{ 'node-ip-value--revealed': ipRevealed }">{{ ip }}</span><template v-if="isLan"> (LAN)</template></span>
+            >IP:
+            <span class="node-ip-value" :class="{ 'node-ip-value--revealed': ipRevealed }">{{
+              ip
+            }}</span
+            ><template v-if="isLan"> (LAN)</template></span
+          >
           <span v-if="location && !isLan">{{ location }}</span>
           <span v-if="uptime && uptime.days > 0">{{
             $t('node.meta.uptime_days', { days: uptime.days })

--- a/nodelite-server/web/src/views/NodeDetailView.vue
+++ b/nodelite-server/web/src/views/NodeDetailView.vue
@@ -109,13 +109,15 @@ function ensureTabData(): void {
 async function loadNode(id: string): Promise<void> {
   await store.load(id);
   const summary = nodesStore.nodesById.get(id);
-  if (summary) store.applyRealtimeSummary(summary);
+  const generatedAt = nodesStore.lastGeneratedAt;
+  if (summary && generatedAt) store.applyRealtimeSummary(summary, generatedAt);
 }
 
 const currentSummary = computed(() => nodesStore.nodesById.get(nodeId.value) ?? null);
 
 watch(currentSummary, (summary) => {
-  if (summary) store.applyRealtimeSummary(summary);
+  const generatedAt = nodesStore.lastGeneratedAt;
+  if (summary && generatedAt) store.applyRealtimeSummary(summary, generatedAt);
 });
 
 const wsUnsubscribers: Array<() => void> = [];
@@ -124,6 +126,7 @@ onMounted(() => {
   wsUnsubscribers.push(
     ws.on('initial_state', (msg) => {
       nodesStore.applyServerState(msg.nodes, msg.generated_at);
+      if (!nodesStore.nodesById.has(nodeId.value)) store.markRemoved(nodeId.value);
     }),
     ws.on('node_upsert', (msg) => {
       nodesStore.upsertNode(msg.node, msg.generated_at);

--- a/nodelite-server/web/src/ws/__fixtures__/browser_messages.json
+++ b/nodelite-server/web/src/ws/__fixtures__/browser_messages.json
@@ -1,0 +1,115 @@
+{
+  "server_to_browser": {
+    "initial_state": {
+      "type": "initial_state",
+      "generated_at": "2026-07-01T12:34:56Z",
+      "overview": {
+        "generated_at": "2026-07-01T12:34:56Z",
+        "total_nodes": 1,
+        "online_nodes": 1,
+        "offline_nodes": 0,
+        "total_rx_bytes": 123456,
+        "total_tx_bytes": 654321,
+        "current_rx_bytes_per_sec": 128.5,
+        "current_tx_bytes_per_sec": 256.25,
+        "average_latency_ms": 15.5
+      },
+      "nodes": [
+        {
+          "identity": {
+            "node_id": "contract-node-01",
+            "node_label": "Contract Node",
+            "hostname": "contract.example",
+            "tags": [
+              "contract",
+              "edge"
+            ]
+          },
+          "geoip_country": "Singapore",
+          "geoip_city": "Singapore",
+          "geoip_latitude": 1.3521,
+          "geoip_longitude": 103.8198,
+          "location_override_country": null,
+          "location_override_city": null,
+          "location_override_latitude": null,
+          "location_override_longitude": null,
+          "snapshot": {
+            "cpu_usage_percent": 37.5,
+            "load": {
+              "one": 0.75
+            },
+            "memory": {
+              "total_bytes": 8589934592,
+              "used_bytes": 3221225472
+            }
+          },
+          "latency_ms": 12,
+          "online": true
+        }
+      ]
+    },
+    "overview_update": {
+      "type": "overview_update",
+      "generated_at": "2026-07-01T12:34:56Z",
+      "overview": {
+        "generated_at": "2026-07-01T12:34:56Z",
+        "total_nodes": 1,
+        "online_nodes": 1,
+        "offline_nodes": 0,
+        "total_rx_bytes": 123456,
+        "total_tx_bytes": 654321,
+        "current_rx_bytes_per_sec": 128.5,
+        "current_tx_bytes_per_sec": 256.25,
+        "average_latency_ms": 15.5
+      }
+    },
+    "node_upsert": {
+      "type": "node_upsert",
+      "generated_at": "2026-07-01T12:34:56Z",
+      "node": {
+        "identity": {
+          "node_id": "contract-node-01",
+          "node_label": "Contract Node",
+          "hostname": "contract.example",
+          "tags": [
+            "contract",
+            "edge"
+          ]
+        },
+        "geoip_country": "Singapore",
+        "geoip_city": "Singapore",
+        "geoip_latitude": 1.3521,
+        "geoip_longitude": 103.8198,
+        "location_override_country": null,
+        "location_override_city": null,
+        "location_override_latitude": null,
+        "location_override_longitude": null,
+        "snapshot": {
+          "cpu_usage_percent": 37.5,
+          "load": {
+            "one": 0.75
+          },
+          "memory": {
+            "total_bytes": 8589934592,
+            "used_bytes": 3221225472
+          }
+        },
+        "latency_ms": 12,
+        "online": true
+      }
+    },
+    "node_removed": {
+      "type": "node_removed",
+      "generated_at": "2026-07-01T12:34:56Z",
+      "node_id": "contract-node-01"
+    },
+    "pong": {
+      "type": "pong"
+    }
+  },
+  "browser_to_server": {
+    "ping": {
+      "type": "ping"
+    }
+  }
+}

--- a/nodelite-server/web/src/ws/browserMessageContract.spec.ts
+++ b/nodelite-server/web/src/ws/browserMessageContract.spec.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WS } from 'vitest-websocket-mock';
+import contract from './__fixtures__/browser_messages.json';
+import { parseBrowserMessage, WsClient, type WsClientLogger } from './client';
+
+const wsUrl = 'ws://localhost:1240/ws/browser-contract';
+const serverMessageKeys = [
+  'initial_state',
+  'overview_update',
+  'node_upsert',
+  'node_removed',
+  'pong',
+] as const;
+
+function sortedKeys(value: object): string[] {
+  return Object.keys(value).sort();
+}
+
+describe('BrowserMessage contract fixture', () => {
+  let server: WS | undefined;
+  let client: WsClient | undefined;
+  let logger: WsClientLogger;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    logger = {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: false,
+    });
+  });
+
+  afterEach(() => {
+    client?.destroy();
+    server?.close();
+    vi.useRealTimers();
+  });
+
+  it('accepts every Rust-generated message through the runtime parser', () => {
+    for (const key of serverMessageKeys) {
+      const message = contract.server_to_browser[key];
+      expect(parseBrowserMessage(message), key).toEqual(message);
+    }
+
+    expect(parseBrowserMessage(contract.browser_to_server.ping)).toEqual(
+      contract.browser_to_server.ping,
+    );
+  });
+
+  it('locks message and nested payload field names', () => {
+    expect(sortedKeys(contract.server_to_browser.initial_state)).toEqual([
+      'generated_at',
+      'nodes',
+      'overview',
+      'type',
+    ]);
+    expect(sortedKeys(contract.server_to_browser.overview_update)).toEqual([
+      'generated_at',
+      'overview',
+      'type',
+    ]);
+    expect(sortedKeys(contract.server_to_browser.node_upsert)).toEqual([
+      'generated_at',
+      'node',
+      'type',
+    ]);
+    expect(sortedKeys(contract.server_to_browser.node_removed)).toEqual([
+      'generated_at',
+      'node_id',
+      'type',
+    ]);
+    expect(sortedKeys(contract.server_to_browser.pong)).toEqual(['type']);
+    expect(sortedKeys(contract.browser_to_server.ping)).toEqual(['type']);
+
+    const initial = parseBrowserMessage(contract.server_to_browser.initial_state);
+    expect(initial?.type).toBe('initial_state');
+    if (!initial || initial.type !== 'initial_state') throw new Error('invalid initial_state fixture');
+
+    expect(sortedKeys(initial.overview)).toEqual([
+      'average_latency_ms',
+      'current_rx_bytes_per_sec',
+      'current_tx_bytes_per_sec',
+      'generated_at',
+      'offline_nodes',
+      'online_nodes',
+      'total_nodes',
+      'total_rx_bytes',
+      'total_tx_bytes',
+    ]);
+
+    const node = initial.nodes[0];
+    expect(node).toBeDefined();
+    if (!node) throw new Error('initial_state fixture should contain one node');
+
+    expect(sortedKeys(node)).toEqual([
+      'geoip_city',
+      'geoip_country',
+      'geoip_latitude',
+      'geoip_longitude',
+      'identity',
+      'latency_ms',
+      'location_override_city',
+      'location_override_country',
+      'location_override_latitude',
+      'location_override_longitude',
+      'online',
+      'snapshot',
+    ]);
+    expect(sortedKeys(node.identity)).toEqual(['hostname', 'node_id', 'node_label', 'tags']);
+    expect(node.identity.node_id).toBe('contract-node-01');
+    expect(node.snapshot).not.toBeNull();
+    if (!node.snapshot) throw new Error('contract node should contain a snapshot');
+    expect(sortedKeys(node.snapshot)).toEqual(['cpu_usage_percent', 'load', 'memory']);
+    expect(sortedKeys(node.snapshot.load)).toEqual(['one']);
+    expect(sortedKeys(node.snapshot.memory)).toEqual(['total_bytes', 'used_bytes']);
+
+    const upsert = parseBrowserMessage(contract.server_to_browser.node_upsert);
+    expect(upsert?.type).toBe('node_upsert');
+    if (!upsert || upsert.type !== 'node_upsert') throw new Error('invalid node_upsert fixture');
+    expect(upsert.node).toEqual(node);
+  });
+
+  it('dispatches Rust-generated server messages through WsClient', async () => {
+    server = new WS(wsUrl);
+    client = new WsClient(wsUrl, logger);
+    const initialHandler = vi.fn();
+    const overviewHandler = vi.fn();
+    const upsertHandler = vi.fn();
+    const removedHandler = vi.fn();
+    client.on('initial_state', initialHandler);
+    client.on('overview_update', overviewHandler);
+    client.on('node_upsert', upsertHandler);
+    client.on('node_removed', removedHandler);
+
+    client.connect();
+    await server.connected;
+    server.send(JSON.stringify(contract.server_to_browser.initial_state));
+    server.send(JSON.stringify(contract.server_to_browser.overview_update));
+    server.send(JSON.stringify(contract.server_to_browser.node_upsert));
+    server.send(JSON.stringify(contract.server_to_browser.node_removed));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(initialHandler).toHaveBeenCalledWith(contract.server_to_browser.initial_state);
+    expect(overviewHandler).toHaveBeenCalledWith(contract.server_to_browser.overview_update);
+    expect(upsertHandler).toHaveBeenCalledWith(contract.server_to_browser.node_upsert);
+    expect(removedHandler).toHaveBeenCalledWith(contract.server_to_browser.node_removed);
+  });
+
+  it('serializes the browser heartbeat exactly like the Rust Ping fixture', async () => {
+    vi.useFakeTimers();
+    server = new WS(wsUrl);
+    client = new WsClient(wsUrl, logger);
+
+    client.connect();
+    await vi.advanceTimersByTimeAsync(100);
+    await server.connected;
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(server.messages).toContain(JSON.stringify(contract.browser_to_server.ping));
+  });
+});


### PR DESCRIPTION
## Summary
- stream NodeDetailView live status from the browser WebSocket while retaining REST for initial detail, history, and logs
- virtualize the fixed-height node card grid and keep incremental node upserts in stable shallow collections
- lock all six BrowserMessage variants to Rust-generated JSON fixtures consumed by parser, dispatch, and heartbeat tests

## Verification
- pnpm test: 83 files, 514 tests passed
- pnpm typecheck
- pnpm lint
- pnpm build
- cargo test --workspace
- cargo +stable fmt --all --check
- cargo clippy --all-targets -- -D warnings
- browser verification with 500 nodes: 3 cards initially, 24 after scrolling, visible route navigation succeeded, measured about 101 FPS

Closes #259
Closes #261
Closes #314